### PR TITLE
Version and publish article

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -2,47 +2,72 @@
 <html>
   <head>
     <base target="_top">
+    <link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons1.css">
+
     <script>
       function onSuccess(contents) {
         var div = document.getElementById('output');
-        div.innerHTML = JSON.stringify(contents);
+        div.innerHTML = contents;
+        handleMeta();
       }
       
-      function onSuccessPublish(contents) {
-        var div = document.getElementById('publish-output');
-        div.innerHTML = JSON.stringify(contents);
-      }
-      function handlePublishClick() {
-         google.script.run.withSuccessHandler(onSuccessPublish).publishArticle();
+      function onSuccessMeta(data) {
+        var revisionIdSpan = document.getElementById('revision-id');
+        revisionIdSpan.innerHTML = data.articleID;
+
+        var isPublishedSpan = document.getElementById('is-published');
+        var isPublishedYesNo = "no";
+        if (data.isPublished) {
+          isPublishedYesNo = "yes";
+        }
+        isPublishedSpan.innerHTML = isPublishedYesNo;
       }
 
-      function handleArticleIDClick() {
-         google.script.run.withSuccessHandler(onSuccess).getArticleID();
+      function handleMeta() {
+         google.script.run.withSuccessHandler(onSuccessMeta).getArticleMeta();
       }
 
       function handleClick() {
          google.script.run.withSuccessHandler(onSuccess).getCurrentDocContents();
       }
       
-      function handleLocalesClick() {
-         google.script.run.withSuccessHandler(onSuccess).getLocales();
-      }
-
+      window.onload = (function(){
+        handleMeta();
+      });
 
     </script>
+    <style>
+      .branding-below {
+        bottom: 56px;
+        top: 0;
+      }
+      </style>
+
   </head>
   <body>
-    <h1 class="title">Webiny Integration</h1>
+    <div class="sidebar branding-below">
+      <h1 class="title">Publishing Info</h1>
 
-    <div id="output"></div>
-    <pre id="publish-output"></pre>
-    
-    <!-- 
-    <button class="button" onclick="handleArticleIDClick()">Check for ID</button>
-    <button class="button" onclick="handleLocalesClick()">Get Locales</button> 
-    -->
-    <button class="button" onclick="handleClick()">Save Article</button>
-    <button class="button" onclick="handlePublishClick()">Publish Article</button>
+      <div class="block">
+        <p>
+          <b>Revision ID:</b> <span id="revision-id"></span>
+        </p>
+        <p>
+          <b>Published?</b> <span id="is-published"></span>
+        </p>
+      </div>
+
+      <div id="output" class="block"></div>
+      
+      <div class="block">
+        <button class="button blue" onclick="handleClick()">Save Article</button>
+      </div>
+    </div>
+    <div class="sidebar bottom">
+      <span class="gray">
+        Powered by News Catalyst
+      </span>
+    </div>
 
   </body>
 </html>


### PR DESCRIPTION
Issue #6

I realised that the saved articles were showing up in Webiny's admin as drafts, and that the admin had two buttons: "save" and "save & publish"

I described what happens behind the scenes of Webiny's admin in the linked issue. 

So, this PR includes a bunch of changes:

* upon opening the sidebar for the first time, I request all the article metadata to find out what the latest revision ID is
  * I'm doing this in case things are out of sync, and to be careful
  * so, upon opening the sidebar, the `articleID` is updated to be set to the latest revision ID (google apps script document store)
* **save article** checks for an articleID
  * if it exist, a new `revision` of the article is saved using the mutation `CreateBasicArticleFrom`
  * otherwise, a new article is saved using `CreateBasicArticle`
* every subsequent save after the first one creates a new `revision`
* upon successful save, the article is Published
  * this calls the `PublishBasicArticle` mutation
  * each revision may be published only once; so, we have to create a new one before doing this
  * publishing the article marks the current revision with `published: true` and updates the publishedOn datetime
* the article revision ID and whether or not it's been published also now show up in the sidebar, and are updated after each save.
* google add-ons CSS also now included, and the sidebar looks nicer

<img width="318" alt="Screen Shot 2020-07-08 at 9 23 02 am" src="https://user-images.githubusercontent.com/3397/86854890-ad4cbb00-c0fc-11ea-8bd0-6c3871eb0a8e.png">
