### PR TITLE
Set headline and byline in sidebar

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -11,16 +11,34 @@
         handleMeta();
       }
       
+      function displayFormMessage(text) {
+        // first, switch the "published" text to say "No"
+        // because the headline and/or byline has likely changed.
+        setPublishedFlag(false);
+        var div = document.getElementById('form-output');
+        div.innerHTML = text;
+      }
+
+      function setPublishedFlag(value) {
+        var isPublishedSpan = document.getElementById('is-published');
+        var isPublishedYesNo = "no";
+        if (value) {
+          isPublishedYesNo = "yes";
+        }
+        isPublishedSpan.innerHTML = isPublishedYesNo;
+      }
+
       function onSuccessMeta(data) {
         var revisionIdSpan = document.getElementById('revision-id');
         revisionIdSpan.innerHTML = data.articleID;
 
-        var isPublishedSpan = document.getElementById('is-published');
-        var isPublishedYesNo = "no";
-        if (data.isPublished) {
-          isPublishedYesNo = "yes";
-        }
-        isPublishedSpan.innerHTML = isPublishedYesNo;
+        setPublishedFlag(data.isPublished);
+
+        var articleHeadline = document.getElementById('article-headline');
+        articleHeadline.value = data.headline;
+
+        var articleByline = document.getElementById('article-byline');
+        articleByline.value = data.byline;
       }
 
       function handleMeta() {
@@ -35,6 +53,20 @@
         handleMeta();
       });
 
+      function handleFormSubmit(formObject) {
+        google.script.run.withSuccessHandler(displayFormMessage).processForm(formObject);
+      }
+
+      // Prevent forms from submitting.
+      function preventFormSubmit() {
+        var forms = document.querySelectorAll('form');
+        for (var i = 0; i < forms.length; i++) {
+          forms[i].addEventListener('submit', function(event) {
+            event.preventDefault();
+          });
+        }
+      }
+      window.addEventListener('load', preventFormSubmit);
     </script>
     <style>
       .branding-below {
@@ -47,6 +79,25 @@
   <body>
     <div class="sidebar branding-below">
       <h1 class="title">Publishing Info</h1>
+
+      <form id="articleMeta" onsubmit="handleFormSubmit(this)">
+        <div id="form-output" class="block secondary"></div>
+        <div class="block form-group">
+          <label for="article-headline">
+            <b>Headline</b>
+          </label>
+          <input id="article-headline" name="article-headline" type="text" />
+        </div>
+        <div class="block form-group">
+          <label for="article-byline">
+            <b>Byline</b>
+          </label>
+          <input id="article-byline" name="article-byline" type="text" />
+        </div>
+        <div class="block">
+          <button class="blue">Submit</button>
+        </div>
+      </form>
 
       <div class="block">
         <p>


### PR DESCRIPTION
Issue #18 

This PR adds the following functionality to the add-on (not yet published):

* new form in the sidebar with `headline` and `byline` fields
* submitting form stores both values in document store
* upon opening sidebar, the existing metadata function now checks if a custom headline was already set; if not, the document name/title is used
* creating a new article or revision now uses the custom headline (fallback: document title, see above) and byline when storing article in webiny
* submitting that new sidebar form now changes the displayed "Published? Yes" to "Published? No" 
  * this needs more work, but I'm trying to indicate that changing the hed or byline requires republishing

Some screenshots showing initial display, changing the contents, and then republishing.

<img width="309" alt="Screen Shot 2020-07-09 at 10 52 14 am" src="https://user-images.githubusercontent.com/3397/86984843-08e97800-c1d3-11ea-9a94-10f36eaa6eb4.png">

<img width="310" alt="Screen Shot 2020-07-09 at 10 52 42 am" src="https://user-images.githubusercontent.com/3397/86984847-0d159580-c1d3-11ea-875d-891b4d53785b.png">

<img width="317" alt="Screen Shot 2020-07-09 at 10 52 58 am" src="https://user-images.githubusercontent.com/3397/86984854-1141b300-c1d3-11ea-9cb0-323d2fbe3f5b.png">

