### PR TITLE
Fix for 400 error loading sidebar on new docs

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -68,9 +68,21 @@ function getLatestVersionPublished() {
 
 function getArticleMeta() {
   var articleID = getArticleID();
+
   var isLatestVersionPublished = getLatestVersionPublished();
   var headline = getHeadline();
   var byline = getByline();
+
+  if (typeof(articleID) === "undefined" || articleID === null) {
+    Logger.log("articleID is undefined, returning new doc state");
+    return {
+      articleID: null,
+      isPublished: false,
+      headline: headline,
+      byline: byline
+    }
+  }
+  Logger.log("articleID is: ", articleID);
 
   return {
     articleID: articleID,
@@ -828,6 +840,10 @@ function setArticleMeta() {
   if (typeof(headline) === "undefined" || headline === null || headline.trim() === "") {
     headline = getDocumentName();
     storeHeadline(headline);
+  }
+
+  if (typeof(articleID) === "undefined" || articleID === null) {
+    return null;
   }
 
   var formData = {


### PR DESCRIPTION
Issue #24 

The sidebar was trying to request the latest data from webiny on the article in all cases, not checking whether it already had an articleID (had been saved/published to webiny).

This fix:

* adds a check for articleID existing before requesting webiny data
* allows saving a custom headline & byline (sidebar form) even without an articleID
