### PR TITLE
Preserve styles on entire paragraph for titles vs normal text

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -404,6 +404,7 @@ function formatElements() {
   }).forEach(element => {
     var formattedElement = {
       type: element.type,
+      style: element.style,
       link: element.link,
       listType: element.listType
     };


### PR DESCRIPTION
Issue #35 

I had omitted the top-level `style` attribute from the data that gets sent through the JSON. Now that "Heading 2 Placeholder" text comes through the JSON like this:

```
{
  "type":"text",
  "style":"HEADING_2",
  "link":null,
  "children":[
    {
      "index":679,
      "style":{

      },
      "content":"Heading 2 Placeholder"
    }
  ]
}
```

Comparing that to a regular paragraph with inline text formatting (bold, etc) - the first one from the same article:

```
{
  "type":"text",
  "style":"NORMAL_TEXT",
  "link":null,
  "children":[
    {
      "index":114,
      "style":{
        "underline":true
      },
      "link":"https://newscatalyst.org",
      "content":"Digitalize"
    },
    {
      "index":235,
      "style":{

      },
      "content":". Crisp ppt goalposts hit the ground running yet anti-pattern product launch technologically savvy this is a no-brainer."
    },
    {
      "index":244,
      "style":{
        "bold":true
      },
      "content":"What the."
    },
    {
      "index":298,
      "style":{

      },
      "content":"Bob called an all-hands this afternoon going forward"
    },
    {
      "index":317,
      "style":{
        "italic":true
      },
      "content":"nor drive awareness"
    },
    {
      "index":341,
      "style":{

      },
      "content":"to increase engagement"
    },
    {
      "index":368,
      "style":{
        "bold":true,
        "italic":true
      },
      "content":"so quick sync parallel path"
    },
    {
      "index":528,
      "style":{

      },
      "content":". Can you ballpark the cost per unit for me the last person we talked to said this would be ready blue sky thinking, but feature creep, for talk to the slides."
    }
  ]
}
```

Are we happy with this? A regular paragraph (non-heading) of text comes through with the top-level style of `NORMAL_TEXT` and then has inline `style` attributes dictating underline, bold, italic. A title or heading head a top-level style that varies but indicates the level of heading, like the one above is `HEADING_2`. That child-level style attribute for the heading could potentially include `italic: true` if there was additional formatting.

As a total aside, I'm looking forward to working with real content as this text generated from random lorem-ipsum sites is starting to get to me 🤪 