### PR TITLE
Store the first and last published dates in the article JSON/webiny

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -705,6 +705,8 @@ function createArticleFrom(versionID, title, elements) {
 
   var byline = getByline();
 
+  var publishingInfo = getPublishingInfo();
+
   var articleTags = getTags(); // only id
   Logger.log("createArticleFrom articleTags: ", articleTags);
   // create any new tags
@@ -780,6 +782,22 @@ function createArticleFrom(versionID, title, elements) {
             },
           ],
         },
+        firstPublishedOn: {
+          values:[
+            {
+              value: publishingInfo.firstPublishedOn,
+              locale: localeID
+            }
+          ]
+        },
+        lastPublishedOn: {
+          values:[
+            {
+              value: publishingInfo.lastPublishedOn,
+              locale: localeID
+            }
+          ]
+        },
         body: {
           values: [
             {
@@ -834,7 +852,6 @@ function createArticle(title, elements) {
   var ACCESS_TOKEN = scriptConfig['ACCESS_TOKEN'];
   var CONTENT_API = scriptConfig['CONTENT_API'];
 
-
   var localeID = getLocaleID();
   if (localeID === null) {
     var locales = getLocales();
@@ -846,6 +863,8 @@ function createArticle(title, elements) {
   }
 
   var byline = getByline();
+
+  var publishingInfo = getPublishingInfo();
 
   var allTags = getValueJSON('ALL_TAGS'); // don't look up in the DB again, too slow
   var articleTags = getTags();
@@ -879,6 +898,22 @@ function createArticle(title, elements) {
               value: title,
             },
           ],
+        },
+        firstPublishedOn: {
+          values:[
+            {
+              value: publishingInfo.firstPublishedOn,
+              locale: localeID
+            }
+          ]
+        },
+        lastPublishedOn: {
+          values:[
+            {
+              value: publishingInfo.lastPublishedOn,
+              locale: localeID
+            }
+          ]
         },
         body: {
           values: [


### PR DESCRIPTION
This PR adds the first & last published dates to the article data that gets stored in Webiny. I added these as "date time with timezone" fields to the article.

Here is example JSON resulting from a `getBasicArticle` query:

```
{
  "data": {
    "content": {
      "data": {
        "id": "5f1612777e4cf2000743a570",
        "firstPublishedOn": {
          "values": [
            {
              "value": "2020-07-07T04:19:54.733Z"
            }
          ]
        },
        "lastPublishedOn": {
          "values": [
            {
              "value": "2020-07-20T04:07:29.311Z"
            }
          ]
        },
        "savedOn": "2020-07-20T21:54:03.556Z",
      }
    }
  }
}
```

Those dates are in UTC, btw. (I was not working at just past 4am or almost 10pm AEST 😉) This is testable in the add-on either by taking my word for it or Run > Test (latest code) ... or perhaps by just opening a doc and running the sidebar to save the article?