### PR TITLE
Select a category and store it on the article

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -84,6 +84,10 @@
         var articleTwitterDescription = document.getElementById('article-twitter-description');
         articleTwitterDescription.value = data.seo.twitterDescription;
 
+        console.log("data: ", data);
+        var slugDiv = document.getElementById('slug');
+        slugDiv.innerHTML = data.slug;
+
         var loadingDiv = document.getElementById('loading');
         loadingDiv.style.display = "none";
 
@@ -117,11 +121,10 @@
 
         if (data.publishingInfo) {
           var firstPubDiv = document.getElementById('first-published');
-          var lastPubDiv = document.getElementById('last-published');
-          var slugDiv = document.getElementById('slug');
           firstPubDiv.innerHTML = data.publishingInfo.firstPublishedOn;
+
+          var lastPubDiv = document.getElementById('last-published');
           lastPubDiv.innerHTML = data.publishingInfo.lastPublishedOn;
-          slugDiv.innerHTML = data.publishingInfo.slug;
         }
       }
 
@@ -363,6 +366,9 @@
 
       <div class="block">
         <div id="revision-info">
+          <p>
+            <b>Article slug:</b> <span id="slug"></span>
+          </p>
           <p>
             <b>Revision ID:</b> <span id="revision-id"></span>
           </p>


### PR DESCRIPTION
Issue #52 

This PR:

* added [a Category model](https://d1tj6tnba0qfzt.cloudfront.net/admin/cms/content-models/5f17808f125ea90008bd775a) to webiny
* added "category" reference field to [the basic article content model](https://d1tj6tnba0qfzt.cloudfront.net/admin/cms/content-models/5efcf8c8ea4024000780e6d3)
* adds a query to list all categories on sidebar loading
* adds a select field to choose the article category
* stores all categories & selected article category in the document properties
* saves the selected category on new articles and in updates to existing articles
* includes the category in the slug, so an example slug for "U.S." category and "A Very New Headline" is: "us/a-very-new-headline"
* displays the article slug in the sidebar

To test:

* script editor -> run -> test as add-on -> latest code
* open the sidebar
* try selecting a category, submit that form
* try saving the article

To include the category when retrieving the article, add this to the `data {}` section of the graphql query:

```
      category {
        value {
          id
          title {
            value
          }
          slug {
            value
          }
        }
      }
```

That part of the query will return:

```
        "category": {
          "value": {
            "id": "5f178108125ea90008bd775d",
            "title": {
              "value": "U.S."
            },
            "slug": {
              "value": "us"
            }
          }
        },
```
