### PR TITLE
Feature/speed up loading

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -30,6 +30,12 @@
       }
 
       function onSuccessMeta(data) {
+        var loadingDiv = document.getElementById('loading');
+        loadingDiv.style.display = "none";
+
+        var form = document.getElementById('article-meta-form');
+        form.style.display = "block";
+
         var articleCategorySelect = document.getElementById('article-category');
         data.categories.forEach(category => {
           var option = document.createElement("option");
@@ -84,15 +90,8 @@
         var articleTwitterDescription = document.getElementById('article-twitter-description');
         articleTwitterDescription.value = data.seo.twitterDescription;
 
-        console.log("data: ", data);
         var slugDiv = document.getElementById('slug');
         slugDiv.innerHTML = data.slug;
-
-        var loadingDiv = document.getElementById('loading');
-        loadingDiv.style.display = "none";
-
-        var form = document.getElementById('article-meta-form');
-        form.style.display = "block";
 
         $('#article-tags').select2({
           width: 'resolve',


### PR DESCRIPTION
Issue #26 

I managed to speed up the loading time for the sidebar from around **9** seconds to **_1.5_** seconds!

I'm also displaying the form slightly faster: I had been waiting for every piece of data before showing it, but it actually runs nicer when the form gets displayed first. I haven't noticed a delay in the values showing up tbh.

I sped up the actual load time by first benchmarking the two functions that are run `onLoad` then sorting through what each was doing.

`getArticleMeta` is run and had been doing several graphql queries. This is mostly what took so long. Instead of doing those queries every time, I'm checking if we already have values stored in the doc properties, and if we don't, I run the queries.

We may need or want to add a manual trigger for these in the future; specifically the query that looks up all tags. For now, you can add a new tag in the sidebar - that adds it to the db (webiny) and to the doc properties. 