### PR TITLE
Feature/ui fixes

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -149,7 +149,7 @@ function uploadImageToS3(imageID, contentUri) {
     return null;
   }
 
-  var destinationPath = orgNameSlug + "/" + headlineSlug + "/" + objectName;
+  var destinationPath = orgNameSlug + "/" + articleSlug + "/" + objectName;
   var s3;
 
   try {
@@ -516,7 +516,12 @@ function getArticleMeta() {
 . * Gets the current document's contents and
 .  * posts them to webiny
 . */
-function getCurrentDocContents() {
+function getCurrentDocContents(formObject) {
+  Logger.log("getCurrentDocContents: ", formObject);
+
+  var propMessage = processForm(formObject);
+  Logger.log(propMessage);
+
   var title = getHeadline();
   var formattedElements = formatElements();
 
@@ -920,7 +925,7 @@ function createArticleFrom(versionID, title, elements) {
         slug: {
           values:[
             {
-              value: headlineSlug,
+              value: slug,
               locale: localeID
             }
           ]
@@ -1116,7 +1121,7 @@ function createArticle(title, elements) {
         slug: {
           values:[
             {
-              value: headlineSlug,
+              value: slug,
               locale: localeID
             }
           ]
@@ -1889,6 +1894,10 @@ function setArticleMeta() {
 .* setting the headline and byline (for now)
 .*/
 function processForm(formObject) {
+  if (formObject === null || typeof(formObject) === "undefined") {
+    return;
+  }
+  Logger.log("processForm: ", formObject);
   var headline = formObject["article-headline"];
   storeHeadline(headline);
 

--- a/Page.html
+++ b/Page.html
@@ -10,10 +10,12 @@
 
     <script>
       function onSuccess(contents) {
-
+        // first, switch the "published" text to say "No"
+        // because the headline and/or byline has likely changed.
+        setPublishedFlag(false);
         var configDiv = document.getElementById('config');
         configDiv.display = 'none';
-        var div = document.getElementById('output');
+        var div = document.getElementById('form-output');
         div.innerHTML = contents;
         handleMeta();
       }
@@ -22,11 +24,6 @@
         var loadingDiv = document.getElementById('loading');
         console.log(error);
         loadingDiv.innerHTML = "An error occurred: " + error;
-      }
-
-      function handleNewTagForm(formObject) {
-         google.script.run.withSuccessHandler(onSuccessTags).addTagToLocalStore(formObject);
-        // var articleTagsSelect = document.getElementById('article-tags');
       }
 
       function onSuccessMeta(data) {
@@ -115,8 +112,11 @@
         var revisionDiv = document.getElementById('revision-info');
         revisionDiv.style.display = "block";
 
-        var saveDiv = document.getElementById('save-article');
-        saveDiv.style.display = "block";
+        var saveDivTop = document.getElementById('save-article-top');
+        saveDivTop.style.display = "block";
+
+        var saveDivBottom = document.getElementById('save-article-bottom');
+        saveDivBottom.style.display = "block";
 
         if (data.publishingInfo !== null && typeof(data.publishingInfo) !== 'undefined') {
           if (data.publishingInfo.firstPublishedOn !== null && typeof(data.publishingInfo.firstPublishedOn) !== 'undefined') {
@@ -134,17 +134,6 @@
             slugDiv.innerHTML = data.publishingInfo.slug;
           }
         }
-      }
-
-      function displayFormMessage(text) {
-        // first, switch the "published" text to say "No"
-        // because the headline and/or byline has likely changed.
-        setPublishedFlag(false);
-        var configDiv = document.getElementById('config');
-        configDiv.display = 'none';
-        var div = document.getElementById('form-output');
-        div.innerHTML = text;
-
       }
 
       function displayConfigFormMessage(text) {
@@ -187,12 +176,18 @@
       }
 
       function handleMeta() {
-        //  google.script.run.withSuccessHandler(onSuccessTags).getTags();
          google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessMeta).getArticleMeta();
       }
 
-      function handleClick() {
-         google.script.run.withSuccessHandler(onSuccess).getCurrentDocContents();
+      function handleClick(formObject) {
+        var form = document.getElementById('article-meta-form');
+        form.style.display = "none";
+
+        var loadingDiv = document.getElementById('loading');
+        loadingDiv.style.display = "block";
+
+        console.log("handling click, form object is: ", formObject);
+        google.script.run.withSuccessHandler(onSuccess).getCurrentDocContents(formObject);
       }
       
       window.onload = (function(){
@@ -202,8 +197,11 @@
         var revisionDiv = document.getElementById('revision-info');
         revisionDiv.style.display = "none";
 
-        var saveDiv = document.getElementById('save-article');
-        saveDiv.style.display = "none";
+        var saveDivTop = document.getElementById('save-article-top');
+        saveDivTop.style.display = "none";
+
+        var saveDivBottom = document.getElementById('save-article-bottom');
+        saveDivBottom.style.display = "none";
 
         handleScriptConfig();
 
@@ -212,11 +210,6 @@
 
       function handleScriptConfigSubmit(formObject) {
         google.script.run.withSuccessHandler(displayConfigFormMessage).setScriptConfig(formObject);
-      }
-
-      function handleFormSubmit(formObject) {
-        console.log("handleFormSubmit: ", formObject);
-        google.script.run.withSuccessHandler(displayFormMessage).processForm(formObject);
       }
 
       // Prevent forms from submitting.
@@ -244,10 +237,10 @@
 
   </head>
   <body>
-    <div class="sidebar branding-below">
+    <a id='top' href="#"></a>
+    <div id="sidebar-wrapper" class="sidebar branding-below">
       <h1 class="title">Publishing Tools</h1>
 
-      <pre id="tags-output"></pre>
       <div class="block" id="loading">Loading...</div>
 
       <div id="config"></div>
@@ -301,8 +294,12 @@
       </form>
 
       <div id="article-meta-form">
-        <form onsubmit="handleFormSubmit(this)">
-          <div id="form-output" class="block secondary"></div>
+        <form onsubmit="handleClick(this)">
+          <div id="form-output" class="block success"></div>
+          <div id="save-article-top" class="block">
+            <input type="submit" class="blue" value="Save & Publish Article"/>
+          </div>
+
           <div class="block form-group">
             <label for="article-headline">
               <b>Headline</b>
@@ -366,8 +363,8 @@
             </label>
             <input id="article-twitter-description" name="article-twitter-description" type="text" />
           </div>
-          <div class="block">
-            <button class="blue">Submit</button>
+          <div id="save-article-bottom" class="block">
+            <input type="submit" class="blue" value="Save & Publish Article"/>
           </div>
         </form>
       </div>
@@ -393,11 +390,8 @@
       </div>
 
       <div id="output" class="block"></div>
-      
-      <div id="save-article" class="block">
-        <button class="button blue" onclick="handleClick()">Save Article</button>
-      </div>
     </div>
+
     <div class="sidebar bottom">
       <span class="gray">
         Powered by News Catalyst


### PR DESCRIPTION
Issue #59 

This PR contains fixes for a hopefully better UI/UX in the sidebar. 

* "save" button now at top and bottom of sidebar
* saving metadata as an extra step is no longer required: "save" now saves the metadata, stores the full article in webiny, and publishes
* this cleans up the UI a bit by removing that extra/confusing "submit" button
* clicking either "save" button switches to the "Loading..." view
* once the save is complete the form is returned to view, along with a message

This is saved as version **17** in the add-on "UI Fixes PR #62"

Saving this PR for now as a draft until I make the rest of the adjustments in issue #59 