### PR TITLE
Article slugs should only include the headline

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -85,21 +85,15 @@ function cleanStyle(incomingStyle) {
   return cleanedStyle;
 }
 
-// Generates a slug for the article based on its category and headline
+// Generates a slug for the article based on its headline
+// NOTE: this was generating a slug with category + headline, but nextjs routing doesn't work with a slash in the slug :-/
 function createArticleSlug(category, headline) {
-  var catSlug;
-  if (category !== null && category.trim() !== "") {
-    catSlug = slugify(category);
-  } 
-  Logger.log("category slug: ", catSlug);
   var hedSlug;
   if (headline !== null && headline.trim() !== "") {
     hedSlug = slugify(headline);
   }
   Logger.log("headline slug: ", hedSlug);
-  var articleSlug = [catSlug, hedSlug].join("/");
-  Logger.log("article slug: ", articleSlug);
-  return articleSlug;
+  return hedSlug;
 }
 
 // Implementation from https://gist.github.com/codeguy/6684588


### PR DESCRIPTION
I realized that the way I had updates slugs in this add-on wouldn't work for nextjs routing. I had:

`[category]/[headline]`

As the value of the article's `slug`. These need to be stored separately as `category.slug` and `slug` instead on the article, otherwise next's routing breaks on the slash.