### PR TITLE
Fixes 'Published? No' bug

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -434,6 +434,7 @@ function getArticleMeta() {
   var isLatestVersionPublished = getLatestVersionPublished();
 
   var publishingInfo = getPublishingInfo();
+  Logger.log("publishingInfo: ", publishingInfo);
 
   var headline = getHeadline();
   if (typeof(headline) === "undefined" || headline === null || headline.trim() === "") {
@@ -470,7 +471,6 @@ function getArticleMeta() {
 
     return {
       articleID: null,
-      isPublished: false,
       headline: headline,
       byline: byline,
       publishingInfo: publishingInfo,
@@ -485,7 +485,6 @@ function getArticleMeta() {
   }
   var articleMetadata = {
     articleID: articleID,
-    isPublished: isLatestVersionPublished,
     headline: headline,
     byline: byline,
     publishingInfo: publishingInfo,
@@ -1472,8 +1471,6 @@ function loadTagsFromDB() {
   var responseData = JSON.parse(responseText);
   Logger.log(responseData);
 
-  // TODO update latestVersionPublished flag
-
   if (responseData && responseData.data && responseData.data.content && responseData.data.content.data !== null) {
     return responseData.data.content.data;
   } else {
@@ -1847,8 +1844,11 @@ function setArticleMeta() {
   // the ID of the most recent revision of the article should now be treated as its articleID
   // save this in the document properties store
   if (publishingInfo.latestVersionID !== null) {
+    Logger.log("storing article ID and publishingInfo: ", publishingInfo);
     storeArticleID(publishingInfo.latestVersionID);
     storePublishingInfo(publishingInfo);
+  } else {
+    Logger.log("NOT storing article ID and publishingInfo: ", publishingInfo);
   }
 
   var tagsData = responseData.data.content.data.tags.values;

--- a/Page.html
+++ b/Page.html
@@ -78,7 +78,7 @@
         var revisionIdSpan = document.getElementById('revision-id');
         revisionIdSpan.innerHTML = data.articleID;
 
-        setPublishedFlag(data.isPublished);
+        setPublishedFlag(data.publishingInfo.isLatestVersionPublished);
 
         var articleHeadline = document.getElementById('article-headline');
         articleHeadline.value = data.headline;


### PR DESCRIPTION
Issue #69 

This PR fixes the problem where the "Published?" output in the sidebar was always reporting "No" - it was looking in the wrong place in the data for this value.

To test this, use version 20 of the add-on in the script editor to "Run > Test as add-on" and note that the value of "Published?" changes from "No" to "Yes" after successfully publishing, or, if the current article has already been published, it should start out as saying "Published? Yes".