### PR TITLE
Bugfix for 'publish': google app script only allows 1 argument passed to `run()`

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -533,6 +533,19 @@ function getArticleMeta() {
   Logger.log("getArticleMeta END");
   return articleMetadata;
 }
+/**
+ * 
+ * Saves the article as a draft, then publishes
+ * @param {} formObject 
+ */
+function handlePublish(formObject) {
+  Logger.log("Handling publish for formObject:", formObject);
+  // save the article - pass publishFlag as true
+  var message = getCurrentDocContents(formObject, true);
+  Logger.log("message: ", message)
+
+  return message;
+}
 
 /**
  * 

--- a/Page.html
+++ b/Page.html
@@ -272,7 +272,7 @@
         if (formObject.submitted === "Preview") {
           google.script.run.withSuccessHandler(onSuccess).withFailureHandler(onFailure).handlePreview(formObject);
         } else {
-          google.script.run.withSuccessHandler(onSuccess).withFailureHandler(onFailure).getCurrentDocContents(formObject, true);
+          google.script.run.withSuccessHandler(onSuccess).withFailureHandler(onFailure).handlePublish(formObject);
         }
       }
       


### PR DESCRIPTION
Issue #84 was caused by an "Uncaught exception: Forms with file inputs must be the only parameter." happening when you click the 'publish' button. I had made this change to the method signature of the function being called there when I did preview. I didn't realize that `google.script.run.<function()>` could only take one argument.

I fixed this by making a `handlePublish()` function that works similarly to `handlePreview()`, passing `true` as the publish flag, which tells the script whether to save as a draft only (`false`) or to save the draft and publish (`true`).

In order to test that this fixed the problem in the document linked in issue #84 I had to publish the add-on, which I did at version `28` with the code in this PR branch - I was able to successfully publish with this change.