### PR TITLE
Added a 'delete article' button with confirmation; cleaned up styles

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -15,22 +15,42 @@
         setPublishedFlag(false);
         var configDiv = document.getElementById('config');
         configDiv.style.display = 'none';
-        var div = document.getElementById('form-output');
-        div.innerHTML = contents;
+        var div = document.getElementById('loading');
+        div.innerHTML = '<p style="color: #48C774;">' + contents + "</p>";
         handleMeta();
       }
       
+      function onSuccessDelete(contents) {
+        // first, switch the "published" text to say "No"
+        setPublishedFlag(false);
+        var configDiv = document.getElementById('config');
+        configDiv.style.display = 'none';
+
+        var loadingDiv = document.getElementById('loading');
+        loadingDiv.innerHTML = '<p style="color: #48C774;">' + contents + "</p>";
+        loadingDiv.style.display = "block";
+
+        handleMeta();
+      }
+
+      function onFailureDelete(error) {
+        var loadingDiv = document.getElementById('loading');
+        console.log(error);
+        loadingDiv.innerHTML = "<p class='error'>An error occurred while deleting this article from the database: " + error + "</p>";
+      }
+
       function onFailureMeta(error) {
         var loadingDiv = document.getElementById('loading');
         console.log(error);
-        loadingDiv.innerHTML = "An error occurred: " + error;
+        loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + '</p>';
       }
 
       function onFailure(error) {
         var loadingDiv = document.getElementById('loading');
         console.log(error);
-        loadingDiv.innerHTML = "An error occurred: " + error;
+        loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + "</p>";
       }
+
       function onSuccessMeta(data) {
         var loadingDiv = document.getElementById('loading');
         loadingDiv.style.display = "none";
@@ -248,7 +268,7 @@
 
       function onFailureConfig(error) {
         var configDiv = document.getElementById('config');
-        configDiv.innerHTML = "An error occurred. This may be due to being logged into multiple google accounts at once. Try opening this doc in an incognito window.";
+        configDiv.innerHTML = "<p class='error'>An error occurred. This may be due to being logged into multiple google accounts at once. Try opening this doc in an incognito window.</p>";
       }
 
       function handleScriptConfig() {
@@ -270,12 +290,31 @@
         loadingDiv.style.display = "block";
 
         if (formObject.submitted === "Preview") {
+          loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
           google.script.run.withSuccessHandler(onSuccess).withFailureHandler(onFailure).handlePreview(formObject);
         } else {
+          loadingDiv.innerHTML = "<p class='gray'>Publishing article...</p>"
           google.script.run.withSuccessHandler(onSuccess).withFailureHandler(onFailure).handlePublish(formObject);
         }
       }
       
+      function deleteArticle() {
+        if (window.confirm("Are you sure you want to delete this article?")) { 
+          console.log("proceeding with delete")
+          var configDiv = document.getElementById('config');
+          configDiv.style.display = "none";
+          var loadingDiv = document.getElementById('loading');
+          loadingDiv.innerHTML = "Deleting article...";
+          loadingDiv.style.display = "block";
+
+          var articleMetaForm = document.getElementById('article-meta-form');
+          articleMetaForm.style.display = 'none';
+          google.script.run.withFailureHandler(onFailureDelete).withSuccessHandler(onSuccessDelete).deleteArticle();
+        } else {
+          console.log("cancelled delete")
+        }
+      }
+
       window.onload = (function(){
         var form = document.getElementById('article-meta-form');
         form.style.display = "none";
@@ -337,7 +376,7 @@
     <div id="sidebar-wrapper" class="sidebar branding-below">
       <h1 class="title">Publishing Tools</h1>
 
-      <div class="block" id="loading">Loading...</div>
+      <div class="block gray" id="loading">Loading...</div>
 
       <div id="config"></div>
       <div id="script-config-form-output" class="block secondary"></div>
@@ -403,7 +442,6 @@
 
       <div id="article-meta-form">
         <form onsubmit="handleClick(this)">
-          <div id="form-output" class="block success"></div>
           <div class="block">
             <input type="submit" name="preview" id="preview-button-top" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="save-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>
@@ -504,6 +542,9 @@
       <div class="block">
         <button onclick="getConfigAndDisplayForm()">Show Config</button>
         <button onclick="hideConfigForm()">Hide Config</button>
+      </div>
+      <div class="block">
+        <button class="create" onclick="deleteArticle()">Delete Article</button>
       </div>
     </div>
 


### PR DESCRIPTION
Issue #85 

This PR adds delete functionality to the sidebar:

* a red "Delete Article" button now shows up at the very bottom of the sidebar
  * we could add it to the top as well, but I figured maybe we didn't want to make it overly prominent?
* clicking it shows a confirmation dialog, which surprisingly is allowed in google app scripts
* okaying the confirmation triggers the `deleteArticle` app script function
  * the `DeleteBasicArticle` mutation is posted to the API
  * the doc properties for publishing info (includes dates) and articleID are deleted
* cancelling the confirmation just closes the dialog

You should be able to delete the article, then publish it again (or preview it). I did this many times while testing.

We'll want to provide better explanations around this feature, like "delete it from where?"

To test, run the add on at `version 29` on a document, try deleting and publishing it.
