### PR TITLE
Use referenced authors

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -16,6 +16,7 @@
         var configDiv = document.getElementById('config');
         configDiv.style.display = 'none';
         var div = document.getElementById('loading');
+        div.style.display = 'block';
         div.innerHTML = '<p style="color: #48C774;">' + contents + "</p>";
         handleMeta();
       }
@@ -83,6 +84,23 @@
           }
         })
 
+        var articleAuthorsSelect = document.getElementById('article-authors');
+        data.allAuthors.forEach(author => {
+          // first check if this option already exists; don't add dupes!
+          var selectorString = "#article-authors option[value='" + author.id + "']";
+          if ( $(selectorString).length <= 0 ) {
+            var option = document.createElement("option");
+            option.text = author.name.value;
+            option.value = author.id;
+
+            const result = data.articleAuthors.find( ({ id }) => id === author.id );
+            if (result !== undefined) {
+              option.selected = true;
+            }
+            articleAuthorsSelect.add(option);
+          }
+        })
+
         var articleTagsSelect = document.getElementById('article-tags');
         data.allTags.forEach(tag => {
           // first check if this option already exists; don't add dupes!
@@ -137,6 +155,10 @@
 
         var slugDiv = document.getElementById('slug');
         slugDiv.innerHTML = data.slug;
+
+        $('#article-authors').select2({
+          width: 'resolve',
+        });
 
         $('#article-tags').select2({
           width: 'resolve',
@@ -455,6 +477,13 @@
           </div>
 
           <div class="block form-group">
+            <label for="article-authors">
+              <b>Authors</b>
+              <select style="width: 100%" id="article-authors" name="article-authors" multiple="multiple"></select>
+            </label>
+          </div>
+
+          <div class="block form-group">
             <label for="article-byline">
               <b>Byline</b>
             </label>
@@ -474,6 +503,7 @@
               <select style="width: 100%" id="article-tags" name="article-tags" multiple="multiple"></select>
             </label>
           </div>
+
           <div class="block form-group">
             <label for="article-search-title">
               <b>Search title</b>


### PR DESCRIPTION
Issue #89 

This PR adds a field to the sidebar for `Authors`:

* Basic Article content model updated to include "list of references" type "Authors" field to allow one or more authors
* Sidebar requests list of authors from webiny
* Similar to tags, typeahead/select multiple field used for authors
* Unlike tags, you cannot create a new author from here
* Preview and publishing both save the updated article with selected referenced authors

Note: I've left the byline field in for now, though I realise this is confusing. I'm thinking we might want to allow for a freeform byline field in case selecting authors from a predefined list won't work (ex: "by Anonymous" or "by the Editorial Board"). We'd definitely need clearer labelling though. Thoughts?

To test:

1. Open the add-on in [the script editor](https://script.google.com/a/newscatalyst.org/d/1ILURq69o3cYUy6k1n1X6HwxdMfl9xWNhILYuZxgLfeblb3IR15WCMZSj/edit).
2. Run > test as add-on > latest code > choose a document.
3. Open the sidebar, select one or more authors, preview and/or publish.