### PR TITLE
Store author slugs in byline

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -49,6 +49,7 @@
       function onFailure(error) {
         var loadingDiv = document.getElementById('loading');
         console.log(error);
+        loadingDiv.style.display = "block";
         loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + "</p>";
       }
 
@@ -126,8 +127,10 @@
         var articleHeadline = document.getElementById('article-headline');
         articleHeadline.value = data.headline;
 
-        var articleByline = document.getElementById('article-byline');
-        articleByline.value = data.byline;
+        if (data.customByline !== null && data.customByline !== undefined) {
+          var articleCustomByline = document.getElementById('article-custom-byline');
+          articleCustomByline.value = data.customByline;
+        }
 
         var articleSearchTitle = document.getElementById('article-search-title');
         articleSearchTitle.value = data.seo.searchTitle;
@@ -484,10 +487,10 @@
           </div>
 
           <div class="block form-group">
-            <label for="article-byline">
-              <b>Byline</b>
+            <label for="article-custom-byline">
+              <b>Custom Byline</b>
             </label>
-            <input id="article-byline" name="article-byline" type="text" />
+            <input id="article-custom-byline" name="article-custom-byline" type="text" />
           </div>
 
           <div class="block form-group">


### PR DESCRIPTION
Issue #91 

This will allow us to generate author pages by searching for articles by an author.

Example:

If "The Top 3 British Novels" was written by me and Tyler, the `authors` field would reference both of our author records, and the byline field (which should prolly be renamed) will have `tyler-fisher jacqui-lough` as the text value.

This lets us do a search with the `where input` of:

```
{
  "where": {
    "byline_contains":"jacqui-lough"
  }
}
```

To return all articles that I've written.

It's a bit of a hack, but it works, and it lets us do this kind of search without adding a full indexed search layer. 

I think I should rename this field to something more intention revealing, like `author_slugs` and prevent its value from displaying in the sidebar. I left it in there while adding this functionality. Also, do we want to keep the free-form byline field around @TylerFisher?
