### PR TITLE
Handle the 'about' page and other regular/non-article pages

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -736,20 +736,20 @@ function getCurrentDocContents(formObject, publishFlag) {
   // first save the latest article content - either create a new article, or create a new revision on an existing article
   var webinyResponse;
   // if we already have an articleID and latest version info, we need to create a new version of the article
-  // if (articleID !== null) {
-  //   if (documentType === "article") {
-  //     webinyResponse = createArticleFrom(articleID, title, formattedElements);
-  //   } else {
-  //     webinyResponse = createPageFrom(articleID, title, formattedElements);
-  //   }
-  // // otherwise, we create a new article
-  // } else {
+  if (articleID !== null) {
+    if (documentType === "article") {
+      webinyResponse = createArticleFrom(articleID, title, formattedElements);
+    } else {
+      webinyResponse = createPageFrom(articleID, title, formattedElements);
+    }
+  // otherwise, we create a new article
+  } else {
     if (documentType === "article") {
       webinyResponse = createArticle(title, formattedElements);
     } else {
       webinyResponse = createPage(title, formattedElements);
     }
-  // }
+  }
 
   var responseText = webinyResponse.getContentText();
   var responseData = JSON.parse(responseText);

--- a/Code.js
+++ b/Code.js
@@ -2660,17 +2660,21 @@ function processForm(formObject) {
   var headline = formObject["article-headline"];
   storeHeadline(headline);
 
-  var customByline = formObject["article-custom-byline"];
-  storeCustomByline(customByline);
+  var documentType = getDocumentType();
 
-  var authors = formObject["article-authors"];
-  storeAuthors(authors);
+  if (documentType && documentType === "article") {
+    var customByline = formObject["article-custom-byline"];
+    storeCustomByline(customByline);
 
-  var tags = formObject["article-tags"];
-  storeTags(tags);
+    var authors = formObject["article-authors"];
+    storeAuthors(authors);
 
-  var categoryID = formObject["article-category"]
-  storeCategoryID(categoryID);
+    var tags = formObject["article-tags"];
+    storeTags(tags);
+
+    var categoryID = formObject["article-category"]
+    storeCategoryID(categoryID);
+  }
 
   var seoData = {
     searchTitle: formObject["article-search-title"],
@@ -2683,6 +2687,5 @@ function processForm(formObject) {
 
   storeSEO(seoData);
 
-  return "Updated article metadata. You still need to publish the article for these changes to go live!"
-
+  return "Updated document metadata. You still need to publish for these changes to go live!"
 }

--- a/Code.js
+++ b/Code.js
@@ -507,6 +507,14 @@ function storeSEO(seoData) {
   storeValueJSON("ARTICLE_SEO", seoData);
 }
 
+function storeDocumentType(value) {
+  storeValue('DOCUMENT_TYPE', value);
+}
+
+function getDocumentType() {
+  getValue('DOCUMENT_TYPE');
+}
+
 //
 // Functions for retrieving and formatting document contents
 //
@@ -517,6 +525,29 @@ function storeSEO(seoData) {
 . */
 function getArticleMeta() {
   Logger.log("getArticleMeta START");
+
+  // first determine if the document is an article or a static page for the site
+  // this is based on which folder the document is in: 'pages' (static pages) or anything else (articles)
+  // in order to do this we need to use the Google Drive API
+  // which requires the "https://www.googleapis.com/auth/drive.readonly" scope
+  var documentID = DocumentApp.getActiveDocument().getId();
+  var driveFile = DriveApp.getFileById(documentID)
+  var fileParents = driveFile.getParents();
+  var isStaticPage = false;
+  while ( fileParents.hasNext() ) {
+    var folder = fileParents.next();
+    if (folder.getName() === "pages") {
+      isStaticPage = true;
+    }
+  }
+
+  var documentType = 'article';
+  Logger.log("isStaticPage:", isStaticPage);
+  if (isStaticPage) {
+    documentType = 'page';
+  }
+  storeDocumentType(documentType);
+
   var articleID = getArticleID();
 
   var publishingInfo = getPublishingInfo();
@@ -590,6 +621,7 @@ function getArticleMeta() {
       awsAccessKey: awsAccessKey,
       awsSecretKey: awsSecretKey,
       awsBucket: awsBucket,
+      documentType: documentType,
       graphqlApi: graphqlApi,
       personalAccessToken: personalAccessToken,
       accessToken: accessToken,
@@ -617,6 +649,7 @@ function getArticleMeta() {
     awsAccessKey: awsAccessKey,
     awsSecretKey: awsSecretKey,
     awsBucket: awsBucket,
+    documentType: documentType,
     graphqlApi: graphqlApi,
     personalAccessToken: personalAccessToken,
     accessToken: accessToken,

--- a/Page.html
+++ b/Page.html
@@ -64,34 +64,33 @@
           };
         }
 
-        var articleCategorySelect = document.getElementById('article-category');
-        var categoriesSorted = data.categories.sort(function (a, b) {
-          let comparison = 0;
-          if (a.title.value > b.title.value) {
-            comparison = 1;
-          } else if (a.title.value < b.title.value) {
-            comparison = -1;
-          }
-          return comparison;
-        });
-        categoriesSorted.forEach(category => {
-          // first check if this option already exists; don't add dupes!
-          var selectorString = "#article-category option[value='" + category.id + "']";
-          if ( $(selectorString).length <= 0 ) {
-            var option = document.createElement("option");
-            option.text = category.title.value;
-            option.value = category.id;
-
-            if (data.categoryID !== null && data.categoryID == category.id) {
-              option.selected = true;
-            }
-            articleCategorySelect.add(option);
-          }
-        })
-
-        var articleAuthorsSelect = document.getElementById('article-authors');
-
         if (data.documentType === 'article') {
+          var articleCategorySelect = document.getElementById('article-category');
+          var categoriesSorted = data.categories.sort(function (a, b) {
+            let comparison = 0;
+            if (a.title.value > b.title.value) {
+              comparison = 1;
+            } else if (a.title.value < b.title.value) {
+              comparison = -1;
+            }
+            return comparison;
+          });
+          categoriesSorted.forEach(category => {
+            // first check if this option already exists; don't add dupes!
+            var selectorString = "#article-category option[value='" + category.id + "']";
+            if ( $(selectorString).length <= 0 ) {
+              var option = document.createElement("option");
+              option.text = category.title.value;
+              option.value = category.id;
+
+              if (data.categoryID !== null && data.categoryID == category.id) {
+                option.selected = true;
+              }
+              articleCategorySelect.add(option);
+            }
+          })
+
+          var articleAuthorsSelect = document.getElementById('article-authors');
           data.allAuthors.forEach(author => {
             // first check if this option already exists; don't add dupes!
             var selectorString = "#article-authors option[value='" + author.id + "']";
@@ -172,27 +171,26 @@
           $('#article-authors').select2({
             width: 'resolve',
           });
+
+          $('#article-tags').select2({
+            width: 'resolve',
+            tags: true,
+            createTag: function (params) {
+              var term = $.trim(params.term);
+
+              if (term === '') {
+                return null;
+              }
+
+              return {
+                id: term,
+                text: term,
+                newTag: true // add additional parameters
+              }
+            }
+          });
         }
 
-        $('#article-tags').select2({
-          width: 'resolve',
-          tags: true,
-          createTag: function (params) {
-            var term = $.trim(params.term);
-
-            if (term === '') {
-              return null;
-            }
-
-            return {
-              id: term,
-              text: term,
-              newTag: true // add additional parameters
-            }
-          }
-        });
-
-        
         var revisionDiv = document.getElementById('revision-info');
         revisionDiv.style.display = "block";
 
@@ -220,9 +218,9 @@
             var localisedDate = new Date(data.publishingInfo.lastPublishedOn).toLocaleString();
             lastPubDiv.innerHTML = localisedDate;
           }
-
         }
       }
+
       function onSuccessMeta(data) {
         var loadingDiv = document.getElementById('loading');
         loadingDiv.style.display = "none";

--- a/Page.html
+++ b/Page.html
@@ -57,6 +57,13 @@
         var form = document.getElementById('article-meta-form');
         form.style.display = "block";
 
+        if (data.documentType !== "article") {
+          var elements = document.getElementsByClassName('articles-only');
+          for (var i = 0; i < elements.length; i++) {
+            elements[i].style.display = "none";
+          };
+        }
+
         var articleCategorySelect = document.getElementById('article-category');
         var categoriesSorted = data.categories.sort(function (a, b) {
           let comparison = 0;
@@ -83,21 +90,24 @@
         })
 
         var articleAuthorsSelect = document.getElementById('article-authors');
-        data.allAuthors.forEach(author => {
-          // first check if this option already exists; don't add dupes!
-          var selectorString = "#article-authors option[value='" + author.id + "']";
-          if ( $(selectorString).length <= 0 ) {
-            var option = document.createElement("option");
-            option.text = author.name.value;
-            option.value = author.id;
 
-            const result = data.articleAuthors.find( ({ id }) => id === author.id );
-            if (result !== undefined) {
-              option.selected = true;
+        if (data.documentType === 'article') {
+          data.allAuthors.forEach(author => {
+            // first check if this option already exists; don't add dupes!
+            var selectorString = "#article-authors option[value='" + author.id + "']";
+            if ( $(selectorString).length <= 0 ) {
+              var option = document.createElement("option");
+              option.text = author.name.value;
+              option.value = author.id;
+
+              const result = data.articleAuthors.find( ({ id }) => id === author.id );
+              if (result !== undefined) {
+                option.selected = true;
+              }
+              articleAuthorsSelect.add(option);
             }
-            articleAuthorsSelect.add(option);
-          }
-        })
+          })
+        }
 
         var articleTagsSelect = document.getElementById('article-tags');
         data.allTags.forEach(tag => {
@@ -124,9 +134,11 @@
         var articleHeadline = document.getElementById('article-headline');
         articleHeadline.value = data.headline;
 
-        if (data.customByline !== null && data.customByline !== undefined) {
-          var articleCustomByline = document.getElementById('article-custom-byline');
-          articleCustomByline.value = data.customByline;
+        if (data.documentType === 'article') {
+          if (data.customByline !== null && data.customByline !== undefined) {
+            var articleCustomByline = document.getElementById('article-custom-byline');
+            articleCustomByline.value = data.customByline;
+          }
         }
 
         var articleSearchTitle = document.getElementById('article-search-title');
@@ -156,9 +168,11 @@
         var slugDiv = document.getElementById('slug');
         slugDiv.innerHTML = data.slug;
 
-        $('#article-authors').select2({
-          width: 'resolve',
-        });
+        if (data.documentType === 'article') {
+          $('#article-authors').select2({
+            width: 'resolve',
+          });
+        }
 
         $('#article-tags').select2({
           width: 'resolve',
@@ -486,14 +500,14 @@
             <input id="article-headline" name="article-headline" type="text" />
           </div>
 
-          <div class="block form-group">
+          <div class="block form-group articles-only">
             <label for="article-authors">
               <b>Authors</b>
               <select style="width: 100%" id="article-authors" name="article-authors" multiple="multiple"></select>
             </label>
           </div>
 
-          <div class="block form-group">
+          <div class="block form-group articles-only">
             <label for="article-custom-byline">
               <b>Custom Byline</b>
             </label>

--- a/Page.html
+++ b/Page.html
@@ -514,14 +514,14 @@
             <input id="article-custom-byline" name="article-custom-byline" type="text" />
           </div>
 
-          <div class="block form-group">
+          <div class="block form-group articles-only">
             <label for="article-category">
               <b>Category/Section</b>
               <select style="width: 100%" id="article-category" name="article-category"></select>
             </label>
           </div>
 
-          <div class="block form-group">
+          <div class="block form-group articles-only">
             <label for="article-tags">
               <b>Tags</b>
               <select style="width: 100%" id="article-tags" name="article-tags" multiple="multiple"></select>

--- a/appsscript.json
+++ b/appsscript.json
@@ -16,7 +16,8 @@
     "https://www.googleapis.com/auth/documents", 
     "https://www.googleapis.com/auth/script.external_request", 
     "https://www.googleapis.com/auth/script.container.ui", 
-    "https://www.googleapis.com/auth/documents.currentonly"
+    "https://www.googleapis.com/auth/documents.currentonly",
+    "https://www.googleapis.com/auth/drive.readonly"
   ],
   "runtimeVersion": "V8"
 }


### PR DESCRIPTION
This PR adds some additional functionality to the sidebar to handle publishing docs that aren't articles. The code has been tested (using "latest code" in "run > test as add-on") on both articles and an about page.

* the add-on now has a "document type" concept
  * if the document is in a folder called "pages" it is a page
  * otherwise it is an article
  * my test "About" page has been shared with you and is found here: https://drive.google.com/drive/folders/1-rbjIVjg_Eqf7azKGM5Hu53qneHzGHZy?usp=sharing
* article-specific fields like authors, category, byline, and tags are hidden on page-type docs
* saving a page for the first time calls the `createPage` mutation instead of `createBasicArticle`
* subsequent saves call `createPageFrom` instead of `createArticleFrom`
* previewing a page now returns the same url as article previews do - will need to change once [this issue](https://github.com/news-catalyst/next-tinynewsdemo/issues/103) is taken care of
* publishing a page calls the appropriate create mutation and then `publishPage` instead of `publishArticle`
* requesting and saving lists of things like authors, categories, and tags is skipped on pages

Once this is reviewed, approved, and merged:

* [ ] locally `git pull origin master` && `clasp push`
* [ ] create new version in script editor
* [ ] publish add-on at the new version
* [ ] test on article & page document