### PR TITLE
Set first and last published dates on initial save for articles

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -349,9 +349,11 @@ function storePublishingInfo(info) {
 function getPublishingInfo() {
   var publishingInfo = JSON.parse(getValue("PUBLISHING_INFO"));
   if (publishingInfo === null || typeof(publishingInfo) === 'undefined') {
+    let pubDate = new Date();
+    let pubDateString = pubDate.toISOString();
     publishingInfo = {
-      firstPublishedOn: "",
-      lastPublishedOn: "",
+      firstPublishedOn: pubDateString,
+      lastPublishedOn: pubDateString,
       latestVersionID: "",
       isLatestVersionPublished: false,
       publishedOn: ""
@@ -1808,6 +1810,22 @@ function createArticle(title, elements) {
               value: seoData.twitterDescription,
             },
           ],
+        },
+        firstPublishedOn: {
+          values:[
+            {
+              value: publishingInfo.firstPublishedOn,
+              locale: localeID
+            }
+          ]
+        },
+        lastPublishedOn: {
+          values:[
+            {
+              value: publishingInfo.lastPublishedOn,
+              locale: localeID
+            }
+          ]
         },
       },
     },


### PR DESCRIPTION
Issue #98 

This sets the first & last published dates when creating a new article. Subsequent updates already do this.

To test:

* create a new document in Google Docs
* open [the script editor for the add-on](https://script.google.com/a/newscatalyst.org/d/1ILURq69o3cYUy6k1n1X6HwxdMfl9xWNhILYuZxgLfeblb3IR15WCMZSj/edit)
* run > test as add-on > select your new doc
* publish the article
* verify the published dates are set (I did this in the [graphql admin playground](https://d3a91xrcpp69ev.cloudfront.net/cms/manage/production) with query below)

```
query listBasicArticles($where: BasicArticleListWhereInput) {
  content: listBasicArticles(where: $where) {
    error {
      code
      message
    }
  	data {
    	id
      headline {
        value
      }
      byline {
        value
      }
      tags {
          value {
            title {
              value
            }
            slug {
              value
            }
          }
      }
      authors {
        value {
          name {
            value
          }
          slug {
            value
          }
        }
      }
      slug {
        values {
          value
        }
      }
      category {
        value {
          slug {
            value
          }
        }
      }
      firstPublishedOn {
        value
      }
      lastPublishedOn {
        value
      }
      meta {
        published
        locked
      }
  	} 
  }
}
```

variables - specify fragment of your new doc headline to get the right result:

```
{
  "where":{
    "headline_contains": "first"
  }
}
```