### PR TITLE
Bugfix/save new tags

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -467,8 +467,10 @@ function storeTags(tags) {
     } else {
       tagID = tag;
     }
+    Logger.log("looking for tagID", tagID, "in allTags:", allTags);
     var result = allTags.find( ({ id }) => id === tagID );
     if (result !== undefined) {
+      Logger.log(tagID, "succeeded finding it")
       storableTags.push({
         id: result.id,
         newTag: false,
@@ -476,6 +478,7 @@ function storeTags(tags) {
       });
     // treat this as a new tag
     } else {
+      Logger.log(tagID, "failed finding it, new tag")
       storableTags.push({
         id: null,
         newTag: true,
@@ -1286,8 +1289,11 @@ function createArticleFrom(versionID, title, elements) {
     })
   }
 
-  var allTags = getValueJSON('ALL_TAGS'); // don't look up in the DB again, too slow
+  var allTags = getAllTags(); // don't look up in the DB again, too slow
+  Logger.log("allTags:", allTags);
 
+  var articleTags = getTags(); // refresh list of tags for this article as some may have been created just above
+  Logger.log("articleTags:", articleTags);
   // compare all tags array to those selected for this article
   var tagsArrayForGraphQL = [];
   allTags.forEach(tag => {
@@ -1308,6 +1314,8 @@ function createArticleFrom(versionID, title, elements) {
       });
     }
   });
+
+  Logger.log("TAGS FOR GRAPHQL:", tagsArrayForGraphQL);
 
   var formData = {
     query: `mutation CreateBasicArticleFrom($revision: ID!, $data: BasicArticleInput) {
@@ -2429,6 +2437,8 @@ function createTag(tagTitle) {
   // after creating the tag we have to publish it
   publishTag(newTagData.id);
 
+  var allTags = getAllTags();
+
   // if we found this tag already in the articleTags, update it with the ID and mark it as no longer new
   const tagIndex = articleTags.findIndex( ({title}) => title === tagTitle);
   if (tagIndex > 0) {
@@ -2436,19 +2446,38 @@ function createTag(tagTitle) {
     articleTags[tagIndex].newTag = false;
     articleTags[tagIndex].id = newTagData.id;
     Logger.log("created new tag, updated articleTags data is: ", articleTags[tagIndex]);
+    var allTagsData = {
+      title: {
+        value: articleTags[tagIndex].title
+      },
+      newTag: false,
+      id: articleTags[tagIndex].id
+    }
+    allTags.push(allTagsData);
+    Logger.log("updated allTags is: ", allTags);
+
   // otherwise just append the new tag data
   } else {
     Logger.log("created new tag, now appending it to articleTags data");
-    articleTags.push({
+    let tagData ={
       id: newTagData.id,
       newTag: false,
       title: newTagData.title
-    });
+    }
+    articleTags.push(tagData);
     Logger.log("created new tag, appended it to articleTags data: ", articleTags);
+    // append to ALL_TAGS
+    var allTagsData = {
+      title: {
+        value: tagData.title
+      },
+      newTag: false,
+      id: tagData.id
+    }
+    allTags.push(tagData);
   }
 
-  // PUBLISH the tag as well
-  // TODO
+  storeAllTags(allTags);
   storeTags(articleTags);
 
   return responseData;

--- a/Code.js
+++ b/Code.js
@@ -349,9 +349,11 @@ function storePublishingInfo(info) {
 function getPublishingInfo() {
   var publishingInfo = JSON.parse(getValue("PUBLISHING_INFO"));
   if (publishingInfo === null || typeof(publishingInfo) === 'undefined') {
+    let pubDate = new Date();
+    let pubDateString = pubDate.toISOString();
     publishingInfo = {
-      firstPublishedOn: "",
-      lastPublishedOn: "",
+      firstPublishedOn: pubDateString,
+      lastPublishedOn: pubDateString,
       latestVersionID: "",
       isLatestVersionPublished: false,
       publishedOn: ""
@@ -1808,6 +1810,22 @@ function createArticle(title, elements) {
               value: seoData.twitterDescription,
             },
           ],
+        },
+        firstPublishedOn: {
+          values:[
+            {
+              value: publishingInfo.firstPublishedOn,
+              locale: localeID
+            }
+          ]
+        },
+        lastPublishedOn: {
+          values:[
+            {
+              value: publishingInfo.lastPublishedOn,
+              locale: localeID
+            }
+          ]
         },
       },
     },


### PR DESCRIPTION
Issue #97 

This PR fixes handling of new tags on both new articles and existing articles. Any new tag entered will now get created as a `Tag` model instance and associated on the new/updated article.

To test...

* on a new article: create a new document, create a new test case (script editor > run > test as add-on > latest code), add a new tag, publish
* on a existing article: open existing test case (script editor > run > test as add-on > latest code), add a new tag, publish

Both cases should result in the article having the new tag created in webiny.

Btw, both this PR and PR #99 merge into master. I don't think we need the added complexity of a develop branch on this repo :) 