### PR TITLE
Updated queries for new api

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -756,13 +756,13 @@ function getCurrentDocContents(formObject, publishFlag) {
   var articleID = responseData.id;
   storeArticleID(articleID);
 
-  var webinyResponseCode = webinyResponse.getResponseCode();
-  var responseText;
-  if (webinyResponseCode === 200) {
+  // var webinyResponseCode = webinyResponse.getResponseCode();
+  // var responseText;
+  // if (webinyResponseCode === 200) {
     responseText = `Successfully stored ${documentType} in webiny.`;
-  } else {
-    responseText = 'Webiny responded with code ' + webinyResponseCode;
-  }
+  // } else {
+  //   responseText = 'Webiny responded with code ' + webinyResponseCode;
+  // }
 
   if (publishFlag) {
     // Logger.log(`Publishing ${documentType}...`)
@@ -1983,6 +1983,10 @@ function publishArticle() {
     query: `mutation UpdateArticle($id: ID!, $data: ArticleInput!) {
       articles { 
         updateArticle(id: $id, data: $data) {
+          error {
+            code
+            message
+          }
           data {
             id
             firstPublishedOn
@@ -2018,12 +2022,12 @@ function publishArticle() {
   );
   var responseText = response.getContentText();
   var responseData = JSON.parse(responseText);
-  // Logger.log(responseData);
+  Logger.log("publish response:", responseData);
 
   // TODO update latestVersionPublished flag
 
   Logger.log("END publishArticle");
-  if (responseData && responseData.data && response.data.articles && response.data.articles.updateArticle && response.data.articles.updateArticle.data) {
+  if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.updateArticle && responseData.data.articles.updateArticle.data) {
     return "Published article at revision " + versionID;
   } else {
     return responseData.data.articles.updateArticle.error;

--- a/Page.html
+++ b/Page.html
@@ -441,18 +441,6 @@
           <input id="content-api" name="CONTENT_API" type="text" />
         </div>
         <div class="block form-group">
-          <label for="personal-access-token">
-            <b>GraphQL API Access Token</b>
-          </label>
-          <input id="personal-access-token" name="PERSONAL_ACCESS_TOKEN" type="text" />
-        </div>
-        <div class="block form-group">
-          <label for="graphql-api-url">
-            <b>GraphQL API URL</b>
-          </label>
-          <input id="graphql-api-url" name="GRAPHQL_API" type="text" />
-        </div>
-        <div class="block form-group">
           <label for="preview-url">
             <b>Preview Host URL</b>
           </label>

--- a/Page.html
+++ b/Page.html
@@ -91,12 +91,15 @@
           })
 
           var articleAuthorsSelect = document.getElementById('article-authors');
+          console.log("data:", data);
+          console.log("data.allAuthors:", data.allAuthors);
           data.allAuthors.forEach(author => {
+            console.log("author:", author);
             // first check if this option already exists; don't add dupes!
             var selectorString = "#article-authors option[value='" + author.id + "']";
             if ( $(selectorString).length <= 0 ) {
               var option = document.createElement("option");
-              option.text = author.name.value;
+              option.text = author.name;
               option.value = author.id;
 
               const result = data.articleAuthors.find( ({ id }) => id === author.id );
@@ -114,7 +117,7 @@
           var selectorString = "#article-tags option[value='" + tag.id + "']";
           if ( $(selectorString).length <= 0 ) {
             var option = document.createElement("option");
-            option.text = tag.title.value;
+            option.text = tag.title.values[0].value;
             option.value = tag.id;
 
             const result = data.articleTags.find( ({ id }) => id === tag.id );
@@ -128,7 +131,7 @@
         var revisionIdSpan = document.getElementById('revision-id');
         revisionIdSpan.innerHTML = data.articleID;
 
-        setPublishedFlag(data.publishingInfo.isLatestVersionPublished);
+        setPublishedFlag(true); // todo: get rid of this?;
 
         var articleHeadline = document.getElementById('article-headline');
         articleHeadline.value = data.headline;


### PR DESCRIPTION
Issue #103 

This PR includes a lot of changes, but the end result should function the same: the add-on should now work with the scripted version of the API.

Summary:

* there's just one content API now, no more "cms" read & write versions
* and one access token (posted in slack)
* opening the sidebar add-on should load the above as part of its configuration
* preview and publish article should work as expected
