### PR TITLE
Bugfix: display title found in values for each category in dropdown

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -798,7 +798,8 @@ function getCurrentDocContents(formObject, publishFlag) {
 .* Preserves order, indicates that order with `index` attribute
 .*/
 function getElements() {
-  var documentID = DocumentApp.getActiveDocument().getId();
+  var activeDoc = DocumentApp.getActiveDocument();
+  var documentID = activeDoc.getId();
   var document = Docs.Documents.get(documentID);
 
   var elements = document.body.content;
@@ -847,7 +848,7 @@ function getElements() {
   }
 
   var listInfo = {};
-  var listItems = DocumentApp.getActiveDocument().getListItems();
+  var listItems = activeDoc.getListItems();
   listItems.forEach(li => {
     var id = li.getListId();
     var glyphType = li.getGlyphType();

--- a/Page.html
+++ b/Page.html
@@ -68,9 +68,9 @@
           var articleCategorySelect = document.getElementById('article-category');
           var categoriesSorted = data.categories.sort(function (a, b) {
             let comparison = 0;
-            if (a.title.value > b.title.value) {
+            if (a.title.values[0].value > b.title.values[0].value) {
               comparison = 1;
-            } else if (a.title.value < b.title.value) {
+            } else if (a.title.values[0].value < b.title.values[0].value) {
               comparison = -1;
             }
             return comparison;
@@ -80,7 +80,7 @@
             var selectorString = "#article-category option[value='" + category.id + "']";
             if ( $(selectorString).length <= 0 ) {
               var option = document.createElement("option");
-              option.text = category.title.value;
+              option.text = category.title.values[0].value;
               option.value = category.id;
 
               if (data.categoryID !== null && data.categoryID == category.id) {
@@ -91,10 +91,7 @@
           })
 
           var articleAuthorsSelect = document.getElementById('article-authors');
-          console.log("data:", data);
-          console.log("data.allAuthors:", data.allAuthors);
           data.allAuthors.forEach(author => {
-            console.log("author:", author);
             // first check if this option already exists; don't add dupes!
             var selectorString = "#article-authors option[value='" + author.id + "']";
             if ( $(selectorString).length <= 0 ) {


### PR DESCRIPTION
Issue: #105 

Category titles used to be accessible in the data under `category.title.value` but are now another level down `category.title.values[0].value`. The category titles should now display.

What's confusing to me is why you see 3 categories but I only see 1... I'm wondering which API your add-on/sidebar is talking to.

While I was fixing this, I also ran into a small issue where Google Docs API gets confused if you ask for the active/current document too many times. We really only need to do this once per function, so I fixed that too.