### PR TITLE
Store headline for searching as a regular string

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1328,6 +1328,7 @@ function createArticleFrom(versionID, title, elements) {
                 value
               }
             }
+            headlineSearch
             authors {
               id
               name
@@ -1367,6 +1368,7 @@ function createArticleFrom(versionID, title, elements) {
             },
           ],
         },
+        headlineSearch: title,
         content: {
           values: [
             {
@@ -1733,6 +1735,7 @@ function createArticle(title, elements) {
                 value
               }
             }
+            headlineSearch
             authors {
               id
               name
@@ -1757,6 +1760,7 @@ function createArticle(title, elements) {
             },
           ],
         },
+        headlineSearch: title,
         slug: slug,
         category: categoryID,
         content: {


### PR DESCRIPTION
This change will allow the following query to work. The new `headlineSearch` field stays set to whatever the regular i18n headline is via this PR.

<img width="1408" alt="Screen Shot 2020-10-12 at 1 47 25 pm" src="https://user-images.githubusercontent.com/3397/95699942-79e87200-0c91-11eb-8f04-922cb34a1e85.png">