### PR TITLE
Request latest categories from webiny on load

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -588,11 +588,11 @@ function getArticleMeta() {
     storeAuthorSlugs(authorSlugsValue);
   }
 
-  var categories = getCategories();
-  if (categories === null || categories.length <= 0) {
-    categories = listCategories();
+  // var categories = getCategories();
+  // if (categories === null || categories.length <= 0) {
+    var categories = listCategories();
     storeCategories(categories);
-  }
+  // }
 
   var categoryID = getCategoryID();
   var categoryName = getNameForCategoryID(categories, categoryID);


### PR DESCRIPTION
This PR has a small bugfix: when setting up the sidebar options (`getArticleMeta()`), request the latest categories from webiny. The sidebar was looking for a cached set instead; I think it's best to always look for the latest instead. We can address performance issues as needed, when needed :)

I noticed this problem when trying to debug https://github.com/news-catalyst/next-tinynewsdemo/issues/162 - I couldn't assign a category because the menu had 1 old category that had been deleted. This should fix that problem!