### PR TITLE
Store document id info for each locale on articles

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -693,9 +693,10 @@ function getArticleMeta() {
   }
   storeDocumentType(documentType);
 
+  var locales = getLocales();
+
   var articleID = getArticleID();
 
-  // TODO: getArticle if articleID not null
   if (articleID !== null && articleID !== undefined) {
     var latestArticleData = getArticleDataByID(articleID);
 
@@ -822,55 +823,57 @@ function getArticleMeta() {
   if (typeof(articleID) === "undefined" || articleID === null) {
 
     return {
+      accessToken: accessToken,
+      allAuthors: allAuthors,
+      allTags: allTags,
+      articleAuthors: articleAuthors,
+      articleID: null,
+      articleTags: articleTags,
+      authorSlugs: authorSlugsValue,
       awsAccessKey: awsAccessKey,
       awsSecretKey: awsSecretKey,
       awsBucket: awsBucket,
-      documentType: documentType,
-      accessToken: accessToken,
-      contentApi: contentApi,
-      previewUrl: previewUrl,
-      previewSecret: previewSecret,
-      articleID: null,
-      headline: headline,
-      customByline: customByline,
-      authorSlugs: authorSlugsValue,
-      publishingInfo: publishingInfo,
-      published: published,
-      allAuthors: allAuthors,
-      articleAuthors: articleAuthors,
-      allTags: allTags,
-      articleTags: articleTags,
       categories: categories,
       categoryID: categoryID,
       categoryName: categoryName,
-      slug: slug,
+      contentApi: contentApi,
+      customByline: customByline,
+      documentType: documentType,
+      headline: headline,
+      locales: locales,
+      previewSecret: previewSecret,
+      previewUrl: previewUrl,
+      published: published,
+      publishingInfo: publishingInfo,
       seo: seoData,
+      slug: slug,
       republishUrl: republishUrl
     }
   }
 
   var articleMetadata = {
+    accessToken: accessToken,
+    allAuthors: allAuthors,
+    allTags: allTags,
+    articleAuthors: articleAuthors,
+    articleID: articleID,
+    articleTags: articleTags,
+    authorSlugs: authorSlugsValue,
     awsAccessKey: awsAccessKey,
     awsSecretKey: awsSecretKey,
     awsBucket: awsBucket,
-    documentType: documentType,
-    accessToken: accessToken,
-    contentApi: contentApi,
-    previewUrl: previewUrl,
-    previewSecret: previewSecret,
-    articleID: articleID,
-    headline: headline,
-    customByline: customByline,
-    authorSlugs: authorSlugsValue,
-    publishingInfo: publishingInfo,
-    published: published,
-    allAuthors: allAuthors,
-    articleAuthors: articleAuthors,
-    allTags: allTags,
-    articleTags: articleTags,
     categories: categories,
     categoryID: categoryID,
     categoryName: categoryName,
+    contentApi: contentApi,
+    customByline: customByline,
+    documentType: documentType,
+    previewUrl: previewUrl,
+    previewSecret: previewSecret,
+    headline: headline,
+    locales: locales,
+    published: published,
+    publishingInfo: publishingInfo,
     slug: slug,
     seo: seoData,
     republishUrl: republishUrl

--- a/Code.js
+++ b/Code.js
@@ -1,4 +1,5 @@
 const availableLocalesKey = 'AVAILABLE_LOCALES';
+const localeNameKey = 'LOCALE_NAME';
 /**
  * The event handler triggered when installing the add-on.
  * @param {Event} e The onInstall event.
@@ -306,11 +307,14 @@ function storeLocaleID(localeID) {
 }
 
 function getSelectedLocaleName() {
-  getValue('LOCALE_NAME');
+  var value = getValue(localeNameKey);
+  Logger.log("getSelectedLocaleName:", value);
+  return value;
 }
 
 function storeSelectedLocaleName(localeName) {
-  storeValue('LOCALE_NAME', localeName);
+  Logger.log("storing selected locale name:", localeName);
+  storeValue(localeNameKey, localeName);
 }
 
 function getAvailableLocales() {
@@ -319,6 +323,7 @@ function getAvailableLocales() {
 }
 
 function storeAvailableLocales(localesString) {
+  Logger.log("storeAvailableLocales:", localesString);
   storeValue(availableLocalesKey, localesString);
 }
 
@@ -977,6 +982,9 @@ function handlePreview(formObject) {
 . */
 function getCurrentDocContents(formObject, publishFlag) {
 
+  var activeDoc = DocumentApp.getActiveDocument();
+  var documentID = activeDoc.getId();
+
   var returnValue = {
     status: "",
     message: ""
@@ -993,6 +1001,7 @@ function getCurrentDocContents(formObject, publishFlag) {
 
   var articleData = {};
   articleData.id = articleID;
+  articleData.documentID = documentID;
   articleData.headline = title;
   articleData.formattedElements = formattedElements;
 
@@ -1006,11 +1015,11 @@ function getCurrentDocContents(formObject, publishFlag) {
     return returnValue;
   }
 
-  Logger.log("..LocaleName:", selectedLocaleName);
-  Logger.log("..LocaleID:", selectedLocale);
-
   articleData.localeName = selectedLocaleName;
   articleData.localeID = selectedLocale;
+
+  Logger.log("articleData for locale:", articleData.localeID, articleData.localeName);
+
   articleData.published = publishFlag;
   articleData.categoryID = getCategoryID();
   articleData.authors = getAuthors();
@@ -1911,6 +1920,9 @@ function createArticle(articleData) {
 
   storeAvailableLocales(localeName);
 
+  var googleDocs = {}
+  googleDocs[localeName] = articleData.documentID;
+
   var categoryName = getNameForCategoryID(categories, categoryID);
 
   var slug = getArticleSlug();
@@ -2067,7 +2079,8 @@ function createArticle(articleData) {
           ],
         },
         firstPublishedOn: publishingInfo.firstPublishedOn,
-        lastPublishedOn: publishingInfo.lastPublishedOn
+        lastPublishedOn: publishingInfo.lastPublishedOn,
+        googleDocs: JSON.stringify(googleDocs)
       }
   };
   var formData = {
@@ -3273,8 +3286,9 @@ function i18nGetLocales(currentLocaleID, exampleLocalisedValues) {
   });
 
   availableLocales = localeNames.join(" ");
-  Logger.log("so, locale names:", localeNames, "and availableLocales:", availableLocales);
+  Logger.log("availableLocales:", availableLocales);
   storeAvailableLocales(availableLocales);
+
   return availableLocales;
 }
 

--- a/Code.js
+++ b/Code.js
@@ -1,3 +1,4 @@
+const availableLocalesKey = 'AVAILABLE_LOCALES';
 /**
  * The event handler triggered when installing the add-on.
  * @param {Event} e The onInstall event.
@@ -313,12 +314,12 @@ function storeSelectedLocaleName(localeName) {
 }
 
 function getAvailableLocales() {
-  getValue('AVAILABLE_LOCALES');
+  var value = getValue(availableLocalesKey)
+  return value;
 }
 
 function storeAvailableLocales(localesString) {
-  Logger.log("storing available locales:", localesString);
-  storeValue('AVAILABLE_LOCALES', localesString);
+  storeValue(availableLocalesKey, localesString);
 }
 
 function getArticleSlug() {
@@ -394,7 +395,6 @@ function getPublishingInfo(updateDates) {
     }
     let pubDate = new Date();
     let pubDateString = pubDate.toISOString();
-    Logger.log("setting published dates to:", pubDateString);
     publishingInfo.firstPublishedOn = pubDateString;
     publishingInfo.lastPublishedOn = pubDateString;
     publishingInfo.publishedOn = pubDateString;

--- a/Code.js
+++ b/Code.js
@@ -1582,6 +1582,9 @@ function createArticleFrom(articleData) {
   // grab current article contents
   var previousArticleData = getArticle(versionID);
 
+  if (!previousArticleData) {
+    Logger.log("NO previous article data for:", versionID);
+  }
   var availableLocaleNames = i18nGetLocales(localeID, previousArticleData.headline.values);
 
   // then merge in the new content with previous locale data
@@ -3249,22 +3252,34 @@ function handleSearch(formObject) {
 function associateArticle(formObject) {
   Logger.log("associateArticle:", formObject);
 
+  var articleData = {};
+
   var articleID  = formObject["article-id"];
+  articleData.id = articleID;
+
+  var documentID = DocumentApp.getActiveDocument().getId();
+  articleData.documentID = documentID;
+
   var localeID  = formObject["article-locale"];
+  articleData.localeID = localeID;
+
+  var locales = getLocales();
+  var selectedLocale = locales.find((locale) => locale.id === localeID);
+  if (selectedLocale) {
+    storeSelectedLocaleName(selectedLocale.code);
+    articleData.localeName = selectedLocale.code;
+  }
 
   var headline = getHeadline();
   if (typeof(headline) === "undefined" || headline === null || headline.trim() === "") {
     headline = getDocumentName();
     storeHeadline(headline);
   }
+  articleData.headline = headline;
 
   var formattedElements = formatElements();
-
-  var articleData = {};
-  articleData.id = articleID;
-  articleData.headline = headline;
   articleData.formattedElements = formattedElements;
-  articleData.localeID = localeID;
+
   articleData.published = false;
   articleData.authors = getAuthors();
   articleData.tags = getTags();

--- a/Code.js
+++ b/Code.js
@@ -1504,6 +1504,7 @@ function createArticleFrom(articleData) {
   var title = articleData.headline;
   var elements = articleData.formattedElements;
   var localeID = articleData.localeID;
+  var localeName = articleData.localeName;
   var articleAuthors = articleData.authors;
   var articleTags = articleData.tags; // only id
   var categoryID = articleData.categoryID;
@@ -1593,8 +1594,29 @@ function createArticleFrom(articleData) {
   var twitterTitleValues = i18nSetValues(seoData.twitterTitle, localeID, previousArticleData.twitterTitle.values);
   var twitterDescriptionValues = i18nSetValues(seoData.twitterDescription, localeID, previousArticleData.twitterDescription.values);
 
+  var updatedGoogleDocs = {};
+  if (previousArticleData && previousArticleData.googleDocs) {
+    var priorGoogleDocs = previousArticleData.googleDocs;
+    Logger.log("found prior googleDocs:", priorGoogleDocs);
+
+    var priorGoogleDocsParsed = JSON.parse(priorGoogleDocs);
+    if (priorGoogleDocsParsed[localeName]) {
+      Logger.log("found prior googleDocs for locale!", localeName, priorGoogleDocsParsed[localeName])
+    } else {
+      Logger.log("NO prior googleDocs for locale:", localeName)
+    }
+    priorGoogleDocsParsed[localeName] = articleData.documentID;
+    updatedGoogleDocs = priorGoogleDocsParsed;
+  } else {
+    updatedGoogleDocs[localeName] = articleData.documentID;
+    Logger.log("no prior article data, creating google docs info now:", updatedGoogleDocs)
+  }
+  Logger.log("updatedGoogleDocs:", updatedGoogleDocs);
+
+
   var data = {
     availableLocales: availableLocaleNames,
+    googleDocs: JSON.stringify(updatedGoogleDocs),
     published: published,
     category: categoryID,
     customByline: customByline,
@@ -1920,7 +1942,7 @@ function createArticle(articleData) {
 
   storeAvailableLocales(localeName);
 
-  var googleDocs = {}
+  var googleDocs = {};
   googleDocs[localeName] = articleData.documentID;
 
   var categoryName = getNameForCategoryID(categories, categoryID);
@@ -2882,6 +2904,8 @@ function getArticle(id) {
           }
           data {
             id
+            googleDocs
+            availableLocales
             firstPublishedOn
             lastPublishedOn
             headline {

--- a/Code.js
+++ b/Code.js
@@ -953,7 +953,8 @@ function handlePreview(formObject) {
 function getCurrentDocContents(formObject, publishFlag) {
   var documentType = getDocumentType();
 
-  var title = getHeadline();
+  var title = formObject['article-headline'];
+  storeHeadline(title);
   var formattedElements = formatElements();
 
   storeSEO({
@@ -983,7 +984,7 @@ function getCurrentDocContents(formObject, publishFlag) {
   if (selectedLocale === null || selectedLocale === undefined) {
     selectedLocale = getLocaleID();
   }
-  // if no locale was settled, refuse to try publishing the article
+  // if no locale was selected, refuse to try publishing the article
   if (selectedLocale === null || selectedLocale === undefined) {
     Logger.log("FAILED FINDING A LOCALE FOR THIS ARTICLE, ERROR");
     returnValue.status = "error";
@@ -991,6 +992,8 @@ function getCurrentDocContents(formObject, publishFlag) {
     return returnValue;
   }
 
+  // finally, be sure to store the selected locale ID before proceeding
+  storeLocaleID(selectedLocale);
   articleData.localeID = selectedLocale;
   articleData.published = publishFlag;
   articleData.categoryID = formObject['article-category'];

--- a/Code.js
+++ b/Code.js
@@ -1909,6 +1909,8 @@ function createArticle(articleData) {
     storeCategories(categories);
   }
 
+  storeAvailableLocales(localeName);
+
   var categoryName = getNameForCategoryID(categories, categoryID);
 
   var slug = getArticleSlug();

--- a/Code.js
+++ b/Code.js
@@ -699,10 +699,12 @@ function getArticleMeta() {
 
   var locales = getLocales();
   var selectedLocaleID = getLocaleID();
-  var selectedLocale = locales.find((locale) => locale.id === selectedLocaleID);
   var selectedLocaleName = null;
-  if (selectedLocale) {
-    selectedLocaleName = selectedLocale.code;
+  if (selectedLocaleID) {
+    var selectedLocale = locales.find((locale) => locale.id === selectedLocaleID);
+    if (selectedLocale) {
+      selectedLocaleName = selectedLocale.code;
+    }
   }
 
   var articleID = getArticleID();
@@ -1550,7 +1552,6 @@ function createArticleFrom(articleData) {
 
   // grab current article contents
   var previousArticleData = getArticle(versionID);
-  Logger.log("found article data:", previousArticleData);
 
   // then merge in the new content with previous locale data
   var headlineValues = i18nSetValues(title, localeID, previousArticleData.headline.values);
@@ -1586,6 +1587,7 @@ function createArticleFrom(articleData) {
     data.lastPublishedOn = publishingInfo.lastPublishedOn;
   }
 
+  Logger.log(JSON.stringify(data))
   // Logger.log("tagIDs: ", tagIDs);
   var variables = {
     id: versionID,
@@ -1599,6 +1601,7 @@ function createArticleFrom(articleData) {
         updateArticle(id: $id, data: $data) {
           error {
             code
+            data
             message
           }
           data {
@@ -1651,11 +1654,8 @@ function createArticleFrom(articleData) {
     CONTENT_API,
     options
   );
-  Logger.log("createArticleFrom response:", response);
   var responseText = response.getContentText();
   var responseData = JSON.parse(responseText);
-  // Logger.log("createArticleFrom responseData:", responseData);
-  Logger.log("END createArticleFrom:", responseData.data.articles.updateArticle.searchTitle);
 
   var returnValue = {
     status: "",
@@ -1668,6 +1668,7 @@ function createArticleFrom(articleData) {
   } else if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.updateArticle && responseData.data.articles.updateArticle.error !== null) {
     returnValue.status = "error";
     returnValue.message = responseData.data.articles.updateArticle.error;
+    Logger.log(JSON.stringify(returnValue.message));
   }
 
   return returnValue;
@@ -3201,6 +3202,10 @@ function associateArticle(formObject) {
 }
 
 function i18nSetValues(text, localeID, previousValues) {
+  // don't bother appending blank values for this locale
+  if (text === null || text === undefined || text === "") {
+    return previousValues;
+  }
   var newValues;
   if (previousValues && previousValues.length > 0) {
     var foundIt = false;

--- a/Code.js
+++ b/Code.js
@@ -3210,16 +3210,10 @@ function handleSearch(formObject) {
 .* called from ManualPage.html, this function associates the google doc with the selected article
 .*/
 function associateArticle(formObject) {
-  
-  // var scriptConfig = getScriptConfig();
-  // var ACCESS_TOKEN = scriptConfig['ACCESS_TOKEN'];
-  // var CONTENT_API = scriptConfig['CONTENT_API'];
-
   Logger.log("associateArticle:", formObject);
 
   var articleID  = formObject["article-id"];
   var localeID  = formObject["article-locale"];
-  // var documentType = getDocumentType();
 
   var headline = getHeadline();
   if (typeof(headline) === "undefined" || headline === null || headline.trim() === "") {
@@ -3235,7 +3229,10 @@ function associateArticle(formObject) {
   articleData.formattedElements = formattedElements;
   articleData.localeID = localeID;
   articleData.published = false;
+  articleData.authors = getAuthors();
+  articleData.tags = getTags();
 
+  Logger.log("articleData:", articleData);
   var responseData = createArticleFrom(articleData);
   Logger.log("response:", responseData);
 

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -225,18 +225,25 @@
          google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessMeta).getArticleMeta();
       }
 
+      function deletePage() {
+        if (window.confirm("Are you sure you want to delete this page?")) { 
+          var loadingDiv = document.getElementById('loading');
+          loadingDiv.innerHTML = "Deleting page...";
+          loadingDiv.style.display = "block";
+
+          google.script.run.withFailureHandler(onFailureDelete).withSuccessHandler(onSuccessDelete).deletePage();
+        }
+      }
       function deleteArticle() {
         if (window.confirm("Are you sure you want to delete this article?")) { 
-          console.log("proceeding with delete")
           var loadingDiv = document.getElementById('loading');
           loadingDiv.innerHTML = "Deleting article...";
           loadingDiv.style.display = "block";
 
           google.script.run.withFailureHandler(onFailureDelete).withSuccessHandler(onSuccessDelete).deleteArticle();
-        } else {
-          console.log("cancelled delete")
         }
       }
+
       function onSuccessDelete(contents) {
         hideConfigForm();
 
@@ -392,6 +399,7 @@
       </div>
       <div class="block">
         <button class="create" onclick="deleteArticle()">Delete Article</button>
+        <button class="create" onclick="deletePage()">Delete Page</button>
       </div>
     </div>
 

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -63,6 +63,10 @@
       }
 
       function onSuccess(contents) {
+        if (contents && contents.status && contents.status === "error") {
+          onFailure(contents);
+          return;
+        }
         hideConfigForm();
         var div = document.getElementById('loading');
         div.style.display = 'block';
@@ -78,10 +82,16 @@
       }
 
       function onFailure(error) {
-        var loadingDiv = document.getElementById('loading');
         console.log(error);
+        var loadingDiv = document.getElementById('loading');
         loadingDiv.style.display = "block";
-        loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + "</p>";
+        var message = "An error occurred: ";
+        if (error && error.message) {
+          message += JSON.stringify(error.message);
+        } else {
+          message += "unknown";
+        }
+        loadingDiv.innerHTML = "<p class='error'>" + message + "</p>";
       }
 
       function displayConfigFormMessage(text) {
@@ -192,7 +202,7 @@
       }
       
       function handleAssociate(formObject) {
-        if (window.confirm("Are you sure you want to do this? It will overwrite the article with this document's contents, and there's no undo!")) { 
+        if (window.confirm("Are you sure you want to do this? Any content in the linked article in this locale will be replaced by your document!")) { 
           hideLoading();
           console.log("associating article...", formObject);
           // var articleId = $(this).data('article-id');

--- a/Page.html
+++ b/Page.html
@@ -20,6 +20,7 @@
       }
 
       function onSuccess(contents) {
+        console.log("onSuccess response:", contents);
         // first, switch the "published" text to say "No"
         // because the headline and/or byline has likely changed.
         setPublishedFlag(false);
@@ -27,7 +28,11 @@
         configDiv.style.display = 'none';
         var div = document.getElementById('loading');
         div.style.display = 'block';
-        div.innerHTML = '<p style="color: #48C774;">' + contents + "</p>";
+        if (contents && contents.status && contents.status === "error") {
+          div.innerHTML = "<p class='error'>An error occurred: " + contents.message + '</p>';
+        } else {
+          div.innerHTML = '<p style="color: #48C774;">' + contents.message + "</p>";
+        }
         handleMetaPreserveLoading();
       }
       
@@ -38,6 +43,7 @@
       }
 
       function onFailure(error) {
+        console.log("onFailure contents:", error);
         var loadingDiv = document.getElementById('loading');
         console.log(error);
         loadingDiv.style.display = "block";
@@ -58,28 +64,37 @@
 
         if (data.documentType === 'article') {
           var articleLocaleSelect = document.getElementById('article-locale');
+          if (data.localeName !== null && data.localeName !== undefined) {
+            articleLocaleSelect.style.display = 'none';
+            articleLocaleSelect.style.visibility = 'hidden';
 
-          data.locales.forEach(locale => {
-            // first check if this option already exists; don't add dupes!
-            var selectorString = "#article-locale option[value='" + locale.id + "']";
-            if ( $(selectorString).length <= 0 ) {
-              var option = document.createElement("option");
-              if (locale.code) {
-                option.text = locale.code;
-              } else {
-                option.text = "(BUG) unknown locale";
-              }
-              // mark this locale as selected if it's the article's locale ID -or- is the default locale
-              if (data.locale !== null && data.locale === locale.id) {
-                option.selected = true;
-              } else if (locale.default) {
-                option.selected = true;
-              }
-              option.value = locale.id;
+            var selectedLocaleDiv = document.getElementById('selected-locale');
+            selectedLocaleDiv.innerHTML = "<b>" + data.localeName + "</b>";
 
-              articleLocaleSelect.add(option);
-            }
-          })
+          } else {
+
+            data.locales.forEach(locale => {
+              // first check if this option already exists; don't add dupes!
+              var selectorString = "#article-locale option[value='" + locale.id + "']";
+              if ( $(selectorString).length <= 0 ) {
+                var option = document.createElement("option");
+                if (locale.code) {
+                  option.text = locale.code;
+                } else {
+                  option.text = "(BUG) unknown locale";
+                }
+                // mark this locale as selected if it's the article's locale ID -or- is the default locale
+                if (data.localeID !== null && data.localeID === locale.id) {
+                  option.selected = true;
+                } else if (locale.default) {
+                  option.selected = true;
+                }
+                option.value = locale.id;
+
+                articleLocaleSelect.add(option);
+              }
+            })
+          }
 
           var articleCategorySelect = document.getElementById('article-category');
           var categoriesSorted = data.categories.sort(function (a, b) {
@@ -455,8 +470,9 @@
 
           <div class="block form-group">
             <label for="article-locale">
-              <b>Select locale</b>
+              <b>Locale</b>
             </label>
+            <div id="selected-locale"></div>
             <select style="width: 100%" id="article-locale" name="article-locale"></select>
           </div>
 

--- a/Page.html
+++ b/Page.html
@@ -217,6 +217,12 @@
         var slugDiv = document.getElementById('slug');
         slugDiv.innerHTML = data.slug;
 
+        var availableLocalesDiv = document.getElementById('available-locales');
+        availableLocalesDiv.innerHTML = data.availableLocales;
+
+        var sitewideLocalesDiv = document.getElementById('sitewide-locales');
+        sitewideLocalesDiv.innerHTML = data.locales.map(locale=>locale.code).join(" | ");
+
         if (data.documentType === 'article') {
           $('#article-authors').select2({
             width: 'resolve',
@@ -560,6 +566,9 @@
             <b>Article slug:</b> <span id="slug"></span>
           </p>
           <p>
+            <b>Available locales:</b> <span id="available-locales"></span>
+          </p>
+          <p>
             <b>Revision ID:</b> <span id="revision-id"></span>
           </p>
           <p>
@@ -570,6 +579,9 @@
           </p>
           <p>
             <b>Last published:</b> <span id="last-published"></span>
+          </p>
+          <p>
+            <b>Site-wide Locales:</b> <span id="sitewide-locales"></span>
           </p>
         </div>
       </div>

--- a/Page.html
+++ b/Page.html
@@ -69,8 +69,10 @@
               } else {
                 option.text = "(BUG) unknown locale";
               }
-              // todo: check if this is the previously selected locale, fallback to default
-              if (locale.default) {
+              // mark this locale as selected if it's the article's locale ID -or- is the default locale
+              if (data.locale !== null && data.locale === locale.id) {
+                option.selected = true;
+              } else if (locale.default) {
                 option.selected = true;
               }
               option.value = locale.id;

--- a/Page.html
+++ b/Page.html
@@ -57,6 +57,28 @@
         }
 
         if (data.documentType === 'article') {
+          var articleLocaleSelect = document.getElementById('article-locale');
+
+          data.locales.forEach(locale => {
+            // first check if this option already exists; don't add dupes!
+            var selectorString = "#article-locale option[value='" + locale.id + "']";
+            if ( $(selectorString).length <= 0 ) {
+              var option = document.createElement("option");
+              if (locale.code) {
+                option.text = locale.code;
+              } else {
+                option.text = "(BUG) unknown locale";
+              }
+              // todo: check if this is the previously selected locale, fallback to default
+              if (locale.default) {
+                option.selected = true;
+              }
+              option.value = locale.id;
+
+              articleLocaleSelect.add(option);
+            }
+          })
+
           var articleCategorySelect = document.getElementById('article-category');
           var categoriesSorted = data.categories.sort(function (a, b) {
             let comparison = 0;
@@ -427,6 +449,13 @@
           <div class="block">
             <input type="submit" name="preview" id="preview-button-top" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="save-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>
+          </div>
+
+          <div class="block form-group">
+            <label for="article-locale">
+              <b>Select locale</b>
+            </label>
+            <select style="width: 100%" id="article-locale" name="article-locale"></select>
           </div>
 
           <div class="block form-group">

--- a/Page.html
+++ b/Page.html
@@ -62,40 +62,40 @@
           };
         }
 
-        if (data.documentType === 'article') {
-          var articleLocaleSelect = document.getElementById('article-locale');
-          if (data.localeName !== null && data.localeName !== undefined) {
-            articleLocaleSelect.style.display = 'none';
-            articleLocaleSelect.style.visibility = 'hidden';
+        var articleLocaleSelect = document.getElementById('article-locale');
+        if (data.localeName !== null && data.localeName !== undefined) {
+          articleLocaleSelect.style.display = 'none';
+          articleLocaleSelect.style.visibility = 'hidden';
 
-            var selectedLocaleDiv = document.getElementById('selected-locale');
-            selectedLocaleDiv.innerHTML = "<b>" + data.localeName + "</b>";
+          var selectedLocaleDiv = document.getElementById('selected-locale');
+          selectedLocaleDiv.innerHTML = "<b>" + data.localeName + "</b>";
 
-          } else {
+        } else {
 
-            data.locales.forEach(locale => {
-              // first check if this option already exists; don't add dupes!
-              var selectorString = "#article-locale option[value='" + locale.id + "']";
-              if ( $(selectorString).length <= 0 ) {
-                var option = document.createElement("option");
-                if (locale.code) {
-                  option.text = locale.code;
-                } else {
-                  option.text = "(BUG) unknown locale";
-                }
-                // mark this locale as selected if it's the article's locale ID -or- is the default locale
-                if (data.localeID !== null && data.localeID === locale.id) {
-                  option.selected = true;
-                } else if (locale.default) {
-                  option.selected = true;
-                }
-                option.value = locale.id;
-
-                articleLocaleSelect.add(option);
+          data.locales.forEach(locale => {
+            // first check if this option already exists; don't add dupes!
+            var selectorString = "#article-locale option[value='" + locale.id + "']";
+            if ( $(selectorString).length <= 0 ) {
+              var option = document.createElement("option");
+              if (locale.code) {
+                option.text = locale.code;
+              } else {
+                option.text = "(BUG) unknown locale";
               }
-            })
-          }
+              // mark this locale as selected if it's the article's locale ID -or- is the default locale
+              if (data.localeID !== null && data.localeID === locale.id) {
+                option.selected = true;
+              } else if (locale.default) {
+                option.selected = true;
+              }
+              option.value = locale.id;
 
+              articleLocaleSelect.add(option);
+            }
+          })
+        }
+
+        if (data.documentType === 'article') {
           var articleCategorySelect = document.getElementById('article-category');
           var categoriesSorted = data.categories.sort(function (a, b) {
             let comparison = 0;


### PR DESCRIPTION
Issue #127 

This PR handles the data end of associating google docs with an article in specific locales and will allow us to list edit links in the sidebar for an article in its available translations. These changes store a field as JSON data called `googleDocs` on the article in webiny as mentioned below.

To test this, I verified each scenario by running my list articles query (I'm lazy) in [the graphql playground](https://d27ff8ul81gmi2.cloudfront.net/graphql); I just made sure to include `id`, `googleDocs` and `headline` so I knew which one I was looking at.

* [x] when creating an article, store the current document ID as the value, and the current locale code as the key: `{googleDocs={"en-US":"1Hc7Mz4AyN18IUcbrZXUEDUsbnJCuoArLBVT-_2kwbzQ"}`
* [x] when updating an article, merge the current `localeID: documentID` in with the existing value of `googleDocs`
* [x] when linking or associating a doc with an existing article in a new locale, properly merge the new locale & document IDs into the existing `googleDocs` field: `"googleDocs":"{\"en-US\":\"1Hc7Mz4AyN18IUcbrZXUEDUsbnJCuoArLBVT-_2kwbzQ\",\"es\":\"1FBH3eQ-2f706RoEuW9sLqJwChUAeLMR74ilC3hdN6yQ\"}"`