### PR TITLE
Feature/edit links for translations

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -637,6 +637,8 @@ function getArticleDataByID(articleID) {
             published
             firstPublishedOn
             lastPublishedOn
+            googleDocs
+            availableLocales
             authors {
               id
               name
@@ -770,6 +772,7 @@ function getArticleMeta() {
     Logger.log("SLUG FOUND:", slug);
   }
 
+  var googleDocsInfo = {};
   if (articleID !== null && articleID !== undefined) {
     var latestArticle = getArticleDataByID(articleID);
 
@@ -779,6 +782,15 @@ function getArticleMeta() {
       if (latestArticleData.published !== undefined) {
         storeIsPublished(latestArticleData.published);
       }
+
+      if (latestArticleData.googleDocs) {
+        try {
+          googleDocsInfo = JSON.parse(latestArticleData.googleDocs);
+        } catch(e) {
+          Logger.log("error parsing googleDocs json:", e);
+        }
+      }
+
       if (latestArticleData.headline && latestArticleData.headline.values && latestArticleData.headline.values[0].value) {
         storeHeadline(latestArticleData.headline.values[0].value);
       }
@@ -786,6 +798,9 @@ function getArticleMeta() {
         storeCustomByline(latestArticleData.customByline);
       }
 
+      if (latestArticleData.availableLocales) {
+        storeAvailableLocales(latestArticleData.availableLocales);
+      }
       if (latestArticleData.authors) {
         latestArticleData.authors.forEach(author => {
             authorSlugs.push(author.slug);
@@ -937,6 +952,7 @@ function getArticleMeta() {
     awsSecretKey: awsSecretKey,
     awsBucket: awsBucket,
     availableLocales: availableLocales,
+    googleDocs: googleDocsInfo,
     categories: categories,
     categoryID: categoryID,
     categoryName: categoryName,

--- a/Page.html
+++ b/Page.html
@@ -275,6 +275,17 @@
             lastPubDiv.innerHTML = localisedDate;
           }
         }
+
+        if (data.googleDocs !== null) {
+          var editDiv = document.getElementById('edit-links');
+          var links = [];
+          $.each( data.googleDocs, function( locale, docID ) {
+            if (locale !== data.localeName) {
+              links.push("<li><a target='_blank' href='https://docs.google.com/document/d/" + docID + "/edit'>" + locale + "</a></li>")
+            }
+          });
+          editDiv.innerHTML = "<p><b>Edit in other languages:</b></p><ul>" + links.join("")+ "</ul>";
+        }
       }
 
       function onSuccessMeta(data) {
@@ -584,6 +595,9 @@
             <b>Site-wide Locales:</b> <span id="sitewide-locales"></span>
           </p>
         </div>
+      </div>
+
+      <div id="edit-links" class="block">
       </div>
 
       <div id="output" class="block"></div>


### PR DESCRIPTION
Issue #128 part I

This PR uses the data in the article's `googleDocs` json field to include links to edit the content in another language. The article must already have a document in another locale for these links to work.

To test, try opening [this document I was using to develop this against](https://docs.google.com/document/d/1Hc7Mz4AyN18IUcbrZXUEDUsbnJCuoArLBVT-_2kwbzQ/edit?addon_dry_run=AAnXSK9m-Fq4XDbKWcB8mUKMI-4cWhsyzd6zQ9FY4xrSn7wp0f_2y9c0_kIQpUCljGxDjwYflQoziWLlstE0PwB6drFQUZfXm9FcygJC3AoEar6DPWOrnNyt6ibLLT43wlw_AMyD4e3i#heading=h.ffwjnjx0yush). Warning the data is all contrived, all versions are english. Upon opening the sidebar, you see a link to edit the article in spanish (`es`). Clicking the link should open another google doc in a new tab/window (you can't replace the current one, and I figure we probably don't want to do that anyway). 

Next up: adding links to create other language versions of the document that do not yet exist.