### PR TITLE
Create links for translations

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -637,6 +637,8 @@ function getArticleDataByID(articleID) {
             published
             firstPublishedOn
             lastPublishedOn
+            googleDocs
+            availableLocales
             authors {
               id
               name
@@ -770,6 +772,7 @@ function getArticleMeta() {
     Logger.log("SLUG FOUND:", slug);
   }
 
+  var googleDocsInfo = {};
   if (articleID !== null && articleID !== undefined) {
     var latestArticle = getArticleDataByID(articleID);
 
@@ -779,6 +782,15 @@ function getArticleMeta() {
       if (latestArticleData.published !== undefined) {
         storeIsPublished(latestArticleData.published);
       }
+
+      if (latestArticleData.googleDocs) {
+        try {
+          googleDocsInfo = JSON.parse(latestArticleData.googleDocs);
+        } catch(e) {
+          Logger.log("error parsing googleDocs json:", e);
+        }
+      }
+
       if (latestArticleData.headline && latestArticleData.headline.values && latestArticleData.headline.values[0].value) {
         storeHeadline(latestArticleData.headline.values[0].value);
       }
@@ -786,6 +798,9 @@ function getArticleMeta() {
         storeCustomByline(latestArticleData.customByline);
       }
 
+      if (latestArticleData.availableLocales) {
+        storeAvailableLocales(latestArticleData.availableLocales);
+      }
       if (latestArticleData.authors) {
         latestArticleData.authors.forEach(author => {
             authorSlugs.push(author.slug);
@@ -937,6 +952,7 @@ function getArticleMeta() {
     awsSecretKey: awsSecretKey,
     awsBucket: awsBucket,
     availableLocales: availableLocales,
+    googleDocs: googleDocsInfo,
     categories: categories,
     categoryID: categoryID,
     categoryName: categoryName,

--- a/Code.js
+++ b/Code.js
@@ -1675,9 +1675,14 @@ function createArticleFrom(articleData) {
   }
   Logger.log("updatedGoogleDocs:", updatedGoogleDocs);
 
+  var documentIDsForArticle = Object.values(updatedGoogleDocs);
+  var documentIDsForArticleString = documentIDsForArticle.join(' ');
+  Logger.log("storing docIDs:", documentIDsForArticleString)
+
   var data = {
     availableLocales: availableLocaleNames,
     googleDocs: JSON.stringify(updatedGoogleDocs),
+    docIDs: documentIDsForArticleString,
     published: published,
     category: categoryID,
     customByline: customByline,
@@ -3442,6 +3447,7 @@ function createNewDoc(newLocale) {
   // setup the articleData
   var articleData = {};
 
+  articleData.documentID = docID;
   articleData.id = parentArticleID;
   articleData.headline = newHeadline;
   articleData.formattedElements = formatElements();

--- a/Code.js
+++ b/Code.js
@@ -810,9 +810,9 @@ function getArticleByDocumentID(documentID) {
 
   var responseText = response.getContentText();
   var responseData = JSON.parse(responseText);
-  if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.listArticles && responseData.data.articles.listArticles.error === null && responseData.data.articles.listArticles.data) {
-    returnValue.status = "success";
+  if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.listArticles && responseData.data.articles.listArticles.error === null && responseData.data.articles.listArticles.data && responseData.data.articles.listArticles.data[0] !== undefined) {
     var firstArticleData = responseData.data.articles.listArticles.data[0];
+    returnValue.status = "success";
     returnValue.id = firstArticleData.id;
     returnValue.data = firstArticleData;
     returnValue.message = "Retrieved article with ID " +  returnValue.id;
@@ -824,7 +824,7 @@ function getArticleByDocumentID(documentID) {
     } else if (responseData.data && responseData.data.articles && responseData.data.articles.listArticles && responseData.data.articles.listArticles.error && responseData.data.articles.listArticles.error !== null) {
       returnValue.message = responseData.data.articles.listArticles.error;
     } else {
-      returnValue.message = "Something else went wrong"
+      returnValue.message = "Couldn't find an article for this Google Doc."
     }
   }
   return returnValue;

--- a/Code.js
+++ b/Code.js
@@ -1706,7 +1706,6 @@ function createArticleFrom(articleData) {
     data.lastPublishedOn = publishingInfo.lastPublishedOn;
   }
 
-  Logger.log("createArticleFrom data:", JSON.stringify(data))
   // Logger.log("tagIDs: ", tagIDs);
   var variables = {
     id: versionID,
@@ -3402,7 +3401,6 @@ function i18nSetValues(text, localeID, previousValues) {
       if (obj.locale === localeID) {
         foundIt = true;
         obj.value = text;
-        Logger.log("found prior in locale", obj)
       }
       return obj;
     });
@@ -3413,7 +3411,7 @@ function i18nSetValues(text, localeID, previousValues) {
         value: text,
         locale: localeID
       });
-      Logger.log("NO prior in locale, appended", newValues.length, newValues);
+      Logger.log("NO prior in locale, appended", newValues.length, "values");
     }
   // case handling when there was NO previous value set in any language
   } else {
@@ -3435,14 +3433,19 @@ function createNewDoc(newLocale) {
   var currentHeadline = getHeadline();
   var newHeadline = currentHeadline + " (" + localeName + ")";
 
-  var doc = DocumentApp.create(newHeadline);
-  Logger.log("created new doc:", doc)
-
-  var docID = doc.getId();
-  Logger.log("* new docID:", docID)
-
   var parentDocID = DocumentApp.getActiveDocument().getId();
   var parentArticleID = getArticleID();
+
+  var docID;
+  var driveFile = DriveApp.getFileById(parentDocID);
+  var newFile = driveFile.makeCopy(newHeadline);
+  Logger.log("created new doc:", newFile);
+  if (newFile) {
+    docID = newFile.getId();
+  } else {
+    Logger.log("failed creating new file via DriveApp")
+    return null;
+  }
 
   // setup the articleData
   var articleData = {};

--- a/Page.html
+++ b/Page.html
@@ -19,6 +19,15 @@
         scriptForm.style.display = "none";
       }
 
+      function onSuccessNewDoc(contents) {
+        console.log("onSuccessNewDoc response:", contents);
+        var configDiv = document.getElementById('config');
+        configDiv.style.display = 'none';
+        var div = document.getElementById('loading');
+        div.style.display = 'block';
+        div.innerHTML = "<a href='https://docs.google.com/document/d/" + contents.docID + "/edit?parentID=" + contents.parentID + "' target='_blank'>Open new doc</a>";
+      }
+
       function onSuccess(contents) {
         console.log("onSuccess response:", contents);
         // first, switch the "published" text to say "No"
@@ -279,11 +288,28 @@
         if (data.googleDocs !== null) {
           var editDiv = document.getElementById('edit-links');
           var links = [];
+          var createLocales = data.locales.map(locale=>locale.code);
+          var existingLocales = Object.keys(data.googleDocs);
+
+          console.log("data.googleDocs:", data.googleDocs);
+          console.log("Object.keys(data.googleDocs):", Object.keys(data.googleDocs));
+
+          createLocales = createLocales.filter(function(item) {
+            return !existingLocales.includes(item); 
+          })
+
+          console.log("Locales for create links:", createLocales);
+
           $.each( data.googleDocs, function( locale, docID ) {
             if (locale !== data.localeName) {
               links.push("<li><a target='_blank' href='https://docs.google.com/document/d/" + docID + "/edit'>" + locale + "</a></li>")
             }
           });
+
+          $.each(createLocales, function( index, locale ) {
+            links.push("<li><a onclick='createNewDoc(\"" + locale + "\");'>" + locale + " (new)</a></li>");
+          });
+
           editDiv.innerHTML = "<p><b>Edit in other languages:</b></p><ul>" + links.join("")+ "</ul>";
         }
       }
@@ -321,6 +347,9 @@
         configDiv.innerHTML = "<p class='error'>An error occurred. This may be due to being logged into multiple google accounts at once. Try opening this doc in an incognito window.</p>";
       }
 
+      function createNewDoc(locale) {
+         google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessNewDoc).createNewDoc(locale);
+      }
       function handleScriptConfig() {
          google.script.run.withFailureHandler(onFailureConfig).withSuccessHandler(onSuccessConfig).getScriptConfig();
       }
@@ -375,6 +404,8 @@
         handleScriptConfig();
 
         handleMeta();
+
+
       });
 
       function displayConfigFormMessage(text) {

--- a/Page.html
+++ b/Page.html
@@ -275,6 +275,17 @@
             lastPubDiv.innerHTML = localisedDate;
           }
         }
+
+        if (data.googleDocs !== null) {
+          var editDiv = document.getElementById('edit-links');
+          var links = [];
+          $.each( data.googleDocs, function( locale, docID ) {
+            if (locale !== data.localeName) {
+              links.push("<li><a target='_blank' href='https://docs.google.com/document/d/" + docID + "/edit'>" + locale + "</a></li>")
+            }
+          });
+          editDiv.innerHTML = "<p><b>Edit in other languages:</b></p><ul>" + links.join("")+ "</ul>";
+        }
       }
 
       function onSuccessMeta(data) {
@@ -584,6 +595,9 @@
             <b>Site-wide Locales:</b> <span id="sitewide-locales"></span>
           </p>
         </div>
+      </div>
+
+      <div id="edit-links" class="block">
       </div>
 
       <div id="output" class="block"></div>

--- a/Page.html
+++ b/Page.html
@@ -285,7 +285,7 @@
           }
         }
 
-        if (data.googleDocs !== null) {
+        if (data.googleDocs !== null && data.googleDocs !== undefined) {
           var editDiv = document.getElementById('edit-links');
           var links = [];
           var createLocales = data.locales.map(locale=>locale.code);

--- a/appsscript.json
+++ b/appsscript.json
@@ -17,7 +17,8 @@
     "https://www.googleapis.com/auth/script.external_request", 
     "https://www.googleapis.com/auth/script.container.ui", 
     "https://www.googleapis.com/auth/documents.currentonly",
-    "https://www.googleapis.com/auth/drive.readonly"
+    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/drive"
   ],
   "runtimeVersion": "V8"
 }


### PR DESCRIPTION
Issue #129 

This one was a lot more complicated than adding the "edit" links for existing translations of an article because we have to duplicate the google doc and somehow associate this new doc with the same article in webiny... without being able to write to [the Google DocumentProperties Service](https://developers.google.com/apps-script/reference/properties/properties-service#getDocumentProperties()).

I think I've figured out a way, though, that isn't a crazy hack. I'm making this PR as ready for review, but I have a feeling we might have to go a couple rounds with bug fixes - sorry. This was tricky. I'm going to continue testing it as well in whatever scenarios I think of and try to break it.

**To test:**

* Use the test case "Version 45 - 'Article in Default Locale'"
* Opening that article's sidebar should show a link at the bottom "es (new)"
* Clicking that link results in a not great UX - to fix - but will create a new google doc behind the scenes & update webiny with knowledge of its existence
* A link should appear at the top of the sidebar (hence the UX comment) and clicking _that_ should open the newly created google doc
* The sidebar should work in the newly created google doc
* More details on the implementation below


Here's what happens when you click a new locale link:

1. Document is copied via Google Drive API - all contents are preserved including images
2. Document title has the new locale code appended
3. Link to open (horrible UX, I know, TBD) presented at top of sidebar, so scroll back up

And when you open the new doc & then the Publishing Tools sidebar:

1. Does this doc have an `articleID` stored in its properties? <if yes, proceed as usual>
2. If no, execute a query in webiny searching articles where `docIDs` field contains this google document ID
3. If article found, set the document property articleID, headline, localeID and localeName, then proceed as usual
4. The "as usual" path includes looking up the article by (webiny) ID for the latest data, so all other properties should be set from here.
5. Subsequent sidebar opens find the `articleID` property, so this should only happen once.
