### PR TITLE
Display either 'Delete Article' or 'Delete Page' button 

### DIFF
--- a/ManualPage.html
+++ b/ManualPage.html
@@ -229,6 +229,16 @@
         } else {
           loadingDiv.innerHTML = "<p>You can link this document to an existing article in Webiny to publish it to the web and mobile.</p>"
         }
+
+        var deleteArticleButton = document.getElementById("deleteArticleButton");
+        var deletePageButton = document.getElementById("deletePageButton");
+        if (data.documentType === "page") {
+          deleteArticleButton.style.display = "none";
+          deletePageButton.style.display = "block";
+        } else {
+          deletePageButton.style.display = "none";
+          deleteArticleButton.style.display = "block";
+        }
       }
 
       function handleMeta() {
@@ -408,8 +418,8 @@
         <button onclick="hideConfigForm();showSearchForm();">Hide Config</button>
       </div>
       <div class="block">
-        <button class="create" onclick="deleteArticle()">Delete Article</button>
-        <button class="create" onclick="deletePage()">Delete Page</button>
+        <button style="display: none;" id="deleteArticleButton" class="create" onclick="deleteArticle()">Delete Article</button>
+        <button style="display: none;" id="deletePageButton" class="create" onclick="deletePage()">Delete Page</button>
       </div>
     </div>
 


### PR DESCRIPTION
Issue #133 

Based on the document type (article or page) display only one of the delete buttons.

This is stored as Version 42 in the [script editor](https://script.google.com/a/newscatalyst.org/d/1ILURq69o3cYUy6k1n1X6HwxdMfl9xWNhILYuZxgLfeblb3IR15WCMZSj/edit). I did this to allow testing of PR #139 as "latest code".

To test this PR you'll have to make a new test case for version 42 on a doc; I tested by choosing the "about" document (a `page`) and any other article (I used "available locales" but it shouldn't matter). Then open the Admin Tools. You should see only one delete button.