### PR TITLE
Updating slug and fixing published status

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -272,17 +272,6 @@ function deleteArticleID() {
   deleteValue('ARTICLE_ID');
 }
 
-function storeLatestVersionPublished(isLatestVersionPublished) {
-  var documentProperties = PropertiesService.getDocumentProperties();
-  documentProperties.setProperty('LATEST_VERSION_PUBLISHED', isLatestVersionPublished);
-}
-
-function getLatestVersionPublished() {
-  var documentProperties = PropertiesService.getDocumentProperties();
-  var isLatestVersionPublished = documentProperties.getProperty('LATEST_VERSION_PUBLISHED');
-  return isLatestVersionPublished;
-}
-
 function getIsPublished() {
   return getValue('IS_PUBLISHED');
 }

--- a/Page.html
+++ b/Page.html
@@ -322,10 +322,14 @@
       }
 
       function setPublishedFlag(value) {
+        console.log("setPublishedFlag:", value, typeof(value));
         var isPublishedSpan = document.getElementById('is-published');
         var isPublishedYesNo = "no";
-        if (value) {
+        if (value === "true" || value) {
+          console.log("setting published to 'yes'")
           isPublishedYesNo = "yes";
+        } else {
+          console.log("value is not 'true' or true:", value)
         }
         isPublishedSpan.innerHTML = isPublishedYesNo;
       }

--- a/Page.html
+++ b/Page.html
@@ -325,8 +325,13 @@
         console.log("setPublishedFlag:", value, typeof(value));
         var isPublishedSpan = document.getElementById('is-published');
         var isPublishedYesNo = "no";
-        if (value === "true" || value) {
-          console.log("setting published to 'yes'")
+
+        if (value === "false") { 
+          console.log("value is the string 'false'");
+        }
+
+        if (value === "true" || value === true) { // 😭 javascript + JSON + boolean `published: true` or `published: false` as string
+          console.log("setting published to 'yes' because value is:", value);
           isPublishedYesNo = "yes";
         } else {
           console.log("value is not 'true' or true:", value)
@@ -359,10 +364,12 @@
       }
 
       function handleMetaPreserveLoading() {
+        console.log("call: handleMetaPreserveLoading");
          google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessMetaPreserveLoading).getArticleMeta();
       }
 
       function handleMeta() {
+        console.log("call: handleMeta");
          google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessMeta).getArticleMeta();
       }
 


### PR DESCRIPTION
Issues #141 and #143 

This PR fixes an issue with how the published flag was set on articles (answer: in a buggy way that wasn't consistent). It also adds a small code update that will regenerate the slug if the article is not published.

To test, use version 48 of the add-on which has this PR branch's code. I used [this document](https://docs.google.com/document/d/1cECfwOjNIX7YSOaDzlOv0JQNFnvDJbD17t6U7dYzdf4/edit?addon_dry_run=AAnXSK9clPOUwR7rbZFa-iekpLdZqE22bhOaqkcOf-f4YNsWFi7n4Xtuea8mC9LdeM0fD8FKGcIm53BaA84lXzcRPh9B05X3auuImyLwuaz-elExpiaXRqBKo68jrPCZA3V4BLwGzlWe_) and made sure to share it with you. 

Try this:

* open [a previously published doc like this one](https://docs.google.com/document/d/1cECfwOjNIX7YSOaDzlOv0JQNFnvDJbD17t6U7dYzdf4/edit?addon_dry_run=AAnXSK9clPOUwR7rbZFa-iekpLdZqE22bhOaqkcOf-f4YNsWFi7n4Xtuea8mC9LdeM0fD8FKGcIm53BaA84lXzcRPh9B05X3auuImyLwuaz-elExpiaXRqBKo68jrPCZA3V4BLwGzlWe)
* open Admin Tools
* Then click to 'Delete Article'
* Open Publishing Tools, sidebar 'published?' should be 'no'
* `Preview` the article, 'published?' should be 'no'
* change the headline, preview, slug should update (note: another UX to-do, you have to wait for the `getArticleMeta` call to run**)
* publish the article, 'published?' should be 'yes'
* change the headline, publish, slug should not change, published should stay as 'yes'


** just thought of something: to speed this up I should probably be returning the 'getArticleMeta' data from the `handlePreview` call in addition to the preview link messaging; I'll log a separate issue.