### PR TITLE
Adds a 'clear cache' button to Admin Tools

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -2496,6 +2496,21 @@ function deleteArticle() {
   }
 }
 
+/* This function clears out the google doc properties (articleID, anything stored) without expecting
+ * access to a webiny API
+ * it's useful if we have to relaunch the API and reconfigure the add-on in the event of an API failure
+ */
+function clearCache() {
+  storeIsPublished(false);
+  deleteArticleSlug();
+  deleteArticleID();
+  deletePublishingInfo();
+  deleteSEO();
+  deleteTags();
+  deleteCategories();
+  return "Cleared cache";
+}
+
 function publishPage() {
   Logger.log("START publishPage");
   var versionID = getArticleID();

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -9,6 +9,19 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
 
     <script>
+      function onSuccessClear(contents) {
+        // hideLoading();
+        var div = document.getElementById('loading');
+        div.style.display = 'block';
+        div.innerHTML = JSON.stringify(contents);
+      }
+      function onFailureClear(contents) {
+        // hideLoading();
+        var div = document.getElementById('loading');
+        div.style.display = 'block';
+        div.innerHTML = JSON.stringify(contents);
+      }
+
       function onSuccessSearch(contents) {
 
         console.log("contents:", contents);
@@ -201,6 +214,10 @@
         google.script.run.withSuccessHandler(onSuccessSearch).withFailureHandler(onFailure).handleSearch(formObject);
       }
       
+      function clearCache() {
+         google.script.run.withFailureHandler(onFailureClear).withSuccessHandler(onSuccessClear).clearCache();
+      }
+
       function handleAssociate(formObject) {
         if (window.confirm("Are you sure you want to do this? Any content in the linked article in this locale will be replaced by your document!")) { 
           hideLoading();
@@ -416,6 +433,7 @@
       <div class="block">
         <button onclick="getConfigAndDisplayForm()">Show Config</button>
         <button onclick="hideConfigForm();showSearchForm();">Hide Config</button>
+        <button onclick="clearCache()">Clear Cache</button>
       </div>
       <div class="block">
         <button style="display: none;" id="deleteArticleButton" class="create" onclick="deleteArticle()">Delete Article</button>


### PR DESCRIPTION
Clicking this button will wipe out data in the google property service - like articleID, isPublished, etc - w/o requiring or expecting access to a Webiny API. So it does everything that 'Delete Article' does except run the 'DeleteArticle' mutation in webiny.