### PR TITLE
Ensure published dates are set on article create and update

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1810,6 +1810,10 @@ function createArticleFrom(articleData) {
   var customByline = getCustomByline();
 
   var publishingInfo = getPublishingInfo();
+  if (publishingInfo.firstPublishedOn === null || publishingInfo.firstPublishedOn === undefined) {
+    publishingInfo.firstPublishedOn = generatePublishDate();
+  }
+  publishingInfo.lastPublishedOn = generatePublishDate();
 
   var seoData = getSEO();
 
@@ -1946,6 +1950,7 @@ function createArticleFrom(articleData) {
 
   // only update or set these if we're publishing the article
   if (published) {
+    Logger.log("createArticleFrom firstPublishedOn:", publishingInfo.firstPublishedOn)
     data.firstPublishedOn = publishingInfo.firstPublishedOn;
     data.lastPublishedOn = publishingInfo.lastPublishedOn;
   }
@@ -2242,6 +2247,11 @@ function createArticle(articleData) {
   var customByline = getCustomByline();
 
   var publishingInfo = getPublishingInfo();
+  if (publishingInfo.firstPublishedOn === null || publishingInfo.firstPublishedOn === undefined) {
+    publishingInfo.firstPublishedOn = generatePublishDate();
+  }
+  publishingInfo.lastPublishedOn = generatePublishDate();
+
   var seoData = getSEO();
 
   var categories = getCategories();


### PR DESCRIPTION
https://github.com/news-catalyst/next-tinynewsdemo/issues/237

After republishing the "Franny Lou’s Porch starts a GoFundMe to buy their building" article with this code (script editor -> test as latest code) the published date appears correctly.

<img width="757" alt="Screen Shot 2020-12-23 at 1 29 49 pm" src="https://user-images.githubusercontent.com/3397/102952343-109f9d80-4523-11eb-806d-60cf77c59fbf.png">
