### PR TITLE
Updated & simplified sidebar action buttons

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1210,14 +1210,44 @@ function getArticleMeta() {
 }
 /**
  * 
- * Saves the article as a draft, then publishes
+ * Sets article as 'published: true'
  * @param {} formObject 
  */
 function handlePublish(formObject) {
   Logger.log("START handlePublish:", formObject);
+
+  var response = publishArticle()
+  Logger.log("handlePublish response:", response);
+  var metadata = getArticleMeta();
+  response.data = metadata;
+  return response;
+}
+
+/**
+ * 
+ * Sets article as 'published: false'
+ * @param {} formObject 
+ */
+function handleUnpublish(formObject) {
+  Logger.log("START handleUnpublish:", formObject);
+
+  var response = unpublishArticle()
+  Logger.log("handleUnpublish response:", response);
+  var metadata = getArticleMeta();
+  response.data = metadata;
+  return response;
+}
+
+/**
+ * 
+ * Saves the article as a draft
+ * @param {} formObject 
+ */
+function handleSave(formObject) {
+  Logger.log("START handleSave:", formObject);
   // save the article - pass publishFlag as true
-  var response = getCurrentDocContents(formObject, true);
-  Logger.log("END handlePublish: ", response)
+  var response = getCurrentDocContents(formObject, false);
+  Logger.log("END handleSave: ", response)
 
   var metadata = getArticleMeta();
   response.data = metadata;
@@ -2708,14 +2738,21 @@ function publishArticle() {
 
   // TODO update latestVersionPublished flag
 
+  var returnValue = {
+    status: "success",
+    message: ""
+  }
   Logger.log("END publishArticle");
   if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.publishArticle && responseData.data.articles.publishArticle.data) {
     storeIsPublished(true);
-    return "Published article at revision " + versionID;
+    returnValue.status = "success";
+    returnValue.message = "Published article at revision " + versionID;
   } else {
     storeIsPublished(false);
-    return responseData.data.articles.publishArticle.error;
+    returnValue.status = "error";
+    returnValue.message = "Failed to publish article because: " + JSON.stringify(responseData.data.articles.publishArticle.error);
   }
+  return returnValue;
 }
 
 /**
@@ -2771,14 +2808,21 @@ function unpublishArticle() {
   var responseData = JSON.parse(responseText);
   Logger.log("unpublish response:", responseData);
 
+  var returnValue = {
+    status: "success",
+    message: ""
+  }
   Logger.log("END unpublishArticle");
   if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.unpublishArticle && responseData.data.articles.unpublishArticle.data) {
     storeIsPublished(false);
-    return "Unpublished article at revision " + versionID;
+    returnValue.status = "success";
+    returnValue.message = "Unpublished article at revision " + versionID;
   } else {
     storeIsPublished(true);
-    return responseData.data.articles.unpublishArticle.error;
+    returnValue.status = "error";
+    returnValue.message = "Failed to unpublish article because: " + JSON.stringify(responseData.data.articles.unpublishArticle.error);
   }
+  return returnValue;
 }
 
 /**

--- a/Code.js
+++ b/Code.js
@@ -202,8 +202,6 @@ function getScriptConfig() {
         }
       }
     }
-  } else {
-    Logger.log("found orgName:", orgName);
   }
 
   // If there's still no org name return an error
@@ -215,7 +213,6 @@ function getScriptConfig() {
   var data = scriptProperties.getProperties();
   var orgData = {}
   var pattern = `^${orgName}_`;
-  Logger.log("looking for", pattern)
   var orgKeyRegEx = new RegExp(pattern, "i")
     // value = value.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
   for (var key in data) {
@@ -224,7 +221,7 @@ function getScriptConfig() {
       orgData[plainKey] = data[key];
     }
   }
-  Logger.log("orgData:", orgData);
+  // Logger.log("orgData:", orgData);
   return orgData;
 }
 
@@ -1788,7 +1785,7 @@ function createArticleFrom(articleData) {
   Logger.log("createArticleFrom data.published: ", articleData.published);
 
   var returnValue = {
-    status: "",
+    status: "success",
     message: ""
   };
 

--- a/Code.js
+++ b/Code.js
@@ -220,7 +220,6 @@ function getScriptConfig() {
     // value = value.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
   for (var key in data) {
     if (orgKeyRegEx.test(key)) {
-      Logger.log("found matching key for this org:", key, data[key]);
       var plainKey = key.replace(orgKeyRegEx, '');
       orgData[plainKey] = data[key];
     }
@@ -1013,7 +1012,7 @@ function getArticleMeta() {
     if (latestArticle && latestArticle.status === "success") {
       var latestArticleData = latestArticle.data;
       Logger.log("getArticleMeta found latestArticleData")
-      if (latestArticleData.published !== undefined) {
+      if (latestArticleData.published !== undefined && latestArticleData.published !== null) {
         Logger.log("getArticleMeta setting published to latestArticleData.published:", typeof(latestArticleData.published), latestArticleData.published);
         storeIsPublished(latestArticleData.published);
       }
@@ -1237,6 +1236,7 @@ function handlePreview(formObject) {
   Logger.log("START handlePreview:", formObject);
   // save the article - pass publishFlag as false
   var response = getCurrentDocContents(formObject, false);
+  Logger.log("handlePreview getCurrentDocContents response:", response);
 
   if (response && response.status === "success") {
     // construct preview url
@@ -1253,6 +1253,8 @@ function handlePreview(formObject) {
   }
   var metadata = getArticleMeta();
   response.data = metadata;
+
+  Logger.log("END handlePreview response:", response);
   return response;
 }
 
@@ -1349,7 +1351,12 @@ function getCurrentDocContents(formObject, publishFlag) {
 
   if (responseData.status !== "success") {
     returnValue.status = "error";
-    returnValue.message = responseData.message;
+    Logger.log("getCurrentDocContents status is not success:", responseData);
+    if (responseData.message !== null) {
+      returnValue.message = responseData.message;
+    } else {
+      returnValue.message = "An unknown error occurred (line 1359)"
+    }
     return returnValue;
   }
 
@@ -2017,10 +2024,12 @@ function createArticleFrom(articleData) {
   var responseData = JSON.parse(responseText);
 
   if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.updateArticle && responseData.data.articles.updateArticle.error === null) {
+    Logger.log("createArticleFrom returning success:", responseData);
     returnValue.status = "success";
     returnValue.id = responseData.data.articles.updateArticle.data.id;
     returnValue.message = "Updated article with ID " +  returnValue.id;
   } else if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.updateArticle && responseData.data.articles.updateArticle.error !== null) {
+    Logger.log("createArticleFrom returning error:", responseData);
     returnValue.status = "error";
     returnValue.message = responseData.data.articles.updateArticle.error;
     Logger.log(JSON.stringify(returnValue.message));
@@ -2438,10 +2447,12 @@ function createArticle(articleData) {
     message: ""
   };
   if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.createArticle && responseData.data.articles.createArticle.error !== null) {
+    Logger.log("createArticle returning failure:", responseData);
     returnValue.status = "error";
     returnValue.id = null;
     returnValue.message = responseData.data.articles.createArticle.error;
   } else {
+    Logger.log("createArticle returning success:", responseData);
     returnValue.message = "Created article with ID " +  returnValue.id;
     returnValue.status = "success";
     returnValue.id = responseData.data.articles.createArticle.data.id;

--- a/Code.js
+++ b/Code.js
@@ -1216,8 +1216,12 @@ function getArticleMeta() {
 function handlePublish(formObject) {
   Logger.log("START handlePublish:", formObject);
 
-  var response = publishArticle()
-  Logger.log("handlePublish response:", response);
+  var response = getCurrentDocContents(formObject, false);
+  Logger.log("getCurrentDocContents response: ", response)
+
+  var response = publishArticle();
+  Logger.log("publishArticle response:", response);
+
   var metadata = getArticleMeta();
   response.data = metadata;
   return response;
@@ -1232,22 +1236,7 @@ function handleUnpublish(formObject) {
   Logger.log("START handleUnpublish:", formObject);
 
   var response = unpublishArticle()
-  Logger.log("handleUnpublish response:", response);
-  var metadata = getArticleMeta();
-  response.data = metadata;
-  return response;
-}
-
-/**
- * 
- * Saves the article as a draft
- * @param {} formObject 
- */
-function handleSave(formObject) {
-  Logger.log("START handleSave:", formObject);
-  // save the article - pass publishFlag as true
-  var response = getCurrentDocContents(formObject, false);
-  Logger.log("END handleSave: ", response)
+  Logger.log("unpublishArticle response:", response);
 
   var metadata = getArticleMeta();
   response.data = metadata;

--- a/Page.html
+++ b/Page.html
@@ -45,7 +45,7 @@
       
       function onFailureMeta(error) {
         var loadingDiv = document.getElementById('loading');
-        console.log(error);
+        console.log("onFailureMeta error:", error);
         loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + '</p>';
       }
 

--- a/Page.html
+++ b/Page.html
@@ -266,17 +266,22 @@
         var revisionDiv = document.getElementById('revision-info');
         revisionDiv.style.display = "block";
 
-        var previewDivTop = document.getElementById('preview-button-top');
-        previewDivTop.style.display = "inline";
+        var buttonsDivBottom = document.getElementById('action-buttons-bottom')
+        buttonsDivBottom.style.display = "inline";
+        var buttonsDivTop = document.getElementById('action-buttons-top')
+        buttonsDivTop.style.display = "inline";
 
-        var previewDivBottom = document.getElementById('preview-button-bottom');
-        previewDivBottom.style.display = "inline";
+        // var previewDivTop = document.getElementById('preview-button-top');
+        // previewDivTop.style.display = "inline";
 
-        var saveDivTop = document.getElementById('save-button-top');
-        saveDivTop.style.display = "inline";
+        // var previewDivBottom = document.getElementById('preview-button-bottom');
+        // previewDivBottom.style.display = "inline";
 
-        var saveDivBottom = document.getElementById('save-button-bottom');
-        saveDivBottom.style.display = "inline";
+        // var saveDivTop = document.getElementById('save-button-top');
+        // saveDivTop.style.display = "inline";
+
+        // var saveDivBottom = document.getElementById('save-button-bottom');
+        // saveDivBottom.style.display = "inline";
 
         if (data.publishingInfo !== null && typeof(data.publishingInfo) !== 'undefined') {
           if (data.publishingInfo.firstPublishedOn !== null && typeof(data.publishingInfo.firstPublishedOn) !== 'undefined') {
@@ -378,9 +383,15 @@
         if (formObject.submitted === "Preview") {
           loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
           google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePreview(formObject);
-        } else {
+        } else if (formObject.submitted === "Save") {
+          loadingDiv.innerHTML = "<p class='gray'>Saving article...</p>"
+          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handleSave(formObject);
+        } else if (formObject.submitted === "Publish") {
           loadingDiv.innerHTML = "<p class='gray'>Publishing article...</p>"
           google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePublish(formObject);
+        } else {
+          loadingDiv.innerHTML = "<p class='gray'>Unpublishing article...</p>"
+          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handleUnpublish(formObject);
         }
       }
       
@@ -392,17 +403,22 @@
         var revisionDiv = document.getElementById('revision-info');
         revisionDiv.style.display = "none";
 
-        var saveDivTop = document.getElementById('save-button-top');
-        saveDivTop.style.display = "none";
+        var buttonsDivBottom = document.getElementById('action-buttons-bottom')
+        buttonsDivBottom.style.display = "none";
+        var buttonsDivTop = document.getElementById('action-buttons-top')
+        buttonsDivTop.style.display = "none";
 
-        var saveDivBottom = document.getElementById('save-button-bottom');
-        saveDivBottom.style.display = "none";
+        // var saveDivTop = document.getElementById('save-button-top');
+        // saveDivTop.style.display = "none";
 
-        var previewButtonTop = document.getElementById('preview-button-top');
-        previewButtonTop.style.display = "none";
+        // var saveDivBottom = document.getElementById('save-button-bottom');
+        // saveDivBottom.style.display = "none";
 
-        var previewButtonBottom = document.getElementById('preview-button-bottom');
-        previewButtonBottom.style.display = "none";
+        // var previewButtonTop = document.getElementById('preview-button-top');
+        // previewButtonTop.style.display = "none";
+
+        // var previewButtonBottom = document.getElementById('preview-button-bottom');
+        // previewButtonBottom.style.display = "none";
 
         handleScriptConfig();
 
@@ -514,9 +530,11 @@
 
       <div id="article-meta-form">
         <form onsubmit="handleClick(this)">
-          <div class="block">
+          <div class="block" id="action-buttons-top">
             <input type="submit" name="preview" id="preview-button-top" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
-            <input type="submit" class="blue" id="save-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="save-button-top" value="Save" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="publish-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="unpublish-button-top" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>
 
           <div class="block form-group">
@@ -598,9 +616,11 @@
             </label>
             <input id="article-twitter-description" name="article-twitter-description" type="text" />
           </div>
-          <div class="block">
+          <div class="block" id="action-buttons-bottom">
             <input type="submit" name="preview" id="preview-button-bottom" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
-            <input type="submit" class="blue" id="save-button-bottom" value="Publish" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="save-button-bottom" value="Save" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="publish-button-bottom" value="Publish" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="unpublish-button-bottom" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>
         </form>
       </div>

--- a/Page.html
+++ b/Page.html
@@ -271,18 +271,6 @@
         var buttonsDivTop = document.getElementById('action-buttons-top')
         buttonsDivTop.style.display = "inline";
 
-        // var previewDivTop = document.getElementById('preview-button-top');
-        // previewDivTop.style.display = "inline";
-
-        // var previewDivBottom = document.getElementById('preview-button-bottom');
-        // previewDivBottom.style.display = "inline";
-
-        // var saveDivTop = document.getElementById('save-button-top');
-        // saveDivTop.style.display = "inline";
-
-        // var saveDivBottom = document.getElementById('save-button-bottom');
-        // saveDivBottom.style.display = "inline";
-
         if (data.publishingInfo !== null && typeof(data.publishingInfo) !== 'undefined') {
           if (data.publishingInfo.firstPublishedOn !== null && typeof(data.publishingInfo.firstPublishedOn) !== 'undefined') {
             var firstPubDiv = document.getElementById('first-published');
@@ -334,6 +322,29 @@
 
         if (value === "true" || value === true) { // 😭 javascript + JSON + boolean `published: true` or `published: false` as string
           isPublishedYesNo = "yes";
+
+          var publishButtonTop = document.getElementById('publish-button-top');
+          publishButtonTop.value = "Re-publish";
+          var publishButtonBottom = document.getElementById('publish-button-bottom');
+          publishButtonBottom.value = "Re-publish";
+
+          // display the unpublish button
+          var unpublishButtonTop = document.getElementById('unpublish-button-top');
+          unpublishButtonTop.style.display = "inline";
+          var unpublishButtonBottom = document.getElementById('unpublish-button-bottom');
+          unpublishButtonBottom.style.display = "inline";
+
+        } else {
+          var publishButtonTop = document.getElementById('publish-button-top');
+          publishButtonTop.value = "Publish";
+          var publishButtonBottom = document.getElementById('publish-button-bottom');
+          publishButtonBottom.value = "Publish";
+
+          // hide the unpublish button
+          var unpublishButtonTop = document.getElementById('unpublish-button-top');
+          unpublishButtonTop.style.display = "none";
+          var unpublishButtonBottom = document.getElementById('unpublish-button-bottom');
+          unpublishButtonBottom.style.display = "none";
         }
         isPublishedSpan.innerHTML = isPublishedYesNo;
       }
@@ -383,10 +394,7 @@
         if (formObject.submitted === "Preview") {
           loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
           google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePreview(formObject);
-        } else if (formObject.submitted === "Save") {
-          loadingDiv.innerHTML = "<p class='gray'>Saving article...</p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handleSave(formObject);
-        } else if (formObject.submitted === "Publish") {
+        } else if ( (formObject.submitted === "Publish") || (formObject.submitted === "Re-publish") ) {
           loadingDiv.innerHTML = "<p class='gray'>Publishing article...</p>"
           google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePublish(formObject);
         } else {
@@ -407,18 +415,6 @@
         buttonsDivBottom.style.display = "none";
         var buttonsDivTop = document.getElementById('action-buttons-top')
         buttonsDivTop.style.display = "none";
-
-        // var saveDivTop = document.getElementById('save-button-top');
-        // saveDivTop.style.display = "none";
-
-        // var saveDivBottom = document.getElementById('save-button-bottom');
-        // saveDivBottom.style.display = "none";
-
-        // var previewButtonTop = document.getElementById('preview-button-top');
-        // previewButtonTop.style.display = "none";
-
-        // var previewButtonBottom = document.getElementById('preview-button-bottom');
-        // previewButtonBottom.style.display = "none";
 
         handleScriptConfig();
 
@@ -532,7 +528,6 @@
         <form onsubmit="handleClick(this)">
           <div class="block" id="action-buttons-top">
             <input type="submit" name="preview" id="preview-button-top" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
-            <input type="submit" class="blue" id="save-button-top" value="Save" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="publish-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="unpublish-button-top" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>
@@ -618,7 +613,6 @@
           </div>
           <div class="block" id="action-buttons-bottom">
             <input type="submit" name="preview" id="preview-button-bottom" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
-            <input type="submit" class="blue" id="save-button-bottom" value="Save" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="publish-button-bottom" value="Publish" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="unpublish-button-bottom" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>


### PR DESCRIPTION
Closes #158 

This PR updates the buttons in the sidebar to the following:

* Preview: same as before, this button saves the data in the db and returns a link to view
* Publish: saves the doc, sets `published: true`; this button is labelled "Re-publish" if the doc's been published already
* Unpublish: sets `published: false` on the article

Thanks for helping with the UX, @TylerFisher!
