### PR TITLE
Toggle publish buttons

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1210,14 +1210,44 @@ function getArticleMeta() {
 }
 /**
  * 
- * Saves the article as a draft, then publishes
+ * Sets article as 'published: true'
  * @param {} formObject 
  */
 function handlePublish(formObject) {
   Logger.log("START handlePublish:", formObject);
+
+  var response = publishArticle()
+  Logger.log("handlePublish response:", response);
+  var metadata = getArticleMeta();
+  response.data = metadata;
+  return response;
+}
+
+/**
+ * 
+ * Sets article as 'published: false'
+ * @param {} formObject 
+ */
+function handleUnpublish(formObject) {
+  Logger.log("START handleUnpublish:", formObject);
+
+  var response = unpublishArticle()
+  Logger.log("handleUnpublish response:", response);
+  var metadata = getArticleMeta();
+  response.data = metadata;
+  return response;
+}
+
+/**
+ * 
+ * Saves the article as a draft
+ * @param {} formObject 
+ */
+function handleSave(formObject) {
+  Logger.log("START handleSave:", formObject);
   // save the article - pass publishFlag as true
-  var response = getCurrentDocContents(formObject, true);
-  Logger.log("END handlePublish: ", response)
+  var response = getCurrentDocContents(formObject, false);
+  Logger.log("END handleSave: ", response)
 
   var metadata = getArticleMeta();
   response.data = metadata;
@@ -2708,14 +2738,21 @@ function publishArticle() {
 
   // TODO update latestVersionPublished flag
 
+  var returnValue = {
+    status: "success",
+    message: ""
+  }
   Logger.log("END publishArticle");
   if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.publishArticle && responseData.data.articles.publishArticle.data) {
     storeIsPublished(true);
-    return "Published article at revision " + versionID;
+    returnValue.status = "success";
+    returnValue.message = "Published article at revision " + versionID;
   } else {
     storeIsPublished(false);
-    return responseData.data.articles.publishArticle.error;
+    returnValue.status = "error";
+    returnValue.message = "Failed to publish article because: " + JSON.stringify(responseData.data.articles.publishArticle.error);
   }
+  return returnValue;
 }
 
 /**
@@ -2771,14 +2808,21 @@ function unpublishArticle() {
   var responseData = JSON.parse(responseText);
   Logger.log("unpublish response:", responseData);
 
+  var returnValue = {
+    status: "success",
+    message: ""
+  }
   Logger.log("END unpublishArticle");
   if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.unpublishArticle && responseData.data.articles.unpublishArticle.data) {
     storeIsPublished(false);
-    return "Unpublished article at revision " + versionID;
+    returnValue.status = "success";
+    returnValue.message = "Unpublished article at revision " + versionID;
   } else {
     storeIsPublished(true);
-    return responseData.data.articles.unpublishArticle.error;
+    returnValue.status = "error";
+    returnValue.message = "Failed to unpublish article because: " + JSON.stringify(responseData.data.articles.unpublishArticle.error);
   }
+  return returnValue;
 }
 
 /**

--- a/Code.js
+++ b/Code.js
@@ -202,8 +202,6 @@ function getScriptConfig() {
         }
       }
     }
-  } else {
-    Logger.log("found orgName:", orgName);
   }
 
   // If there's still no org name return an error
@@ -215,7 +213,6 @@ function getScriptConfig() {
   var data = scriptProperties.getProperties();
   var orgData = {}
   var pattern = `^${orgName}_`;
-  Logger.log("looking for", pattern)
   var orgKeyRegEx = new RegExp(pattern, "i")
     // value = value.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
   for (var key in data) {
@@ -224,7 +221,7 @@ function getScriptConfig() {
       orgData[plainKey] = data[key];
     }
   }
-  Logger.log("orgData:", orgData);
+  // Logger.log("orgData:", orgData);
   return orgData;
 }
 
@@ -1788,7 +1785,7 @@ function createArticleFrom(articleData) {
   Logger.log("createArticleFrom data.published: ", articleData.published);
 
   var returnValue = {
-    status: "",
+    status: "success",
     message: ""
   };
 

--- a/Code.js
+++ b/Code.js
@@ -220,7 +220,6 @@ function getScriptConfig() {
     // value = value.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
   for (var key in data) {
     if (orgKeyRegEx.test(key)) {
-      Logger.log("found matching key for this org:", key, data[key]);
       var plainKey = key.replace(orgKeyRegEx, '');
       orgData[plainKey] = data[key];
     }
@@ -1013,7 +1012,7 @@ function getArticleMeta() {
     if (latestArticle && latestArticle.status === "success") {
       var latestArticleData = latestArticle.data;
       Logger.log("getArticleMeta found latestArticleData")
-      if (latestArticleData.published !== undefined) {
+      if (latestArticleData.published !== undefined && latestArticleData.published !== null) {
         Logger.log("getArticleMeta setting published to latestArticleData.published:", typeof(latestArticleData.published), latestArticleData.published);
         storeIsPublished(latestArticleData.published);
       }
@@ -1237,6 +1236,7 @@ function handlePreview(formObject) {
   Logger.log("START handlePreview:", formObject);
   // save the article - pass publishFlag as false
   var response = getCurrentDocContents(formObject, false);
+  Logger.log("handlePreview getCurrentDocContents response:", response);
 
   if (response && response.status === "success") {
     // construct preview url
@@ -1253,6 +1253,8 @@ function handlePreview(formObject) {
   }
   var metadata = getArticleMeta();
   response.data = metadata;
+
+  Logger.log("END handlePreview response:", response);
   return response;
 }
 
@@ -1349,7 +1351,12 @@ function getCurrentDocContents(formObject, publishFlag) {
 
   if (responseData.status !== "success") {
     returnValue.status = "error";
-    returnValue.message = responseData.message;
+    Logger.log("getCurrentDocContents status is not success:", responseData);
+    if (responseData.message !== null) {
+      returnValue.message = responseData.message;
+    } else {
+      returnValue.message = "An unknown error occurred (line 1359)"
+    }
     return returnValue;
   }
 
@@ -2017,10 +2024,12 @@ function createArticleFrom(articleData) {
   var responseData = JSON.parse(responseText);
 
   if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.updateArticle && responseData.data.articles.updateArticle.error === null) {
+    Logger.log("createArticleFrom returning success:", responseData);
     returnValue.status = "success";
     returnValue.id = responseData.data.articles.updateArticle.data.id;
     returnValue.message = "Updated article with ID " +  returnValue.id;
   } else if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.updateArticle && responseData.data.articles.updateArticle.error !== null) {
+    Logger.log("createArticleFrom returning error:", responseData);
     returnValue.status = "error";
     returnValue.message = responseData.data.articles.updateArticle.error;
     Logger.log(JSON.stringify(returnValue.message));
@@ -2438,10 +2447,12 @@ function createArticle(articleData) {
     message: ""
   };
   if (responseData && responseData.data && responseData.data.articles && responseData.data.articles.createArticle && responseData.data.articles.createArticle.error !== null) {
+    Logger.log("createArticle returning failure:", responseData);
     returnValue.status = "error";
     returnValue.id = null;
     returnValue.message = responseData.data.articles.createArticle.error;
   } else {
+    Logger.log("createArticle returning success:", responseData);
     returnValue.message = "Created article with ID " +  returnValue.id;
     returnValue.status = "success";
     returnValue.id = responseData.data.articles.createArticle.data.id;

--- a/Page.html
+++ b/Page.html
@@ -45,7 +45,7 @@
       
       function onFailureMeta(error) {
         var loadingDiv = document.getElementById('loading');
-        console.log(error);
+        console.log("onFailureMeta error:", error);
         loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + '</p>';
       }
 

--- a/Page.html
+++ b/Page.html
@@ -266,17 +266,22 @@
         var revisionDiv = document.getElementById('revision-info');
         revisionDiv.style.display = "block";
 
-        var previewDivTop = document.getElementById('preview-button-top');
-        previewDivTop.style.display = "inline";
+        var buttonsDivBottom = document.getElementById('action-buttons-bottom')
+        buttonsDivBottom.style.display = "inline";
+        var buttonsDivTop = document.getElementById('action-buttons-top')
+        buttonsDivTop.style.display = "inline";
 
-        var previewDivBottom = document.getElementById('preview-button-bottom');
-        previewDivBottom.style.display = "inline";
+        // var previewDivTop = document.getElementById('preview-button-top');
+        // previewDivTop.style.display = "inline";
 
-        var saveDivTop = document.getElementById('save-button-top');
-        saveDivTop.style.display = "inline";
+        // var previewDivBottom = document.getElementById('preview-button-bottom');
+        // previewDivBottom.style.display = "inline";
 
-        var saveDivBottom = document.getElementById('save-button-bottom');
-        saveDivBottom.style.display = "inline";
+        // var saveDivTop = document.getElementById('save-button-top');
+        // saveDivTop.style.display = "inline";
+
+        // var saveDivBottom = document.getElementById('save-button-bottom');
+        // saveDivBottom.style.display = "inline";
 
         if (data.publishingInfo !== null && typeof(data.publishingInfo) !== 'undefined') {
           if (data.publishingInfo.firstPublishedOn !== null && typeof(data.publishingInfo.firstPublishedOn) !== 'undefined') {
@@ -378,9 +383,15 @@
         if (formObject.submitted === "Preview") {
           loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
           google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePreview(formObject);
-        } else {
+        } else if (formObject.submitted === "Save") {
+          loadingDiv.innerHTML = "<p class='gray'>Saving article...</p>"
+          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handleSave(formObject);
+        } else if (formObject.submitted === "Publish") {
           loadingDiv.innerHTML = "<p class='gray'>Publishing article...</p>"
           google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePublish(formObject);
+        } else {
+          loadingDiv.innerHTML = "<p class='gray'>Unpublishing article...</p>"
+          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handleUnpublish(formObject);
         }
       }
       
@@ -392,17 +403,22 @@
         var revisionDiv = document.getElementById('revision-info');
         revisionDiv.style.display = "none";
 
-        var saveDivTop = document.getElementById('save-button-top');
-        saveDivTop.style.display = "none";
+        var buttonsDivBottom = document.getElementById('action-buttons-bottom')
+        buttonsDivBottom.style.display = "none";
+        var buttonsDivTop = document.getElementById('action-buttons-top')
+        buttonsDivTop.style.display = "none";
 
-        var saveDivBottom = document.getElementById('save-button-bottom');
-        saveDivBottom.style.display = "none";
+        // var saveDivTop = document.getElementById('save-button-top');
+        // saveDivTop.style.display = "none";
 
-        var previewButtonTop = document.getElementById('preview-button-top');
-        previewButtonTop.style.display = "none";
+        // var saveDivBottom = document.getElementById('save-button-bottom');
+        // saveDivBottom.style.display = "none";
 
-        var previewButtonBottom = document.getElementById('preview-button-bottom');
-        previewButtonBottom.style.display = "none";
+        // var previewButtonTop = document.getElementById('preview-button-top');
+        // previewButtonTop.style.display = "none";
+
+        // var previewButtonBottom = document.getElementById('preview-button-bottom');
+        // previewButtonBottom.style.display = "none";
 
         handleScriptConfig();
 
@@ -514,9 +530,11 @@
 
       <div id="article-meta-form">
         <form onsubmit="handleClick(this)">
-          <div class="block">
+          <div class="block" id="action-buttons-top">
             <input type="submit" name="preview" id="preview-button-top" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
-            <input type="submit" class="blue" id="save-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="save-button-top" value="Save" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="publish-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="unpublish-button-top" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>
 
           <div class="block form-group">
@@ -598,9 +616,11 @@
             </label>
             <input id="article-twitter-description" name="article-twitter-description" type="text" />
           </div>
-          <div class="block">
+          <div class="block" id="action-buttons-bottom">
             <input type="submit" name="preview" id="preview-button-bottom" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
-            <input type="submit" class="blue" id="save-button-bottom" value="Publish" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="save-button-bottom" value="Save" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="publish-button-bottom" value="Publish" onclick="this.form.submitted=this.value;"/>
+            <input type="submit" class="blue" id="unpublish-button-bottom" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>
         </form>
       </div>

--- a/Page.html
+++ b/Page.html
@@ -56,6 +56,63 @@
         loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + "</p>";
       }
 
+      function onSuccessUnpublish(response) {
+        var configDiv = document.getElementById('config');
+        configDiv.style.display = 'none';
+        var div = document.getElementById('loading');
+        div.style.display = 'block';
+        if (response && response.status && response.status === "error") {
+          div.innerHTML = "<p class='error'>An error occurred: " + response.message + '</p>';
+        } else {
+          div.innerHTML = '<p style="color: #48C774;">' + response.message + "</p>";
+        }
+
+        // hide the publish buttons
+        console.log("onSuccessUnpublish: showing publish, hiding unpublish")
+        var publishButtonTop = document.getElementById('publish-button-top');
+        publishButtonTop.style.display = "inline";
+        var publishButtonBottom = document.getElementById('publish-button-bottom');
+        publishButtonBottom.style.display = "inline";
+
+        // display the unpublish buttons
+        var unpublishButtonTop = document.getElementById('unpublish-button-top');
+        unpublishButtonTop.style.display = "none";
+        var unpublishButtonBottom = document.getElementById('unpublish-button-bottom');
+        unpublishButtonBottom.style.display = "none";
+
+        if (response.data) {
+          onSuccessMetaPreserveLoading(response.data);
+        }
+      }
+      function onSuccessPublish(response) {
+        var configDiv = document.getElementById('config');
+        configDiv.style.display = 'none';
+        var div = document.getElementById('loading');
+        div.style.display = 'block';
+        if (response && response.status && response.status === "error") {
+          div.innerHTML = "<p class='error'>An error occurred: " + response.message + '</p>';
+        } else {
+          div.innerHTML = '<p style="color: #48C774;">' + response.message + "</p>";
+        }
+
+        // hide the publish buttons
+        console.log("onSuccessPublish: hiding publish, showing unpublish")
+        var publishButtonTop = document.getElementById('publish-button-top');
+        publishButtonTop.style.display = "none";
+        var publishButtonBottom = document.getElementById('publish-button-bottom');
+        publishButtonBottom.style.display = "none";
+
+        // display the unpublish buttons
+        var unpublishButtonTop = document.getElementById('unpublish-button-top');
+        unpublishButtonTop.style.display = "inline";
+        var unpublishButtonBottom = document.getElementById('unpublish-button-bottom');
+        unpublishButtonBottom.style.display = "inline";
+
+        if (response.data) {
+          onSuccessMetaPreserveLoading(response.data);
+        }
+      }
+
       function onSuccessPreviewPublish(response) {
         var configDiv = document.getElementById('config');
         configDiv.style.display = 'none';
@@ -333,9 +390,38 @@
         var isPublishedYesNo = "no";
 
         if (value === "true" || value === true) { // 😭 javascript + JSON + boolean `published: true` or `published: false` as string
+          // hide the publish buttons
+          console.log("setPublishedFlag: hiding publish, showing unpublish")
+          var publishButtonTop = document.getElementById('publish-button-top');
+          publishButtonTop.style.display = "none";
+          var publishButtonBottom = document.getElementById('publish-button-bottom');
+          publishButtonBottom.style.display = "none";
+
+          // display the unpublish buttons
+          var unpublishButtonTop = document.getElementById('unpublish-button-top');
+          unpublishButtonTop.style.display = "inline";
+          var unpublishButtonBottom = document.getElementById('unpublish-button-bottom');
+          unpublishButtonBottom.style.display = "inline";
+
           isPublishedYesNo = "yes";
+
+        } else {
+          console.log("setPublishedFlag: showing publish, hiding unpublish")
+          // show the publish buttons
+          var publishButtonTop = document.getElementById('publish-button-top');
+          publishButtonTop.style.display = "inline";
+          var publishButtonBottom = document.getElementById('publish-button-bottom');
+          publishButtonBottom.style.display = "inline";
+
+          // hide the unpublish buttons
+          var unpublishButtonTop = document.getElementById('unpublish-button-top');
+          unpublishButtonTop.style.display = "none";
+          var unpublishButtonBottom = document.getElementById('unpublish-button-bottom');
+          unpublishButtonBottom.style.display = "none";
         }
         isPublishedSpan.innerHTML = isPublishedYesNo;
+
+
       }
 
       function onSuccessConfig(data) {
@@ -388,10 +474,10 @@
           google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handleSave(formObject);
         } else if (formObject.submitted === "Publish") {
           loadingDiv.innerHTML = "<p class='gray'>Publishing article...</p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePublish(formObject);
+          google.script.run.withSuccessHandler(onSuccessPublish).withFailureHandler(onFailure).handlePublish(formObject);
         } else {
           loadingDiv.innerHTML = "<p class='gray'>Unpublishing article...</p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handleUnpublish(formObject);
+          google.script.run.withSuccessHandler(onSuccessUnpublish).withFailureHandler(onFailure).handleUnpublish(formObject);
         }
       }
       


### PR DESCRIPTION
This PR builds on PR #161 - I figured it probably made sense to toggle which button was available, publish or unpublish, depending on the status.

So, if the article is already published, "unpublish" appears.

If it's not published, "publish" appears.

To test this, compared to PR #161, use "latest code" instead of version 53 of the add-on.

OTOH, maybe it's nicer to display all the buttons (and maybe even allow multiple publishing calls, even though they aren't changing anything?)

Something to consider: how to toggle back to "publish" when:

* article has already been published
* current button options are "preview" "save" and "unpublish"
* you make changes and then want to publish the article again
* what should the flow be here? "save" triggers refresh of buttons and displays "publish"? or...?

