### PR TITLE
bugfix: include locale in the preview url

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1257,10 +1257,11 @@ function handlePreview(formObject) {
   if (response && response.status === "success") {
     // construct preview url
     var slug = getArticleSlug();
+    var locale = getSelectedLocaleName();
     var scriptConfig = getScriptConfig();
     var previewHost = scriptConfig['PREVIEW_URL'];
     var previewSecret = scriptConfig['PREVIEW_SECRET'];
-    var fullPreviewUrl = previewHost + "?secret=" + previewSecret + "&slug=" + slug;
+    var fullPreviewUrl = previewHost + "?secret=" + previewSecret + "&slug=" + slug + "&locale=" + locale;
 
     // open preview url in new window
     response.message += "<br><a href='" + fullPreviewUrl + "' target='_blank'>Preview article in new window</a>"


### PR DESCRIPTION
Closes #170

small change: grab the locale name from the local document properties and append it as a query string param in the preview url.

related to https://github.com/news-catalyst/next-tinynewsdemo/pull/255