### PR TITLE
small fix: "save config" response

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1257,10 +1257,11 @@ function handlePreview(formObject) {
   if (response && response.status === "success") {
     // construct preview url
     var slug = getArticleSlug();
+    var locale = getSelectedLocaleName();
     var scriptConfig = getScriptConfig();
     var previewHost = scriptConfig['PREVIEW_URL'];
     var previewSecret = scriptConfig['PREVIEW_SECRET'];
-    var fullPreviewUrl = previewHost + "?secret=" + previewSecret + "&slug=" + slug;
+    var fullPreviewUrl = previewHost + "?secret=" + previewSecret + "&slug=" + slug + "&locale=" + locale;
 
     // open preview url in new window
     response.message += "<br><a href='" + fullPreviewUrl + "' target='_blank'>Preview article in new window</a>"

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -108,8 +108,9 @@
       }
 
       function displayConfigFormMessage(text) {
+        console.log("displaying response from saving config form...")
         var configDiv = document.getElementById('loading');
-        configDiv.innerHTML = text;
+        configDiv.innerHTML = JSON.stringify(text);
 
         hideConfigForm();
         showSearchForm();


### PR DESCRIPTION
Closes #164 

I didn't want to spend a lot of time on this given the rewrite we're likely gonna have to do.

This switches from output of `[object Object]` (helps no one) to `{"message":"Saved configuration.","status":"success"}`