### PR TITLE
Bugfix setting locale

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1257,10 +1257,11 @@ function handlePreview(formObject) {
   if (response && response.status === "success") {
     // construct preview url
     var slug = getArticleSlug();
+    var locale = getSelectedLocaleName();
     var scriptConfig = getScriptConfig();
     var previewHost = scriptConfig['PREVIEW_URL'];
     var previewSecret = scriptConfig['PREVIEW_SECRET'];
-    var fullPreviewUrl = previewHost + "?secret=" + previewSecret + "&slug=" + slug;
+    var fullPreviewUrl = previewHost + "?secret=" + previewSecret + "&slug=" + slug + "&locale=" + locale;
 
     // open preview url in new window
     response.message += "<br><a href='" + fullPreviewUrl + "' target='_blank'>Preview article in new window</a>"

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -108,8 +108,9 @@
       }
 
       function displayConfigFormMessage(text) {
+        console.log("displaying response from saving config form...")
         var configDiv = document.getElementById('loading');
-        configDiv.innerHTML = text;
+        configDiv.innerHTML = JSON.stringify(text);
 
         hideConfigForm();
         showSearchForm();


### PR DESCRIPTION
I noticed an issue setting the locale from the dropdown when I tried to first save an article with the non-default language first (e.g. spanish before saving an english version).

This fixes the small issue causing that.

Along the way, I realized that the deleteArticle code that was picking out document properties to delete was too selective; it wasn't clearing out the locale, or the authors, for instance. So I added a function that makes more sense and deletes all previously stored documentProperties; this is called when you delete the article or clear cache. This helps debugging but also will help if something gets corrupted in the future and you need to start over.

Finally, the update to Google Add-Ons seems to have changed how logging works, despite me choosing to use the legacy editor. You can no longer log:


```
Logger.log("storedLocale:", locale);
```

It comes through as "storedLocale:" with no value. You have to append like this:

```
Logger.log("storedLocale: " + locale);
```

This isn't a big deal, it's more annoying; all the previous logger statements are now fairly useless. They'll have to be updated or removed.