### PR TITLE
Fix for config form

### DIFF
--- a/ManualPage.html
+++ b/ManualPage.html
@@ -9,6 +9,19 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
 
     <script>
+      function toggleConfigForm() {
+        var scriptForm = document.getElementById('script-config-form')
+
+        // if the config form is being displayed, hide it
+        if (scriptForm.style.display === "block") {
+          hideConfigForm();
+          showSearchForm();
+
+        // otherwise, display it
+        } else {
+          getConfigAndDisplayForm();
+        }
+      }
       function onSuccessClear(contents) {
         // hideLoading();
         var div = document.getElementById('loading');
@@ -243,7 +256,7 @@
 
         console.log(data);
         if ( data.articleID !== null && data.articleID !== undefined) {
-          loadingDiv.innerHTML = "<p>This document is already associated with an article in Webiny (ID #" + data.articleID +").</p>\n<p>Open the Publishing Tools to work with it. Or, stay here to change which article this document is linked to.</p>"
+          loadingDiv.innerHTML = "<p>This document is already associated with an article in Webiny (ID #" + data.articleID +").</p>\n<p>Open the Publishing Tools to work with it. Or, stay here to change which article this document is linked to.</p><hr/>"
         } else {
           loadingDiv.innerHTML = "<p>You can link this document to an existing article in Webiny to publish it to the web and mobile.</p>"
         }
@@ -336,7 +349,7 @@
   <body>
     <a id='top' href="#"></a>
     <div id="sidebar-wrapper" class="sidebar branding-below">
-      <h1 class="title">Admin this Document</h1>
+      <h1 class="title">Admin Tools</h1>
 
       <div class="block gray" id="loading">Loading...</div>
 
@@ -395,11 +408,12 @@
         </div>
       </form>
 
-      <div id="article-search-form">
+      <div id="article-search-form" class="block">
+        <h2>Link Doc with Existing Article</h2>
         <form onsubmit="handleSearch(this)">
           <div class="block form-group">
             <label for="article-headline">
-              <b>Search Articles</b>
+              <b>Find an article by headline</b>
             </label>
             <input id="article-search" name="article-search" type="text" />
           </div>
@@ -409,7 +423,7 @@
         </form>
       </div>
 
-      <div id="associate-article-form">
+      <div id="associate-article-form" class="block">
         <form onsubmit="handleAssociate(this)">
           <div class="block form-group">
             <label for="article-id">
@@ -431,14 +445,17 @@
         </form>
       </div>
 
+
       <div class="block">
-        <button onclick="getConfigAndDisplayForm()">Show Config</button>
-        <button onclick="hideConfigForm();showSearchForm();">Hide Config</button>
+        <hr/>
+        <button onclick="toggleConfigForm()">Toggle Config Form</button>
+        <hr/>
         <button onclick="clearCache()">Clear Cache</button>
-      </div>
-      <div class="block">
+        <hr/>
+        <br/>
         <button style="display: none;" id="deleteArticleButton" class="create" onclick="deleteArticle()">Delete Article</button>
         <button style="display: none;" id="deletePageButton" class="create" onclick="deletePage()">Delete Page</button>
+        <br/>
       </div>
     </div>
 

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -131,31 +131,36 @@
 
       function onSuccessConfigFormValues(data) {
         var accessToken = document.getElementById('access-token');
-        accessToken.value = data.accessToken;
+        accessToken.value = data.accessToken ? data.accessToken : data['ACCESS_TOKEN'];
 
         var contentApi = document.getElementById('content-api');
-        contentApi.value = data.contentApi;
+        contentApi.value = data.contentApi ? data.contentApi : data['CONTENT_API'];
 
         var previewUrl = document.getElementById('preview-url');
-        previewUrl.value = data.previewUrl;
+        previewUrl.value = data.previewUrl ? data.previewUrl : data['PREVIEW_URL'];
 
         var previewSecret = document.getElementById('preview-secret');
-        previewSecret.value = data.previewSecret;
+        previewSecret.value = data.previewSecret ? data.previewSecret : data['PREVIEW_SECRET'];
 
         var awsAccessKey = document.getElementById('aws-access-key');
-        awsAccessKey.value = data.awsAccessKey;
+        awsAccessKey.value = data.awsAccessKey ? data.awsAccessKey : data['AWS_ACCESS_KEY_ID'];
 
         var awsSecretKey = document.getElementById('aws-secret-key');
-        awsSecretKey.value = data.awsSecretKey;
+        awsSecretKey.value = data.awsSecretKey ? data.awsSecretKey : data['AWS_SECRET_KEY'];
 
         var awsBucket = document.getElementById('aws-bucket');
-        awsBucket.value = data.awsBucket;
+        awsBucket.value = data.awsBucket ? data.awsBucket : data['AWS_BUCKET'];
+
+        var deployHook = document.getElementById('aws-bucket');
+        deployHook.value = data.vercelDeployHook ? data.vercelDeployHook : data['VERCEL_DEPLOY_HOOK'];
+
+        showConfigForm();
       }
 
       function getConfigAndDisplayForm() {
         hideSearchForm();
         showConfigForm();
-        google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessConfigFormValues).getArticleMeta();
+        // google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessConfigFormValues).getArticleMeta();
       }
 
       function showArticleForm() {
@@ -200,9 +205,10 @@
 
       function onSuccessConfig(data) {
         // hideLoading();
-        var loadingDiv = document.getElementById('loading');
+        // var loadingDiv = document.getElementById('loading');
         if (data !== null && data !== {} && Object.keys(data).length > 0) {
-          loadingDiv.innerHTML = "<div class='success'>Configuration loaded.</div><hr/>"
+          // loadingDiv.innerHTML = "<div class='success'>Configuration loaded.</div><hr/>"
+          onSuccessConfigFormValues(data);
           hideConfigForm();
           showSearchForm();
         } else {


### PR DESCRIPTION
Closes #172 

Before this PR the config data (the aws keys, api url and token, etc) was being loaded when the admin tools sidebar was first opened, then requested again from the API when clicking the "show config form" button; the form would display immediately and then sit there, blank, before getting the API response and data filled in.

This PR:

* eliminates the extra config data API call - not required as we have already loaded it on sidebar open
* fills the data in the config form first
* then displays the config form

I had accidentally started filling in the form when working on this before data showed up a few times, and I was worried about doing this on a real client. Also, this way is just nicer.


Testable using "latest code" from the script editor; open the Admin Tools and click the toggle config form button, which was introduced in an earlier PR (still open - #178).