### PR TITLE
Feature/nicer translation ux

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -756,6 +756,7 @@ function getArticleDataByID(articleID) {
     returnValue.status = "success";
     returnValue.id = responseData.data.articles.getArticle.data.id;
     returnValue.data = responseData.data.articles.getArticle.data;
+    Logger.log("**getArticleDataByID dates**: " + returnValue.data.firstPublishedOn + " " + returnValue.data.lastPublishedOn)
     returnValue.message = "Retrieved article with ID " +  returnValue.id;
   } else {
     returnValue.status = "error";
@@ -807,6 +808,9 @@ function getArticleByDocumentID(documentID) {
             googleDocs
             docIDs
             availableLocales
+            firstPublishedOn
+            lastPublishedOn
+            published
             twitterTitle {
               values {
                 value
@@ -922,6 +926,9 @@ function getArticleMeta() {
 
   var articleID = getArticleID();
 
+  var firstPublishedOn = null;
+  var lastPublishedOn = null;
+
   // if there's no stored articleID on this document, try to find it by google document ID in webiny
   if (articleID === null) {
     Logger.log("No articleID found; looking up documentID " + documentID + " in webiny now");
@@ -931,6 +938,11 @@ function getArticleMeta() {
 
       articleID = existingArticleData.id;
       storeArticleID(existingArticleData.id);
+
+      firstPublishedOn = existingArticleData.firstPublishedOn;
+      lastPublishedOn = existingArticleData.lastPublishedOn;
+
+      Logger.log("firstPublishedOn: " + firstPublishedOn + "; lastPublishedOn:" + lastPublishedOn)
 
       var headline = getDocumentName();
       Logger.log("headline:", headline);
@@ -1017,7 +1029,9 @@ function getArticleMeta() {
 
     if (latestArticle && latestArticle.status === "success") {
       var latestArticleData = latestArticle.data;
-      Logger.log("getArticleMeta found latestArticleData")
+      firstPublishedOn = latestArticleData.firstPublishedOn;
+      lastPublishedOn = latestArticleData.lastPublishedOn;
+
       if (latestArticleData.published !== undefined && latestArticleData.published !== null) {
         Logger.log("getArticleMeta setting published to latestArticleData.published:", typeof(latestArticleData.published), latestArticleData.published);
         storeIsPublished(latestArticleData.published);
@@ -1168,6 +1182,8 @@ function getArticleMeta() {
       contentApi: contentApi,
       customByline: customByline,
       documentType: documentType,
+      firstPublishedOn: null,
+      lastPublishedOn: null,
       headline: headline,
       localeID: null,
       localeName: null,
@@ -1201,6 +1217,8 @@ function getArticleMeta() {
     contentApi: contentApi,
     customByline: customByline,
     documentType: documentType,
+    firstPublishedOn: firstPublishedOn,
+    lastPublishedOn: lastPublishedOn,
     localeID: selectedLocaleID,
     localeName: selectedLocaleName,
     locales: locales,
@@ -1214,7 +1232,7 @@ function getArticleMeta() {
     republishUrl: republishUrl
   };
 
-  Logger.log("getArticleMeta END, published:", typeof(articleMetadata.published), articleMetadata.published);
+  Logger.log("getArticleMeta END, firstPublishedOn:", firstPublishedOn);
   return articleMetadata;
 }
 /**

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -253,6 +253,16 @@
         }
       }
 
+      function setPublishedFlag(value) {
+        var isPublishedSpan = document.getElementById('is-published');
+        var isPublishedYesNo = "no";
+
+        if (value === "true" || value === true) { // 😭 javascript + JSON + boolean `published: true` or `published: false` as string
+          isPublishedYesNo = "yes";
+        }
+        isPublishedSpan.innerHTML = isPublishedYesNo;
+      }
+
       function handleScriptConfigSubmit(formObject) {
         google.script.run.withSuccessHandler(displayConfigFormMessage).setScriptConfig(formObject);
       }
@@ -261,10 +271,38 @@
         var loadingDiv = document.getElementById('loading');
 
         console.log(data);
+
+        setPublishedFlag(data.published);
+
         if ( data.articleID !== null && data.articleID !== undefined) {
           loadingDiv.innerHTML = "<p>This document is already associated with an article in Webiny (ID #" + data.articleID +").</p>\n<p>Open the Publishing Tools to work with it. Or, stay here to change which article this document is linked to.</p><hr/>"
         } else {
           loadingDiv.innerHTML = "<p>You can link this document to an existing article in Webiny to publish it to the web and mobile.</p>"
+
+        }
+
+        var revisionIdSpan = document.getElementById('revision-id');
+        revisionIdSpan.innerHTML = data.articleID;
+
+        var slugDiv = document.getElementById('slug');
+        slugDiv.innerHTML = data.slug;
+
+        var availableLocalesDiv = document.getElementById('available-locales');
+        availableLocalesDiv.innerHTML = data.availableLocales;
+
+        var sitewideLocalesDiv = document.getElementById('sitewide-locales');
+        sitewideLocalesDiv.innerHTML = data.locales.map(locale=>locale.code).join(" | ");
+
+        if (data.firstPublishedOn !== null && typeof(data.firstPublishedOn) !== 'undefined') {
+          var firstPubDiv = document.getElementById('first-published');
+          var localisedDate = new Date(data.firstPublishedOn).toLocaleString();
+          firstPubDiv.innerHTML = localisedDate;
+        }
+
+        if (data.lastPublishedOn !== null && typeof(data.lastPublishedOn) !== 'undefined') {
+          var lastPubDiv = document.getElementById('last-published');
+          var localisedDate = new Date(data.lastPublishedOn).toLocaleString();
+          lastPubDiv.innerHTML = localisedDate;
         }
 
         var deleteArticleButton = document.getElementById("deleteArticleButton");
@@ -462,6 +500,30 @@
         <button style="display: none;" id="deleteArticleButton" class="create" onclick="deleteArticle()">Delete Article</button>
         <button style="display: none;" id="deletePageButton" class="create" onclick="deletePage()">Delete Page</button>
         <br/>
+        <hr/>
+        <br/>
+        <h3 class="gray">Debugging Info:</h3>
+          <p class="gray">
+            <b>Article slug:</b> <span id="slug"></span>
+          </p>
+          <p class="gray">
+            <b>Available locales:</b> <span id="available-locales"></span>
+          </p>
+          <p class="gray">
+            <b>Revision ID:</b> <span id="revision-id"></span>
+          </p>
+          <p class="gray">
+            <b>Published?</b> <span id="is-published"></span>
+          </p>
+          <p class="gray">
+            <b>First published:</b> <span id="first-published"></span>
+          </p>
+          <p class="gray">
+            <b>Last published:</b> <span id="last-published"></span>
+          </p>
+          <p class="gray">
+            <b>Site-wide Locales:</b> <span id="sitewide-locales"></span>
+          </p>
       </div>
     </div>
 

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -9,6 +9,19 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
 
     <script>
+      function toggleConfigForm() {
+        var scriptForm = document.getElementById('script-config-form')
+
+        // if the config form is being displayed, hide it
+        if (scriptForm.style.display === "block") {
+          hideConfigForm();
+          showSearchForm();
+
+        // otherwise, display it
+        } else {
+          getConfigAndDisplayForm();
+        }
+      }
       function onSuccessClear(contents) {
         // hideLoading();
         var div = document.getElementById('loading');
@@ -243,7 +256,7 @@
 
         console.log(data);
         if ( data.articleID !== null && data.articleID !== undefined) {
-          loadingDiv.innerHTML = "<p>This document is already associated with an article in Webiny (ID #" + data.articleID +").</p>\n<p>Open the Publishing Tools to work with it. Or, stay here to change which article this document is linked to.</p>"
+          loadingDiv.innerHTML = "<p>This document is already associated with an article in Webiny (ID #" + data.articleID +").</p>\n<p>Open the Publishing Tools to work with it. Or, stay here to change which article this document is linked to.</p><hr/>"
         } else {
           loadingDiv.innerHTML = "<p>You can link this document to an existing article in Webiny to publish it to the web and mobile.</p>"
         }
@@ -336,7 +349,7 @@
   <body>
     <a id='top' href="#"></a>
     <div id="sidebar-wrapper" class="sidebar branding-below">
-      <h1 class="title">Admin this Document</h1>
+      <h1 class="title">Admin Tools</h1>
 
       <div class="block gray" id="loading">Loading...</div>
 
@@ -395,11 +408,12 @@
         </div>
       </form>
 
-      <div id="article-search-form">
+      <div id="article-search-form" class="block">
+        <h2>Link Doc with Existing Article</h2>
         <form onsubmit="handleSearch(this)">
           <div class="block form-group">
             <label for="article-headline">
-              <b>Search Articles</b>
+              <b>Find an article by headline</b>
             </label>
             <input id="article-search" name="article-search" type="text" />
           </div>
@@ -409,7 +423,7 @@
         </form>
       </div>
 
-      <div id="associate-article-form">
+      <div id="associate-article-form" class="block">
         <form onsubmit="handleAssociate(this)">
           <div class="block form-group">
             <label for="article-id">
@@ -431,14 +445,17 @@
         </form>
       </div>
 
+
       <div class="block">
-        <button onclick="getConfigAndDisplayForm()">Show Config</button>
-        <button onclick="hideConfigForm();showSearchForm();">Hide Config</button>
+        <hr/>
+        <button onclick="toggleConfigForm()">Toggle Config Form</button>
+        <hr/>
         <button onclick="clearCache()">Clear Cache</button>
-      </div>
-      <div class="block">
+        <hr/>
+        <br/>
         <button style="display: none;" id="deleteArticleButton" class="create" onclick="deleteArticle()">Delete Article</button>
         <button style="display: none;" id="deletePageButton" class="create" onclick="deletePage()">Delete Page</button>
+        <br/>
       </div>
     </div>
 

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -131,31 +131,36 @@
 
       function onSuccessConfigFormValues(data) {
         var accessToken = document.getElementById('access-token');
-        accessToken.value = data.accessToken;
+        accessToken.value = data.accessToken ? data.accessToken : data['ACCESS_TOKEN'];
 
         var contentApi = document.getElementById('content-api');
-        contentApi.value = data.contentApi;
+        contentApi.value = data.contentApi ? data.contentApi : data['CONTENT_API'];
 
         var previewUrl = document.getElementById('preview-url');
-        previewUrl.value = data.previewUrl;
+        previewUrl.value = data.previewUrl ? data.previewUrl : data['PREVIEW_URL'];
 
         var previewSecret = document.getElementById('preview-secret');
-        previewSecret.value = data.previewSecret;
+        previewSecret.value = data.previewSecret ? data.previewSecret : data['PREVIEW_SECRET'];
 
         var awsAccessKey = document.getElementById('aws-access-key');
-        awsAccessKey.value = data.awsAccessKey;
+        awsAccessKey.value = data.awsAccessKey ? data.awsAccessKey : data['AWS_ACCESS_KEY_ID'];
 
         var awsSecretKey = document.getElementById('aws-secret-key');
-        awsSecretKey.value = data.awsSecretKey;
+        awsSecretKey.value = data.awsSecretKey ? data.awsSecretKey : data['AWS_SECRET_KEY'];
 
         var awsBucket = document.getElementById('aws-bucket');
-        awsBucket.value = data.awsBucket;
+        awsBucket.value = data.awsBucket ? data.awsBucket : data['AWS_BUCKET'];
+
+        var deployHook = document.getElementById('aws-bucket');
+        deployHook.value = data.vercelDeployHook ? data.vercelDeployHook : data['VERCEL_DEPLOY_HOOK'];
+
+        showConfigForm();
       }
 
       function getConfigAndDisplayForm() {
         hideSearchForm();
         showConfigForm();
-        google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessConfigFormValues).getArticleMeta();
+        // google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessConfigFormValues).getArticleMeta();
       }
 
       function showArticleForm() {
@@ -200,9 +205,10 @@
 
       function onSuccessConfig(data) {
         // hideLoading();
-        var loadingDiv = document.getElementById('loading');
+        // var loadingDiv = document.getElementById('loading');
         if (data !== null && data !== {} && Object.keys(data).length > 0) {
-          loadingDiv.innerHTML = "<div class='success'>Configuration loaded.</div><hr/>"
+          // loadingDiv.innerHTML = "<div class='success'>Configuration loaded.</div><hr/>"
+          onSuccessConfigFormValues(data);
           hideConfigForm();
           showSearchForm();
         } else {

--- a/Page.html
+++ b/Page.html
@@ -192,9 +192,6 @@
           }
         })
 
-        var revisionIdSpan = document.getElementById('revision-id');
-        revisionIdSpan.innerHTML = data.articleID;
-
         setPublishedFlag(data.published);
 
         var articleHeadline = document.getElementById('article-headline');
@@ -234,12 +231,6 @@
         var slugDiv = document.getElementById('slug');
         slugDiv.innerHTML = data.slug;
 
-        var availableLocalesDiv = document.getElementById('available-locales');
-        availableLocalesDiv.innerHTML = data.availableLocales;
-
-        var sitewideLocalesDiv = document.getElementById('sitewide-locales');
-        sitewideLocalesDiv.innerHTML = data.locales.map(locale=>locale.code).join(" | ");
-
         if (data.documentType === 'article') {
           $('#article-authors').select2({
             width: 'resolve',
@@ -264,25 +255,22 @@
           });
         }
 
-        var revisionDiv = document.getElementById('revision-info');
-        revisionDiv.style.display = "block";
-
         var buttonsDivBottom = document.getElementById('action-buttons-bottom')
         buttonsDivBottom.style.display = "inline";
         var buttonsDivTop = document.getElementById('action-buttons-top')
         buttonsDivTop.style.display = "inline";
 
-        if (data.firstPublishedOn !== null && typeof(data.firstPublishedOn) !== 'undefined') {
-          var firstPubDiv = document.getElementById('first-published');
-          var localisedDate = new Date(data.firstPublishedOn).toLocaleString();
-          firstPubDiv.innerHTML = localisedDate;
-        }
+        // if (data.firstPublishedOn !== null && typeof(data.firstPublishedOn) !== 'undefined') {
+        //   var firstPubDiv = document.getElementById('first-published');
+        //   var localisedDate = new Date(data.firstPublishedOn).toLocaleString();
+        //   firstPubDiv.innerHTML = localisedDate;
+        // }
 
-        if (data.lastPublishedOn !== null && typeof(data.lastPublishedOn) !== 'undefined') {
-          var lastPubDiv = document.getElementById('last-published');
-          var localisedDate = new Date(data.lastPublishedOn).toLocaleString();
-          lastPubDiv.innerHTML = localisedDate;
-        }
+        // if (data.lastPublishedOn !== null && typeof(data.lastPublishedOn) !== 'undefined') {
+        //   var lastPubDiv = document.getElementById('last-published');
+        //   var localisedDate = new Date(data.lastPublishedOn).toLocaleString();
+        //   lastPubDiv.innerHTML = localisedDate;
+        // }
 
         if (data.googleDocs !== null && data.googleDocs !== undefined) {
           var editDiv = document.getElementById('edit-links');
@@ -316,7 +304,7 @@
       }
 
       function setPublishedFlag(value) {
-        var isPublishedSpan = document.getElementById('is-published');
+        // var isPublishedSpan = document.getElementById('is-published');
         var isPublishedYesNo = "no";
 
         if (value === "true" || value === true) { // 😭 javascript + JSON + boolean `published: true` or `published: false` as string
@@ -345,7 +333,7 @@
           var unpublishButtonBottom = document.getElementById('unpublish-button-bottom');
           unpublishButtonBottom.style.display = "none";
         }
-        isPublishedSpan.innerHTML = isPublishedYesNo;
+        // isPublishedSpan.innerHTML = isPublishedYesNo;
       }
 
       function onSuccessConfig(data) {
@@ -406,9 +394,6 @@
         var form = document.getElementById('article-meta-form');
         form.style.display = "none";
         hideConfigForm();
-        
-        var revisionDiv = document.getElementById('revision-info');
-        revisionDiv.style.display = "none";
 
         var buttonsDivBottom = document.getElementById('action-buttons-bottom')
         buttonsDivBottom.style.display = "none";
@@ -540,6 +525,13 @@
           </div>
 
           <div class="block form-group">
+            <label for="article-slug">
+              <b>Article slug</b>
+            </label>
+            <div id="slug"></div>
+          </div>
+
+          <div class="block form-group">
             <label for="article-headline">
               <b>Headline</b>
             </label>
@@ -616,32 +608,6 @@
             <input type="submit" class="blue" id="unpublish-button-bottom" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>
         </form>
-      </div>
-
-      <div class="block">
-        <div id="revision-info">
-          <p>
-            <b>Article slug:</b> <span id="slug"></span>
-          </p>
-          <p>
-            <b>Available locales:</b> <span id="available-locales"></span>
-          </p>
-          <p>
-            <b>Revision ID:</b> <span id="revision-id"></span>
-          </p>
-          <p>
-            <b>Published?</b> <span id="is-published"></span>
-          </p>
-          <p>
-            <b>First published:</b> <span id="first-published"></span>
-          </p>
-          <p>
-            <b>Last published:</b> <span id="last-published"></span>
-          </p>
-          <p>
-            <b>Site-wide Locales:</b> <span id="sitewide-locales"></span>
-          </p>
-        </div>
       </div>
 
       <div id="edit-links" class="block">

--- a/Page.html
+++ b/Page.html
@@ -9,6 +9,37 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
 
     <script>
+      // flags for a subset of all locales
+      // I started with the ones I figured were the most likely; then grabbed more from this
+      // full locale list from https://github.com/ladjs/i18n-locales
+      // emoji flags from https://emojipedia.org/flags/
+      // I took all the major seeming english variants too: Australia, Canada, Ireland, GB, NZ, US, and South Africa
+      const emojiFor = {
+        "es": "🇪🇸",
+        "es-ES": "🇪🇸",
+        "fr": "🇫🇷",
+        "fr-FR": "🇫🇷",
+        "de": "🇩🇪",
+        "de-DE": "🇩🇪",
+        "pt-BR": "🇧🇷",
+        "pt": "🇵🇹",
+        "pt-PT": "🇵🇹",
+        "en": "🇬🇧",
+        "en-AU": "🇦🇺",
+        "en-CA": "🇨🇦",
+        "en-IE": "🇮🇪",
+        "en-GB": "🇬🇧",
+        "en-US": "🇺🇸",
+        "en-NZ": "🇳🇿",
+        "en-ZA": "🇿🇦",
+        "jp": "🇯🇵",
+        "zh": "🇨🇳",
+        "zh-CN": "🇨🇳",
+        "it": "🇮🇹",
+        "ru": "🇷🇺",
+        "ru-RU": "🇷🇺"
+      }
+
       function showConfigForm() {
         var scriptForm = document.getElementById('script-config-form')
         scriptForm.style.display = "block";
@@ -274,7 +305,8 @@
 
         if (data.googleDocs !== null && data.googleDocs !== undefined) {
           var editDiv = document.getElementById('edit-links');
-          var links = [];
+          var createLinks = [];
+          var editLinks = [];
           var createLocales = data.locales.map(locale=>locale.code);
           var existingLocales = Object.keys(data.googleDocs);
 
@@ -283,16 +315,23 @@
           })
 
           $.each( data.googleDocs, function( locale, docID ) {
+            var emojiFlag = emojiFor[locale];
             if (locale !== data.localeName) {
-              links.push("<li><a target='_blank' href='https://docs.google.com/document/d/" + docID + "/edit'>" + locale + "</a></li>")
+              editLinks.push("<li><a target='_blank' href='https://docs.google.com/document/d/" + docID + "/edit'>" + emojiFlag + locale + "</a></li>")
             }
           });
 
           $.each(createLocales, function( index, locale ) {
-            links.push("<li><a onclick='createNewDoc(\"" + locale + "\");'>" + locale + " (new)</a></li>");
+            var emojiFlag = emojiFor[locale];
+            createLinks.push("<li><a onclick='createNewDoc(\"" + locale + "\");'>" + emojiFlag + locale + "</li>");
           });
 
-          editDiv.innerHTML = "<p><b>Edit in other languages:</b></p><ul>" + links.join("")+ "</ul>";
+          if (createLinks.length > 0) {
+            editDiv.innerHTML = "<p><b>Create new translation:</b></p><ul>" + createLinks.join("")+ "</ul>";
+          }
+          if (editLinks.length > 0) {
+            editDiv.innerHTML += "<p><b>Existing translations:</b></p><ul>" + editLinks.join("")+ "</ul>";
+          }
         }
       }
 

--- a/Page.html
+++ b/Page.html
@@ -72,6 +72,7 @@
       }
 
       function onSuccessMetaPreserveLoading(data) {
+        console.log("onSuccessMeta data:", data);
         var form = document.getElementById('article-meta-form');
         form.style.display = "block";
 
@@ -271,18 +272,16 @@
         var buttonsDivTop = document.getElementById('action-buttons-top')
         buttonsDivTop.style.display = "inline";
 
-        if (data.publishingInfo !== null && typeof(data.publishingInfo) !== 'undefined') {
-          if (data.publishingInfo.firstPublishedOn !== null && typeof(data.publishingInfo.firstPublishedOn) !== 'undefined') {
-            var firstPubDiv = document.getElementById('first-published');
-            var localisedDate = new Date(data.publishingInfo.firstPublishedOn).toLocaleString();
-            firstPubDiv.innerHTML = localisedDate;
-          }
+        if (data.firstPublishedOn !== null && typeof(data.firstPublishedOn) !== 'undefined') {
+          var firstPubDiv = document.getElementById('first-published');
+          var localisedDate = new Date(data.firstPublishedOn).toLocaleString();
+          firstPubDiv.innerHTML = localisedDate;
+        }
 
-          if (data.publishingInfo.lastPublishedOn !== null && typeof(data.publishingInfo.lastPublishedOn) !== 'undefined') {
-            var lastPubDiv = document.getElementById('last-published');
-            var localisedDate = new Date(data.publishingInfo.lastPublishedOn).toLocaleString();
-            lastPubDiv.innerHTML = localisedDate;
-          }
+        if (data.lastPublishedOn !== null && typeof(data.lastPublishedOn) !== 'undefined') {
+          var lastPubDiv = document.getElementById('last-published');
+          var localisedDate = new Date(data.lastPublishedOn).toLocaleString();
+          lastPubDiv.innerHTML = localisedDate;
         }
 
         if (data.googleDocs !== null && data.googleDocs !== undefined) {


### PR DESCRIPTION
Closes #179 

This PR splits the links into two lists: "Create new translation" and "Edit existing translation"

It also adds support for emoji flags for the (hopefully) most likely locales, including all major english dialects, spanish, chinese, and a smattering of european languages. We can add more as needed. I think the addition of the flag makes it look friendlier.

This is in the "latest code" for the sidebar and appears in "publishing tools" at the bottom.