### PR TITLE
Prevent dupe translation links

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -491,6 +491,9 @@
 
     </script>
     <style>
+      textarea {
+        width: 100%;
+      }
       .branding-below {
         bottom: 56px;
         top: 0;
@@ -635,7 +638,7 @@
             <label for="article-search-description">
               <b>Search description</b>
             </label>
-            <input id="article-search-description" name="article-search-description" type="text" />
+            <textarea id="article-search-description" name="article-search-description"></textarea>
           </div>
           <div class="block form-group">
             <label for="article-facebook-title">
@@ -647,7 +650,7 @@
             <label for="article-facebook-description">
               <b>Facebook description</b>
             </label>
-            <input id="article-facebook-description" name="article-facebook-description" type="text" />
+            <textarea id="article-facebook-description" name="article-facebook-description"></textarea>
           </div>
           <div class="block form-group">
             <label for="article-twitter-title">
@@ -659,7 +662,7 @@
             <label for="article-twitter-description">
               <b>Twitter description</b>
             </label>
-            <input id="article-twitter-description" name="article-twitter-description" type="text" />
+            <textarea id="article-twitter-description" name="article-twitter-description"></textarea>
           </div>
           <div class="block" id="action-buttons-bottom">
             <input type="submit" name="preview" id="preview-button-bottom" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>

--- a/Page.html
+++ b/Page.html
@@ -203,6 +203,14 @@
         }
 
         var articleTagsSelect = document.getElementById('article-tags');
+
+        // first clear out previous tags - without doing this, we end up with dupes of all the tags
+        // after previewing or publishing
+        var length = articleTagsSelect.options.length;
+        for (i = length-1; i >= 0; i--) {
+          articleTagsSelect.options[i] = null;
+        }
+
         data.allTags.forEach(tag => {
           // first check if this option already exists; don't add dupes!
           var selectorString = "#article-tags option[value='" + tag.id + "']";

--- a/Page.html
+++ b/Page.html
@@ -102,6 +102,14 @@
         }
       }
 
+      function actualTitleOrDefault(title, defaultTitle) {
+        if (title === undefined || title === "" || title === null) {
+          return defaultTitle;
+        } else {
+          return title;
+        }
+      }
+
       function onSuccessMetaPreserveLoading(data) {
         console.log("onSuccessMeta data:", data);
         var form = document.getElementById('article-meta-form');
@@ -243,9 +251,12 @@
           }
         }
 
+        
+        var articleSearchTitle = document.getElementById('article-search-title');
         if (data.seo.searchTitle !== undefined) {
-          var articleSearchTitle = document.getElementById('article-search-title');
-          articleSearchTitle.value = data.seo.searchTitle;
+          articleSearchTitle.value = actualTitleOrDefault(data.seo.searchTitle, data.headline);
+        } else {
+          articleSearchTitle.value = data.headline;
         }
 
         if (data.seo.searchDescription !== undefined) {
@@ -253,9 +264,11 @@
           articleSearchDescription.value = data.seo.searchDescription;
         }
 
+        var articleFacebookTitle = document.getElementById('article-facebook-title');
         if (data.seo.facebookTitle !== undefined) {
-          var articleFacebookTitle = document.getElementById('article-facebook-title');
-          articleFacebookTitle.value = data.seo.facebookTitle;
+          articleFacebookTitle.value = actualTitleOrDefault(data.seo.facebookTitle, data.headline);
+        } else {
+          articleFacebookTitle.value = data.headline;
         }
 
         if (data.seo.facebookDescription !== undefined) {
@@ -263,9 +276,11 @@
           articleFacebookDescription.value = data.seo.facebookDescription;
         }
 
+        var articleTwitterTitle = document.getElementById('article-twitter-title');
         if (data.seo.twitterTitle !== undefined) {
-          var articleTwitterTitle = document.getElementById('article-twitter-title');
-          articleTwitterTitle.value = data.seo.twitterTitle;
+          articleTwitterTitle.value = actualTitleOrDefault(data.seo.twitterTitle, data.headline);
+        } else {
+          articleTwitterTitle.value = data.headline;
         }
 
         if (data.seo.twitterDescription !== undefined) {

--- a/Page.html
+++ b/Page.html
@@ -340,6 +340,8 @@
 
         if (data.googleDocs !== null && data.googleDocs !== undefined) {
           var editDiv = document.getElementById('edit-links');
+          editDiv.innerHTML = ""; // blank this out to prevent subsequent publish calls to duplicate links
+
           var createLinks = [];
           var editLinks = [];
           var createLocales = data.locales.map(locale=>locale.code);


### PR DESCRIPTION
Closes #191 

This was an easy fix - because this list of create & edit translation links is built on every save, I added a line to blank out the section before appending these links.