### PR TITLE
Hasura get article

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -888,323 +888,451 @@ function getArticleByDocumentID(documentID) {
 }
 
 /*
+This is an example snippet - you should consider tailoring it
+to your service.
+*/
+
+async function fetchGraphQL(operationsDoc, operationName, variables) {
+  var scriptConfig = getScriptConfig();
+  var ORG_SLUG = scriptConfig['ACCESS_TOKEN'];
+  var API_URL = scriptConfig['CONTENT_API'];
+
+  var options = {
+    method: 'POST',
+    muteHttpExceptions: true,
+    contentType: 'application/json',
+    headers: {
+      "TNC-Organization": ORG_SLUG
+    },
+    payload: JSON.stringify({
+      query: operationsDoc,
+      variables: variables,
+      operationName: operationName
+    }),
+  };
+
+  const result = await UrlFetchApp.fetch(
+    API_URL,
+    options
+  );
+
+  var responseText = result.getContentText();
+  var responseData = JSON.parse(responseText);
+
+  return responseData;
+}
+
+const getArticleForGoogleDocQuery = `
+query MyQuery($doc_id: String!, $locale_code: String!) {
+  articles(where: {article_google_documents: {google_document: {document_id: {_eq: $doc_id}, locale_code: {_eq: $locale_code}}}, article_translations: {locale_code: {_eq: $locale_code}}}) {
+    category {
+      id
+      slug
+      title
+    }
+    slug
+    tag_articles {
+      tag {
+        id
+        slug
+        tag_translations(where: {locale_code: {_eq: $locale_code}}) {
+          title
+        }
+      }
+      tag_id
+    }
+    article_translations(where: {locale_code: {_eq: $locale_code}}) {
+      content
+      custom_byline
+      facebook_description
+      facebook_title
+      headline
+      last_published_at
+      first_published_at
+      search_description
+      published
+      search_title
+      twitter_description
+      twitter_title
+    }
+    author_articles {
+      author {
+        id
+        name
+        slug
+      }
+    }
+  }
+  categories {
+    id
+    slug
+    category_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
+  }
+  tags {
+    id
+    slug
+    tag_translations(where: {locale_code: {_eq: $locale_code}}) {
+      title
+    }
+  }
+  organization_locales {
+    locale {
+      code
+      name
+    }
+  }
+}`;
+
+function fetchArticleForGoogleDoc(doc_id, locale_code) {
+  return fetchGraphQL(
+    getArticleForGoogleDocQuery,
+    "MyQuery",
+    {"doc_id": doc_id, "locale_code": locale_code}
+  );
+}
+
+/*
+ * looks up an article by google doc ID and locale
+ */
+async function getArticleForGoogleDoc(doc_id, locale_code) {
+  const { errors, data } = await fetchArticleForGoogleDoc(doc_id, locale_code);
+
+  if (errors) {
+    // handle those errors like a pro
+    console.error(errors);
+  }
+
+  // do something great with this precious data
+  console.log(data);
+  return data;
+}
+
+/*
 . * Returns metadata about the article, including its id, whether it was published
 . * headline and byline
 . */
-function getArticleMeta() {
+function hasuraGetArticle() {
   var returnValue = {
     status: "",
-    message: ""
+    message: "",
+    data: {}
   };
-
-  var scriptConfig = getScriptConfig();
-  var ACCESS_TOKEN = scriptConfig['ACCESS_TOKEN'];
-  var CONTENT_API = scriptConfig['CONTENT_API'];
-
-  if (ACCESS_TOKEN === null || CONTENT_API === null || ACCESS_TOKEN === undefined || CONTENT_API === undefined) {
-    returnValue.status = "error";
-    returnValue.message = "API not configured! Please ensure document is in the right folder structure and API is configured."
-    return returnValue;
-  }
 
   var documentID = DocumentApp.getActiveDocument().getId();
-
   var articleID = getArticleID();
-
-  var firstPublishedOn = null;
-  var lastPublishedOn = null;
-
-  // if there's no stored articleID on this document, try to find it by google document ID in webiny
-  if (articleID === null) {
-    var existingArticleData = getArticleByDocumentID(documentID);
-    if (existingArticleData && existingArticleData.status === "success") {
-
-      articleID = existingArticleData.id;
-      storeArticleID(existingArticleData.id);
-
-      firstPublishedOn = existingArticleData.firstPublishedOn;
-      lastPublishedOn = existingArticleData.lastPublishedOn;
-
-      var headline = getDocumentName();
-      storeHeadline(headline);
-
-      var googleDocs = existingArticleData.data.googleDocs;
-      var googleDocsInfo = {};
-      if (googleDocs) {
-        try {
-          googleDocsInfo = JSON.parse(googleDocs);
-
-          var locale = Object.keys(googleDocsInfo).find(key => googleDocsInfo[key] === documentID);
-          if (locale) {
-            storeSelectedLocaleName(locale);
-            var locales = getLocales();
-            var selectedLocaleID = null;
-            var selectedLocale = locales.find((l) => l.code === locale);
-            storeLocaleID(selectedLocale.id);
-          }
-
-        } catch(e) {
-          Logger.log("failed parsing googleDocs:" + e);
-        }
-      }
-    } else {
-      Logger.log("error finding article with this documentID:" + existingArticleData.message);
-    }
+  var locale = getSelectedLocaleName();
+  if (!locale) {
+    locale = "en-US"
   }
 
-  // first determine if the document is an article or a static page for the site
-  // this is based on which folder the document is in: 'pages' (static pages) or anything else (articles)
-  // in order to do this we need to use the Google Drive API
-  // which requires the "https://www.googleapis.com/auth/drive.readonly" scope
-  var driveFile = DriveApp.getFileById(documentID)
-  var fileParents = driveFile.getParents();
-  var isStaticPage = false;
-  while ( fileParents.hasNext() ) {
-    var folder = fileParents.next();
-    if (folder.getName() === "pages") {
-      isStaticPage = true;
-    }
-  }
-  var authorSlugsValue;
-  var authorSlugs = [];
-
-  var documentType = 'article';
-  if (isStaticPage) {
-    documentType = 'page';
-  }
-  storeDocumentType(documentType);
-
-  var locales = getLocales();
-  var selectedLocaleID = getLocaleID();
-  var selectedLocaleName = null;
-  if (selectedLocaleID) {
-    var selectedLocale = locales.find((locale) => locale.id === selectedLocaleID);
-    if (selectedLocale) {
-      selectedLocaleName = selectedLocale.code;
-      storeSelectedLocaleName(selectedLocaleName);
-    }
+  if (documentID && !articleID) {
+    console.log("looking up article by doc id:", documentID);
   }
 
-  var headline = getHeadline();
-  if (typeof(headline) === "undefined" || headline === null || headline.trim() === "") {
-    headline = getDocumentName();
-    storeHeadline(headline);
-  }
+  var article = getArticleForGoogleDoc(documentID, locale);
+  Logger.log("article: ", JSON.stringify(article));
 
-  var slug = getArticleSlug();
-  if (slug === null || slug === undefined || slug.match(/^\s+$/) || slug === '') {
-    slug = slugify(headline);
-    storeArticleSlug(slug);
-  }
+  returnValue.status = "success";
+  returnValue.message = "Retrieved article";
+  returnValue.data = article;
+  return returnValue;
 
-  var googleDocsInfo = {};
-  if (articleID !== null && articleID !== undefined) {
-    var latestArticle = getArticleDataByID(articleID);
+  // // var firstPublishedOn = null;
+  // // var lastPublishedOn = null;
 
-    if (latestArticle && latestArticle.status === "success") {
-      var latestArticleData = latestArticle.data;
-      firstPublishedOn = latestArticleData.firstPublishedOn;
-      lastPublishedOn = latestArticleData.lastPublishedOn;
+  // // // if there's no stored articleID on this document, try to find it by google document ID in webiny
+  // // if (articleID === null) {
+  // //   var existingArticleData = getArticleByDocumentID(documentID);
+  // //   if (existingArticleData && existingArticleData.status === "success") {
 
-      if (latestArticleData.published !== undefined && latestArticleData.published !== null) {
-        storeIsPublished(latestArticleData.published);
-      }
+  // //     articleID = existingArticleData.id;
+  // //     storeArticleID(existingArticleData.id);
 
-      if (latestArticleData.googleDocs) {
-        try {
-          googleDocsInfo = JSON.parse(latestArticleData.googleDocs);
-        } catch(e) {
-          Logger.log("error parsing googleDocs json:", e);
-        }
-      }
+  // //     firstPublishedOn = existingArticleData.firstPublishedOn;
+  // //     lastPublishedOn = existingArticleData.lastPublishedOn;
 
-      if (latestArticleData.headline && latestArticleData.headline.values && latestArticleData.headline.values[0].value) {
-        storeHeadline(latestArticleData.headline.values[0].value);
-      }
-      if (latestArticleData.customByline) {
-        storeCustomByline(latestArticleData.customByline);
-      }
+  // //     var headline = getDocumentName();
+  // //     storeHeadline(headline);
 
-      if (latestArticleData.availableLocales) {
-        storeAvailableLocales(latestArticleData.availableLocales);
-      }
-      if (latestArticleData.authors) {
-        latestArticleData.authors.forEach(author => {
-            authorSlugs.push(author.slug);
-        });
-        if (authorSlugs.length > 0) {
-          authorSlugsValue = authorSlugs.join(' ');
-          storeAuthorSlugs(authorSlugsValue);
-        }
-      }
-      if (latestArticleData.category) {
-        storeCategoryID(latestArticleData.category.id);
-      }
-      if (latestArticleData.tags) {
-        storeTags(latestArticleData.tags);
-      }
-      if (latestArticleData.slug) {
-        storeArticleSlug(latestArticleData.slug);
-      }
+  // //     var googleDocs = existingArticleData.data.googleDocs;
+  // //     var googleDocsInfo = {};
+  // //     if (googleDocs) {
+  // //       try {
+  // //         googleDocsInfo = JSON.parse(googleDocs);
 
-      var seoData = {}
-      if (latestArticleData.searchTitle && latestArticleData.searchTitle.values && latestArticleData.searchTitle.values[0] && latestArticleData.searchTitle.values[0].value) {
-        seoData.searchTitle = latestArticleData.searchTitle.values[0].value;
-      }
-      if (latestArticleData.searchDescription && latestArticleData.searchDescription.values && latestArticleData.searchDescription.values[0] && latestArticleData.searchDescription.values[0].value) {
-        seoData.searchDescription = latestArticleData.searchDescription.values[0].value;
-      }
-      if (latestArticleData.facebookTitle && latestArticleData.facebookTitle.values && latestArticleData.facebookTitle.values[0] && latestArticleData.facebookTitle.values[0].value) {
-        seoData.facebookTitle = latestArticleData.facebookTitle.values[0].value;
-      }
-      if (latestArticleData.facebookDescription && latestArticleData.facebookDescription.values && latestArticleData.facebookDescription.values[0] && latestArticleData.facebookDescription.values[0].value) {
-        seoData.facebookDescription = latestArticleData.facebookDescription.values[0].value;
-      }
-      if (latestArticleData.twitterTitle && latestArticleData.twitterTitle.values && latestArticleData.twitterTitle.values[0] && latestArticleData.twitterTitle.values[0].value) {
-        seoData.twitterTitle = latestArticleData.twitterTitle.values[0].value;
-      }
-      if (latestArticleData.twitterDescription && latestArticleData.twitterDescription.values && latestArticleData.twitterDescription.values[0] && latestArticleData.twitterDescription.values[0].value) {
-        seoData.twitterDescription = latestArticleData.twitterDescription.values[0].value;
-      }
+  // //         var locale = Object.keys(googleDocsInfo).find(key => googleDocsInfo[key] === documentID);
+  // //         if (locale) {
+  // //           storeSelectedLocaleName(locale);
+  // //           var locales = getLocales();
+  // //           var selectedLocaleID = null;
+  // //           var selectedLocale = locales.find((l) => l.code === locale);
+  // //           storeLocaleID(selectedLocale.id);
+  // //         }
 
-      if (Object.values(seoData).length > 0) {
-        storeSEO(seoData);
-      }
-    } else {
-      Logger.log("getArticleMeta failed finding latestArticle: ", latestArticle)
-    }
-  }
+  // //       } catch(e) {
+  // //         Logger.log("failed parsing googleDocs:" + e);
+  // //       }
+  // //     }
+  // //   } else {
+  // //     Logger.log("error finding article with this documentID:" + existingArticleData.message);
+  // //   }
+  // // }
 
-  var published = getIsPublished()
-  // obviously it isn't published if we don't have a webiny article ID
-  if (articleID === null || articleID === undefined) {
-    published = false;
-  }
-  var publishingInfo = getPublishingInfo();
+  // // // first determine if the document is an article or a static page for the site
+  // // // this is based on which folder the document is in: 'pages' (static pages) or anything else (articles)
+  // // // in order to do this we need to use the Google Drive API
+  // // // which requires the "https://www.googleapis.com/auth/drive.readonly" scope
+  // // var driveFile = DriveApp.getFileById(documentID)
+  // // var fileParents = driveFile.getParents();
+  // // var isStaticPage = false;
+  // // while ( fileParents.hasNext() ) {
+  // //   var folder = fileParents.next();
+  // //   if (folder.getName() === "pages") {
+  // //     isStaticPage = true;
+  // //   }
+  // // }
+  // // var authorSlugsValue;
+  // // var authorSlugs = [];
 
-  var customByline = getCustomByline();
+  // // var documentType = 'article';
+  // // if (isStaticPage) {
+  // //   documentType = 'page';
+  // // }
+  // // storeDocumentType(documentType);
 
-  var articleAuthors = getAuthors();
-  var allAuthors = loadAuthorsFromDB();
-  if (allAuthors) {
-    storeAllAuthors(allAuthors);
-    allAuthors.forEach(author => {
-      const result = articleAuthors.find( ({ id }) => id === author.id );
-      if (result !== undefined) {
-        authorSlugs.push(author.slug);
-      }
-    });
-  }
+  // // var locales = getLocales();
+  // // var selectedLocaleID = getLocaleID();
+  // // var selectedLocaleName = null;
+  // // if (selectedLocaleID) {
+  // //   var selectedLocale = locales.find((locale) => locale.id === selectedLocaleID);
+  // //   if (selectedLocale) {
+  // //     selectedLocaleName = selectedLocale.code;
+  // //     storeSelectedLocaleName(selectedLocaleName);
+  // //   }
+  // // }
 
-  if (authorSlugs.length > 0) {
-    authorSlugsValue = authorSlugs.join(' ');
-    storeAuthorSlugs(authorSlugsValue);
-  }
+  // // var headline = getHeadline();
+  // // if (typeof(headline) === "undefined" || headline === null || headline.trim() === "") {
+  // //   headline = getDocumentName();
+  // //   storeHeadline(headline);
+  // // }
 
-  var categories = listCategories();
-  storeCategories(categories);
+  // // var slug = getArticleSlug();
+  // // if (slug === null || slug === undefined || slug.match(/^\s+$/) || slug === '') {
+  // //   slug = slugify(headline);
+  // //   storeArticleSlug(slug);
+  // // }
 
-  var categoryID = getCategoryID();
-  var categoryName = getNameForCategoryID(categories, categoryID);
+  // // var googleDocsInfo = {};
+  // // if (articleID !== null && articleID !== undefined) {
+  // //   var latestArticle = getArticleDataByID(articleID);
 
-  // always load the latest tags from webiny to avoid issues being out of sync
-  // FYI: I've run into problems when this isn't done (e.g. a dupe tag is created elsewhere, which could be likely when actual orgs use this
-  // or more likely, the document storage in Google Docs gets some data weird with new vs existing tags)
-  var allTags = loadTagsFromDB();
-  if (allTags) {
-    storeAllTags(allTags);
-  }
+  // //   if (latestArticle && latestArticle.status === "success") {
+  // //     var latestArticleData = latestArticle.data;
+  // //     firstPublishedOn = latestArticleData.firstPublishedOn;
+  // //     lastPublishedOn = latestArticleData.lastPublishedOn;
 
-  var articleTags = getTags();
+  // //     if (latestArticleData.published !== undefined && latestArticleData.published !== null) {
+  // //       storeIsPublished(latestArticleData.published);
+  // //     }
 
-  var seoData = getSEO();
+  // //     if (latestArticleData.googleDocs) {
+  // //       try {
+  // //         googleDocsInfo = JSON.parse(latestArticleData.googleDocs);
+  // //       } catch(e) {
+  // //         Logger.log("error parsing googleDocs json:", e);
+  // //       }
+  // //     }
 
-  var scriptConfig = getScriptConfig();
-  var publishUrl = scriptConfig['PUBLISH_URL']
-  var previewUrl = scriptConfig['PREVIEW_URL']
-  var previewSecret = scriptConfig['PREVIEW_SECRET'];
-  var accessToken = scriptConfig['ACCESS_TOKEN'];
-  var contentApi = scriptConfig['CONTENT_API'];
-  var awsAccessKey = scriptConfig['AWS_ACCESS_KEY_ID'];
-  var awsSecretKey = scriptConfig['AWS_SECRET_KEY'];
-  var awsBucket = scriptConfig['AWS_BUCKET'];
-  var republishUrl = scriptConfig['VERCEL_DEPLOY_HOOK_URL'];
+  // //     if (latestArticleData.headline && latestArticleData.headline.values && latestArticleData.headline.values[0].value) {
+  // //       storeHeadline(latestArticleData.headline.values[0].value);
+  // //     }
+  // //     if (latestArticleData.customByline) {
+  // //       storeCustomByline(latestArticleData.customByline);
+  // //     }
 
-  var availableLocales = getAvailableLocales();
+  // //     if (latestArticleData.availableLocales) {
+  // //       storeAvailableLocales(latestArticleData.availableLocales);
+  // //     }
+  // //     if (latestArticleData.authors) {
+  // //       latestArticleData.authors.forEach(author => {
+  // //           authorSlugs.push(author.slug);
+  // //       });
+  // //       if (authorSlugs.length > 0) {
+  // //         authorSlugsValue = authorSlugs.join(' ');
+  // //         storeAuthorSlugs(authorSlugsValue);
+  // //       }
+  // //     }
+  // //     if (latestArticleData.category) {
+  // //       storeCategoryID(latestArticleData.category.id);
+  // //     }
+  // //     if (latestArticleData.tags) {
+  // //       storeTags(latestArticleData.tags);
+  // //     }
+  // //     if (latestArticleData.slug) {
+  // //       storeArticleSlug(latestArticleData.slug);
+  // //     }
+
+  // //     var seoData = {}
+  // //     if (latestArticleData.searchTitle && latestArticleData.searchTitle.values && latestArticleData.searchTitle.values[0] && latestArticleData.searchTitle.values[0].value) {
+  // //       seoData.searchTitle = latestArticleData.searchTitle.values[0].value;
+  // //     }
+  // //     if (latestArticleData.searchDescription && latestArticleData.searchDescription.values && latestArticleData.searchDescription.values[0] && latestArticleData.searchDescription.values[0].value) {
+  // //       seoData.searchDescription = latestArticleData.searchDescription.values[0].value;
+  // //     }
+  // //     if (latestArticleData.facebookTitle && latestArticleData.facebookTitle.values && latestArticleData.facebookTitle.values[0] && latestArticleData.facebookTitle.values[0].value) {
+  // //       seoData.facebookTitle = latestArticleData.facebookTitle.values[0].value;
+  // //     }
+  // //     if (latestArticleData.facebookDescription && latestArticleData.facebookDescription.values && latestArticleData.facebookDescription.values[0] && latestArticleData.facebookDescription.values[0].value) {
+  // //       seoData.facebookDescription = latestArticleData.facebookDescription.values[0].value;
+  // //     }
+  // //     if (latestArticleData.twitterTitle && latestArticleData.twitterTitle.values && latestArticleData.twitterTitle.values[0] && latestArticleData.twitterTitle.values[0].value) {
+  // //       seoData.twitterTitle = latestArticleData.twitterTitle.values[0].value;
+  // //     }
+  // //     if (latestArticleData.twitterDescription && latestArticleData.twitterDescription.values && latestArticleData.twitterDescription.values[0] && latestArticleData.twitterDescription.values[0].value) {
+  // //       seoData.twitterDescription = latestArticleData.twitterDescription.values[0].value;
+  // //     }
+
+  // //     if (Object.values(seoData).length > 0) {
+  // //       storeSEO(seoData);
+  // //     }
+  // //   } else {
+  // //     Logger.log("hasuraGetArticle failed finding latestArticle: ", latestArticle)
+  // //   }
+  // // }
+
+  // // var published = getIsPublished()
+  // // // obviously it isn't published if we don't have a webiny article ID
+  // // if (articleID === null || articleID === undefined) {
+  // //   published = false;
+  // // }
+  // // var publishingInfo = getPublishingInfo();
+
+  // // var customByline = getCustomByline();
+
+  // // var articleAuthors = getAuthors();
+  // // var allAuthors = loadAuthorsFromDB();
+  // // if (allAuthors) {
+  // //   storeAllAuthors(allAuthors);
+  // //   allAuthors.forEach(author => {
+  // //     const result = articleAuthors.find( ({ id }) => id === author.id );
+  // //     if (result !== undefined) {
+  // //       authorSlugs.push(author.slug);
+  // //     }
+  // //   });
+  // // }
+
+  // // if (authorSlugs.length > 0) {
+  // //   authorSlugsValue = authorSlugs.join(' ');
+  // //   storeAuthorSlugs(authorSlugsValue);
+  // // }
+
+  // // var categories = listCategories();
+  // // storeCategories(categories);
+
+  // // var categoryID = getCategoryID();
+  // // var categoryName = getNameForCategoryID(categories, categoryID);
+
+  // // // always load the latest tags from webiny to avoid issues being out of sync
+  // // // FYI: I've run into problems when this isn't done (e.g. a dupe tag is created elsewhere, which could be likely when actual orgs use this
+  // // // or more likely, the document storage in Google Docs gets some data weird with new vs existing tags)
+  // // var allTags = loadTagsFromDB();
+  // // if (allTags) {
+  // //   storeAllTags(allTags);
+  // // }
+
+  // // var articleTags = getTags();
+
+  // // var seoData = getSEO();
+
+  // // var scriptConfig = getScriptConfig();
+  // // var publishUrl = scriptConfig['PUBLISH_URL']
+  // // var previewUrl = scriptConfig['PREVIEW_URL']
+  // // var previewSecret = scriptConfig['PREVIEW_SECRET'];
+  // // var accessToken = scriptConfig['ACCESS_TOKEN'];
+  // // var contentApi = scriptConfig['CONTENT_API'];
+  // // var awsAccessKey = scriptConfig['AWS_ACCESS_KEY_ID'];
+  // // var awsSecretKey = scriptConfig['AWS_SECRET_KEY'];
+  // // var awsBucket = scriptConfig['AWS_BUCKET'];
+  // // var republishUrl = scriptConfig['VERCEL_DEPLOY_HOOK_URL'];
+
+  // // var availableLocales = getAvailableLocales();
   
-  if (typeof(articleID) === "undefined" || articleID === null) {
+  // // if (typeof(articleID) === "undefined" || articleID === null) {
 
-    return {
-      accessToken: accessToken,
-      allAuthors: allAuthors,
-      allTags: allTags,
-      articleAuthors: articleAuthors,
-      articleID: null,
-      articleTags: articleTags,
-      authorSlugs: authorSlugsValue,
-      awsAccessKey: awsAccessKey,
-      awsSecretKey: awsSecretKey,
-      awsBucket: awsBucket,
-      availableLocales: null,
-      categories: categories,
-      categoryID: categoryID,
-      categoryName: categoryName,
-      contentApi: contentApi,
-      customByline: customByline,
-      documentType: documentType,
-      firstPublishedOn: null,
-      lastPublishedOn: null,
-      headline: headline,
-      localeID: null,
-      localeName: null,
-      locales: locales,
-      previewSecret: previewSecret,
-      previewUrl: previewUrl,
-      published: published,
-      publishingInfo: publishingInfo,
-      publishUrl: publishUrl,
-      seo: seoData,
-      slug: slug,
-      republishUrl: republishUrl
-    }
-  }
+  // //   return {
+  // //     accessToken: accessToken,
+  // //     allAuthors: allAuthors,
+  // //     allTags: allTags,
+  // //     articleAuthors: articleAuthors,
+  // //     articleID: null,
+  // //     articleTags: articleTags,
+  // //     authorSlugs: authorSlugsValue,
+  // //     awsAccessKey: awsAccessKey,
+  // //     awsSecretKey: awsSecretKey,
+  // //     awsBucket: awsBucket,
+  // //     availableLocales: null,
+  // //     categories: categories,
+  // //     categoryID: categoryID,
+  // //     categoryName: categoryName,
+  // //     contentApi: contentApi,
+  // //     customByline: customByline,
+  // //     documentType: documentType,
+  // //     firstPublishedOn: null,
+  // //     lastPublishedOn: null,
+  // //     headline: headline,
+  // //     localeID: null,
+  // //     localeName: null,
+  // //     locales: locales,
+  // //     previewSecret: previewSecret,
+  // //     previewUrl: previewUrl,
+  // //     published: published,
+  // //     publishingInfo: publishingInfo,
+  // //     publishUrl: publishUrl,
+  // //     seo: seoData,
+  // //     slug: slug,
+  // //     republishUrl: republishUrl
+  // //   }
+  // // }
 
-  var articleMetadata = {
-    accessToken: accessToken,
-    allAuthors: allAuthors,
-    allTags: allTags,
-    articleAuthors: articleAuthors,
-    articleID: articleID,
-    articleTags: articleTags,
-    authorSlugs: authorSlugsValue,
-    awsAccessKey: awsAccessKey,
-    awsSecretKey: awsSecretKey,
-    awsBucket: awsBucket,
-    availableLocales: availableLocales,
-    googleDocs: googleDocsInfo,
-    categories: categories,
-    categoryID: categoryID,
-    categoryName: categoryName,
-    contentApi: contentApi,
-    customByline: customByline,
-    documentType: documentType,
-    firstPublishedOn: firstPublishedOn,
-    lastPublishedOn: lastPublishedOn,
-    localeID: selectedLocaleID,
-    localeName: selectedLocaleName,
-    locales: locales,
-    previewUrl: previewUrl,
-    previewSecret: previewSecret,
-    headline: headline,
-    published: published,
-    publishingInfo: publishingInfo,
-    publishUrl: publishUrl,
-    slug: slug,
-    seo: seoData,
-    republishUrl: republishUrl
-  };
+  // // var articleMetadata = {
+  // //   accessToken: accessToken,
+  // //   allAuthors: allAuthors,
+  // //   allTags: allTags,
+  // //   articleAuthors: articleAuthors,
+  // //   articleID: articleID,
+  // //   articleTags: articleTags,
+  // //   authorSlugs: authorSlugsValue,
+  // //   awsAccessKey: awsAccessKey,
+  // //   awsSecretKey: awsSecretKey,
+  // //   awsBucket: awsBucket,
+  // //   availableLocales: availableLocales,
+  // //   googleDocs: googleDocsInfo,
+  // //   categories: categories,
+  // //   categoryID: categoryID,
+  // //   categoryName: categoryName,
+  // //   contentApi: contentApi,
+  // //   customByline: customByline,
+  // //   documentType: documentType,
+  // //   firstPublishedOn: firstPublishedOn,
+  // //   lastPublishedOn: lastPublishedOn,
+  // //   localeID: selectedLocaleID,
+  // //   localeName: selectedLocaleName,
+  // //   locales: locales,
+  // //   previewUrl: previewUrl,
+  // //   previewSecret: previewSecret,
+  // //   headline: headline,
+  // //   published: published,
+  // //   publishingInfo: publishingInfo,
+  // //   publishUrl: publishUrl,
+  // //   slug: slug,
+  // //   seo: seoData,
+  // //   republishUrl: republishUrl
+  // // };
 
-  return articleMetadata;
+  // return articleMetadata;
 }
 /**
  * 
@@ -1223,9 +1351,9 @@ function handlePublish(formObject) {
   Logger.log("publishArticle took: " + (t3 - t2) + " milliseconds.")
 
   var t4 = new Date().getTime();
-  var metadata = getArticleMeta();
+  var metadata = hasuraGetArticle();
   var t5 = new Date().getTime();
-  Logger.log("getArticleMeta took: " + (t5 - t4) + " milliseconds.")
+  Logger.log("hasuraGetArticle took: " + (t5 - t4) + " milliseconds.")
   response.data = metadata;
   return response;
 }
@@ -1239,7 +1367,7 @@ function handleUnpublish(formObject) {
 
   var response = unpublishArticle()
 
-  var metadata = getArticleMeta();
+  var metadata = hasuraGetArticle();
   response.data = metadata;
   return response;
 }
@@ -1265,7 +1393,7 @@ function handlePreview(formObject) {
     // open preview url in new window
     response.message += "<br><a href='" + fullPreviewUrl + "' target='_blank'>Preview article in new window</a>"
   }
-  var metadata = getArticleMeta();
+  var metadata = hasuraGetArticle();
   response.data = metadata;
 
   return response;

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -225,9 +225,19 @@
         configDiv.innerHTML = "<p class='error'>An error occurred. This may be due to being logged into multiple google accounts at once. Try opening this doc in an incognito window.</p>";
       }
 
+      // this assembles document properties and figures out the orgName based on folder hierarchy
+      // NO API CALLS
       function handleScriptConfig() {
          google.script.run.withFailureHandler(onFailureConfig).withSuccessHandler(onSuccessConfig).getScriptConfig();
       }
+
+      // called on submit of the config form in 'Admin Tools'
+      // this function `setScriptConfig` sets document properties only (they're returned by `getScriptConfig`)
+      // NO API CALLS
+      function handleScriptConfigSubmit(formObject) {
+        google.script.run.withSuccessHandler(displayConfigFormMessage).setScriptConfig(formObject);
+      }
+
 
       function handleSearch(formObject) {
         // hideSearchForm();
@@ -245,10 +255,7 @@
         if (window.confirm("Are you sure you want to do this? Any content in the linked article in this locale will be replaced by your document!")) { 
           hideLoading();
           console.log("associating article...", formObject);
-          // var articleId = $(this).data('article-id');
-          // console.log("articleId:", articleId);
 
-          // hideSearchForm();
           hideConfigForm();
 
           showLoading();
@@ -264,10 +271,6 @@
           isPublishedYesNo = "yes";
         }
         isPublishedSpan.innerHTML = isPublishedYesNo;
-      }
-
-      function handleScriptConfigSubmit(formObject) {
-        google.script.run.withSuccessHandler(displayConfigFormMessage).setScriptConfig(formObject);
       }
 
       function onSuccessMeta(data) {

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -163,7 +163,6 @@
       function getConfigAndDisplayForm() {
         hideSearchForm();
         showConfigForm();
-        // google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessConfigFormValues).getArticleMeta();
       }
 
       function showArticleForm() {
@@ -207,7 +206,7 @@
       }
 
       function onSuccessConfig(data) {
-        // hideLoading();
+        hideLoading();
         // var loadingDiv = document.getElementById('loading');
         if (data !== null && data !== {} && Object.keys(data).length > 0) {
           // loadingDiv.innerHTML = "<div class='success'>Configuration loaded.</div><hr/>"
@@ -352,7 +351,7 @@
         loadingDiv.innerHTML = '<p style="color: #48C774;">' + contents + "</p>";
         loadingDiv.style.display = "block";
 
-        handleMeta();
+        // handleMeta();
       }
       function onFailureDelete(error) {
         var loadingDiv = document.getElementById('loading');
@@ -378,7 +377,7 @@
         
         handleScriptConfig();
 
-        handleMeta();
+        // handleMeta();
       });
 
     </script>

--- a/Page.html
+++ b/Page.html
@@ -9,364 +9,13 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
 
     <script>
-      // flags for a subset of all locales
-      // I started with the ones I figured were the most likely; then grabbed more from this
-      // full locale list from https://github.com/ladjs/i18n-locales
-      // emoji flags from https://emojipedia.org/flags/
-      // I took all the major seeming english variants too: Australia, Canada, Ireland, GB, NZ, US, and South Africa
-      const emojiFor = {
-        "es": "🇪🇸",
-        "es-ES": "🇪🇸",
-        "fr": "🇫🇷",
-        "fr-FR": "🇫🇷",
-        "de": "🇩🇪",
-        "de-DE": "🇩🇪",
-        "pt-BR": "🇧🇷",
-        "pt": "🇵🇹",
-        "pt-PT": "🇵🇹",
-        "en": "🇬🇧",
-        "en-AU": "🇦🇺",
-        "en-CA": "🇨🇦",
-        "en-IE": "🇮🇪",
-        "en-GB": "🇬🇧",
-        "en-US": "🇺🇸",
-        "en-NZ": "🇳🇿",
-        "en-ZA": "🇿🇦",
-        "jp": "🇯🇵",
-        "zh": "🇨🇳",
-        "zh-CN": "🇨🇳",
-        "it": "🇮🇹",
-        "ru": "🇷🇺",
-        "ru-RU": "🇷🇺"
-      }
-
-      function onSuccessNewDoc(contents) {
-        var configDiv = document.getElementById('config');
-        configDiv.style.display = 'none';
-        var div = document.getElementById('output');
-        div.style.display = 'block';
-        div.innerHTML = "<a href='https://docs.google.com/document/d/" + contents.docID + "/edit?parentID=" + contents.parentID + "' target='_blank'>Open new doc</a>";
-      }
-
-      function onSuccess(contents) {
-        // first, switch the "published" text to say "No"
-        // because the headline and/or byline has likely changed.
-        setPublishedFlag(false);
-        var configDiv = document.getElementById('config');
-        configDiv.style.display = 'none';
-        var div = document.getElementById('loading');
-        div.style.display = 'block';
-        if (contents && contents.status && contents.status === "error") {
-          div.innerHTML = "<p class='error'>An error occurred: " + contents.message + '</p>';
+      function setValueOrDefault(elementId, value, defaultValue) {
+        var element = document.getElementById(elementId);
+        if (value !== undefined && value !== null && value !== "") {
+          element.value = value;
         } else {
-          div.innerHTML = '<p style="color: #48C774;">' + contents.message + "</p>";
+          element.value = defaultValue;
         }
-        handleMetaPreserveLoading();
-      }
-      
-      function onFailureMeta(error) {
-        var loadingDiv = document.getElementById('loading');
-        console.log("onFailureMeta error:", error);
-        loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + '</p>';
-      }
-
-      function onFailure(error) {
-        console.log("onFailure error:", error);
-        var loadingDiv = document.getElementById('loading');
-        loadingDiv.style.display = "block";
-        loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + "</p>";
-      }
-
-      function onSuccessPreviewPublish(response) {
-        var configDiv = document.getElementById('config');
-        configDiv.style.display = 'none';
-        var div = document.getElementById('loading');
-        div.style.display = 'block';
-        if (response && response.status && response.status === "error") {
-          div.innerHTML = "<p class='error'>An error occurred: " + response.message + '</p>';
-        } else {
-          div.innerHTML = '<p style="color: #48C774;">' + response.message + "</p>";
-        }
-        if (response.data) {
-          onSuccessMetaPreserveLoading(response.data);
-        }
-      }
-
-      function actualTitleOrDefault(title, defaultTitle) {
-        if (title === undefined || title === "" || title === null) {
-          return defaultTitle;
-        } else {
-          return title;
-        }
-      }
-
-      function onSuccessMetaPreserveLoading(data) {
-        console.log("onSuccessMeta data:", data);
-        var form = document.getElementById('article-meta-form');
-        form.style.display = "block";
-
-        if (data.documentType !== "article") {
-          var elements = document.getElementsByClassName('articles-only');
-          for (var i = 0; i < elements.length; i++) {
-            elements[i].style.display = "none";
-          };
-        }
-
-        var articleLocaleSelect = document.getElementById('article-locale');
-        if (data.localeName !== null && data.localeName !== undefined) {
-          articleLocaleSelect.style.display = 'none';
-          articleLocaleSelect.style.visibility = 'hidden';
-
-          var selectedLocaleDiv = document.getElementById('selected-locale');
-          selectedLocaleDiv.innerHTML = "<b>" + data.localeName + "</b>";
-
-        } else {
-
-          data.locales.forEach(locale => {
-            // first check if this option already exists; don't add dupes!
-            var selectorString = "#article-locale option[value='" + locale.id + "']";
-            if ( $(selectorString).length <= 0 ) {
-              var option = document.createElement("option");
-              if (locale.code) {
-                option.text = locale.code;
-              } else {
-                option.text = "(BUG) unknown locale";
-              }
-              // mark this locale as selected if it's the article's locale ID -or- is the default locale
-              if (data.localeID !== null && data.localeID === locale.id) {
-                option.selected = true;
-              } else if (locale.default) {
-                option.selected = true;
-              }
-              option.value = locale.id;
-
-              articleLocaleSelect.add(option);
-            }
-          })
-        }
-
-        if (data.documentType === 'article') {
-          var articleCategorySelect = document.getElementById('article-category');
-          var categoriesSorted = data.categories.sort(function (a, b) {
-            let comparison = 0;
-            let aTitle, bTitle;
-            if (a.title && a.title.values && a.title.values[0].value) {
-              aTitle = a.title.values[0].value;
-            }
-            if (b.title && b.title.values && b.title.values[0].value) {
-              bTitle = b.title.values[0].value;
-            }
-            if (aTitle > bTitle) {
-              comparison = 1;
-            } else if (aTitle < bTitle) {
-              comparison = -1;
-            }
-            return comparison;
-          });
-          categoriesSorted.forEach(category => {
-            // first check if this option already exists; don't add dupes!
-            var selectorString = "#article-category option[value='" + category.id + "']";
-            if ( $(selectorString).length <= 0 ) {
-              var option = document.createElement("option");
-              if (category.title && category.title.values && category.title.values[0].value) {
-                option.text = category.title.values[0].value;
-              } else {
-                option.text = "(BUG) unknown title";
-              }
-              option.value = category.id;
-
-              if (data.categoryID !== null && data.categoryID == category.id) {
-                option.selected = true;
-              }
-              articleCategorySelect.add(option);
-            }
-          })
-
-          var articleAuthorsSelect = document.getElementById('article-authors');
-          data.allAuthors.forEach(author => {
-            // first check if this option already exists; don't add dupes!
-            var selectorString = "#article-authors option[value='" + author.id + "']";
-            if ( $(selectorString).length <= 0 ) {
-              var option = document.createElement("option");
-              option.text = author.name;
-              option.value = author.id;
-
-              const result = data.articleAuthors.find( ({ id }) => id === author.id );
-              if (result !== undefined) {
-                option.selected = true;
-              }
-              articleAuthorsSelect.add(option);
-            }
-          })
-        }
-
-        var articleTagsSelect = document.getElementById('article-tags');
-
-        // first clear out previous tags - without doing this, we end up with dupes of all the tags
-        // after previewing or publishing
-        var length = articleTagsSelect.options.length;
-        for (i = length-1; i >= 0; i--) {
-          articleTagsSelect.options[i] = null;
-        }
-
-        data.allTags.forEach(tag => {
-          // first check if this option already exists; don't add dupes!
-          var selectorString = "#article-tags option[value='" + tag.id + "']";
-          if ( $(selectorString).length <= 0 ) {
-            var option = document.createElement("option");
-            if (tag.title && tag.title.values && tag.title.values[0].value) {
-              option.text = tag.title.values[0].value;
-            } else {
-              option.text = "(BUG) unknown title";
-            }
-            option.value = tag.id;
-
-            const result = data.articleTags.find( ({ id }) => id === tag.id );
-            if (result !== undefined) {
-              option.selected = true;
-            }
-            articleTagsSelect.add(option);
-          }
-        })
-
-        setPublishedFlag(data.published);
-
-        var articleHeadline = document.getElementById('article-headline');
-        articleHeadline.value = data.headline;
-
-        if (data.documentType === 'article') {
-          if (data.customByline !== null && data.customByline !== undefined) {
-            var articleCustomByline = document.getElementById('article-custom-byline');
-            articleCustomByline.value = data.customByline;
-          }
-        }
-
-        
-        var articleSearchTitle = document.getElementById('article-search-title');
-        if (data.seo.searchTitle !== undefined) {
-          articleSearchTitle.value = actualTitleOrDefault(data.seo.searchTitle, data.headline);
-        } else {
-          articleSearchTitle.value = data.headline;
-        }
-
-        if (data.seo.searchDescription !== undefined) {
-          var articleSearchDescription = document.getElementById('article-search-description');
-          articleSearchDescription.value = data.seo.searchDescription;
-        }
-
-        var articleFacebookTitle = document.getElementById('article-facebook-title');
-        if (data.seo.facebookTitle !== undefined) {
-          articleFacebookTitle.value = actualTitleOrDefault(data.seo.facebookTitle, data.headline);
-        } else {
-          articleFacebookTitle.value = data.headline;
-        }
-
-        if (data.seo.facebookDescription !== undefined) {
-          var articleFacebookDescription = document.getElementById('article-facebook-description');
-          articleFacebookDescription.value = data.seo.facebookDescription;
-        }
-
-        var articleTwitterTitle = document.getElementById('article-twitter-title');
-        if (data.seo.twitterTitle !== undefined) {
-          articleTwitterTitle.value = actualTitleOrDefault(data.seo.twitterTitle, data.headline);
-        } else {
-          articleTwitterTitle.value = data.headline;
-        }
-
-        if (data.seo.twitterDescription !== undefined) {
-          var articleTwitterDescription = document.getElementById('article-twitter-description');
-          articleTwitterDescription.value = data.seo.twitterDescription;
-        }
-
-        var previewUrl = document.getElementById('preview-url');
-        previewUrl.value = data.previewUrl;
-
-        var previewSecret = document.getElementById('preview-secret');
-        previewSecret.value = data.previewSecret;
-
-        var slugDiv = document.getElementById('slug');
-        slugDiv.innerHTML = data.slug;
-
-        if (data.documentType === 'article') {
-          $('#article-authors').select2({
-            width: 'resolve',
-          });
-
-          $('#article-tags').select2({
-            width: 'resolve',
-            tags: true,
-            createTag: function (params) {
-              var term = $.trim(params.term);
-
-              if (term === '') {
-                return null;
-              }
-
-              return {
-                id: term,
-                text: term,
-                newTag: true // add additional parameters
-              }
-            }
-          });
-        }
-
-        var buttonsDivBottom = document.getElementById('action-buttons-bottom')
-        buttonsDivBottom.style.display = "inline";
-        var buttonsDivTop = document.getElementById('action-buttons-top')
-        buttonsDivTop.style.display = "inline";
-
-        // if (data.firstPublishedOn !== null && typeof(data.firstPublishedOn) !== 'undefined') {
-        //   var firstPubDiv = document.getElementById('first-published');
-        //   var localisedDate = new Date(data.firstPublishedOn).toLocaleString();
-        //   firstPubDiv.innerHTML = localisedDate;
-        // }
-
-        // if (data.lastPublishedOn !== null && typeof(data.lastPublishedOn) !== 'undefined') {
-        //   var lastPubDiv = document.getElementById('last-published');
-        //   var localisedDate = new Date(data.lastPublishedOn).toLocaleString();
-        //   lastPubDiv.innerHTML = localisedDate;
-        // }
-
-        if (data.googleDocs !== null && data.googleDocs !== undefined) {
-          var editDiv = document.getElementById('edit-links');
-          editDiv.innerHTML = ""; // blank this out to prevent subsequent publish calls to duplicate links
-
-          var createLinks = [];
-          var editLinks = [];
-          var createLocales = data.locales.map(locale=>locale.code);
-          var existingLocales = Object.keys(data.googleDocs);
-
-          createLocales = createLocales.filter(function(item) {
-            return !existingLocales.includes(item); 
-          })
-
-          $.each( data.googleDocs, function( locale, docID ) {
-            var emojiFlag = emojiFor[locale];
-            if (locale !== data.localeName) {
-              editLinks.push("<li><a target='_blank' href='https://docs.google.com/document/d/" + docID + "/edit'>" + emojiFlag + locale + "</a></li>")
-            }
-          });
-
-          $.each(createLocales, function( index, locale ) {
-            var emojiFlag = emojiFor[locale];
-            createLinks.push("<li><a onclick='createNewDoc(\"" + locale + "\");'>" + emojiFlag + locale + "</li>");
-          });
-
-          if (createLinks.length > 0) {
-            editDiv.innerHTML = "<p><b>Create new translation:</b></p><ul>" + createLinks.join("")+ "</ul>";
-          }
-          if (editLinks.length > 0) {
-            editDiv.innerHTML += "<p><b>Existing translations:</b></p><ul>" + editLinks.join("")+ "</ul>";
-          }
-        }
-      }
-
-      function onSuccessMeta(data) {
-        var loadingDiv = document.getElementById('loading');
-        loadingDiv.style.display = "none";
-
-        onSuccessMetaPreserveLoading(data);
       }
 
       function setPublishedFlag(value) {
@@ -401,88 +50,170 @@
         }
         // isPublishedSpan.innerHTML = isPublishedYesNo;
       }
-
-      // function onSuccessConfig(data) {
-      //   // hideLoading();
-      //   var loadingDiv = document.getElementById('loading');
-      //   if (data !== null && data !== {} && Object.keys(data).length > 0) {
-      //     loadingDiv.innerHTML = "<div class='success'>Loading publishing tools...</div><hr/>"
-      //     hideConfigForm();
-      //   } else {
-      //     showConfigForm();
-      //     loadingDiv.innerHTML = "<div class='error'>No script config found. Fill in the form to use publishing tools.</div><hr/>"
-      //   }
-      // }
-
-      // function onFailureConfig(error) {
-      //   var configDiv = document.getElementById('loading');
-      //   configDiv.innerHTML = "<p class='error'>An error occurred. This may be due to being logged into multiple google accounts at once. Try opening this doc in an incognito window.</p>";
-      // }
-
-      function createNewDoc(locale) {
-         google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessNewDoc).createNewDoc(locale);
-      }
-      // function handleScriptConfig() {
-      //    google.script.run.withFailureHandler(onFailureConfig).withSuccessHandler(onSuccessConfig).getScriptConfig();
-      // }
-
-      function handleMetaPreserveLoading() {
-         google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessMetaPreserveLoading).getArticleMeta();
-      }
-
-      function handleMeta() {
-         google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessMeta).getArticleMeta();
-      }
-
-      function handleClick(formObject) {
-        var form = document.getElementById('article-meta-form');
-        form.style.display = "none";
+      function onSuccessGetArticle(contents) {
+        console.log(contents);
 
         var configDiv = document.getElementById('config');
-        configDiv.style.display = "none";
-
-        var loadingDiv = document.getElementById('loading');
-        loadingDiv.style.display = "block";
-
-        if (formObject.submitted === "Preview") {
-          loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePreview(formObject);
-        } else if ( (formObject.submitted === "Publish") || (formObject.submitted === "Re-publish") ) {
-          loadingDiv.innerHTML = "<p class='gray'>Publishing article...</p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePublish(formObject);
+        configDiv.style.display = 'none';
+        var div = document.getElementById('loading');
+        div.style.display = 'block';
+        if (contents && contents.status && contents.status === "error") {
+          div.innerHTML = "<p class='error'>An error occurred: " + contents.message + '</p>';
         } else {
-          loadingDiv.innerHTML = "<p class='gray'>Unpublishing article...</p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handleUnpublish(formObject);
+          div.innerHTML = '<p style="color: #48C774;">' + contents.message + "</p>";
         }
+
+        var form = document.getElementById('article-form');
+        form.style.display = "block";
+
+        var articleData = contents.data.articles[0];
+        var translationData = articleData.article_translations[0];
+
+        var articleLocaleSelect = document.getElementById('article-locale');
+        contents.data.organization_locales.forEach(localeData => {
+          // first check if this option already exists; don't add dupes!
+          var selectorString = "#article-locale option[value='" + localeData.locale.code + "']";
+          if ( $(selectorString).length <= 0 ) {
+            var option = document.createElement("option");
+            if (localeData.locale.code) {
+              option.text = localeData.locale.code;
+            } else {
+              option.text = "(BUG) unknown locale";
+            }
+            // mark this locale as selected if it's the article's locale ID -or- is the default locale
+            // if (data.localeID !== null && data.localeID === locale.id) {
+            //   option.selected = true;
+            // } else if (locale.default) {
+            //   option.selected = true;
+            // }
+            option.value = localeData.locale.code;
+
+            articleLocaleSelect.add(option);
+          }
+        })
+        var articleCategorySelect = document.getElementById('article-category');
+        var categoriesSorted = contents.data.categories.sort(function (a, b) {
+          let comparison = 0;
+          let aTitle, bTitle;
+          if (a.category_translations && a.category_translations[0] && a.category_translations[0].title) {
+            aTitle = a.category_translations[0].title
+          }
+          if (b.category_translations && b.category_translations[0] && b.category_translations[0].title) {
+            bTitle = b.category_translations[0].title
+          }
+          if (aTitle > bTitle) {
+            comparison = 1;
+          } else if (aTitle < bTitle) {
+            comparison = -1;
+          }
+          return comparison;
+        });
+        categoriesSorted.forEach(category => {
+          // first check if this option already exists; don't add dupes!
+          var selectorString = "#article-category option[value='" + category.id + "']";
+          if ( $(selectorString).length <= 0 ) {
+            var option = document.createElement("option");
+            if (category.category_translations && category.category_translations[0] && category.category_translations[0].title) {
+              option.text = category.category_translations[0].title
+            } else {
+              option.text = "(BUG) unknown title";
+            }
+            option.value = category.id;
+
+            if (articleData.category && articleData.category.id !== null && articleData.category.id == category.id) {
+              option.selected = true;
+            }
+            articleCategorySelect.add(option);
+          }
+        })
+
+        var articleTagsSelect = document.getElementById('article-tags');
+
+        // first clear out previous tags - without doing this, we end up with dupes of all the tags
+        // after previewing or publishing
+        var length = articleTagsSelect.options.length;
+        for (i = length-1; i >= 0; i--) {
+          articleTagsSelect.options[i] = null;
+        }
+
+        contents.data.tags.forEach(tag => {
+          // first check if this option already exists; don't add dupes!
+          var selectorString = "#article-tags option[value='" + tag.id + "']";
+          if ( $(selectorString).length <= 0 ) {
+            var option = document.createElement("option");
+            if (tag.tag_translations && tag.tag_translations[0] && tag.tag_translations[0].title) {
+              option.text = tag.tag_translations[0].title;
+            } else {
+              option.text = "(BUG) unknown title";
+            }
+            option.value = tag.id;
+
+            const result = articleData.tag_articles.find( ({ tag_id }) => tag_id === tag.id );
+            if (result !== undefined) {
+              option.selected = true;
+            }
+            articleTagsSelect.add(option);
+          }
+        })
+
+        setPublishedFlag(translationData.published);
+
+        var articleHeadline = document.getElementById('article-headline');
+        articleHeadline.value = translationData.headline;
+
+        setValueOrDefault('article-custom-byline', translationData.custom_byline, "");
+        setValueOrDefault('article-search-title', translationData.search_title, translationData.headline);
+        setValueOrDefault('article-search-description', translationData.search_description, translationData.headline);
+        setValueOrDefault('article-facebook-title', translationData.facebook_title, translationData.headline);
+        setValueOrDefault('article-facebook-description', translationData.facebook_description, translationData.headline);
+        setValueOrDefault('article-twitter-title', translationData.twitter_title, translationData.headline);
+        setValueOrDefault('article-twitter-description', translationData.twitter_description, translationData.headline);
+
+        $('#article-authors').select2({
+          width: 'resolve',
+        });
+
+        $('#article-tags').select2({
+          width: 'resolve',
+          tags: true,
+          createTag: function (params) {
+            var term = $.trim(params.term);
+
+            if (term === '') {
+              return null;
+            }
+
+            return {
+              id: term,
+              text: term,
+              newTag: true // add additional parameters
+            }
+          }
+        });
       }
       
+      function onFailureGetArticle(error) {
+        console.log("onFailure error:", error);
+        var loadingDiv = document.getElementById('loading');
+        loadingDiv.style.display = "block";
+        loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + "</p>";
+      }
+
+      function handleGetArticle() {
+         google.script.run.withFailureHandler(onFailureGetArticle).withSuccessHandler(onSuccessGetArticle).hasuraGetArticle();
+      }
+
       window.onload = (function(){
-        var form = document.getElementById('article-meta-form');
+        var form = document.getElementById('article-form');
         form.style.display = "none";
-        // hideConfigForm();
 
         var buttonsDivBottom = document.getElementById('action-buttons-bottom')
         buttonsDivBottom.style.display = "none";
         var buttonsDivTop = document.getElementById('action-buttons-top')
         buttonsDivTop.style.display = "none";
 
-        // handleScriptConfig();
-
-        handleMeta();
-
-
+        handleGetArticle();
       });
-
-      // function displayConfigFormMessage(text) {
-      //   var configDiv = document.getElementById('loading');
-      //   configDiv.innerHTML = text;
-
-      //   hideConfigForm();
-      // }
-
-      // function handleScriptConfigSubmit(formObject) {
-      //   google.script.run.withSuccessHandler(displayConfigFormMessage).setScriptConfig(formObject);
-      // }
 
       // Prevent forms from submitting.
       function preventFormSubmit() {
@@ -493,10 +224,10 @@
           });
         }
       }
+
       window.addEventListener('load', preventFormSubmit);
-
-
     </script>
+
     <style>
       textarea {
         width: 100%;
@@ -511,9 +242,9 @@
       .button, button, input[type="button"] {
         min-width: 0 !important;
       }
-      </style>
-
+    </style>
   </head>
+
   <body>
     <a id='top' href="#"></a>
     <div id="sidebar-wrapper" class="sidebar branding-below">
@@ -523,8 +254,8 @@
 
       <div id="config"></div>
 
-      <div id="article-meta-form">
-        <form onsubmit="handleClick(this)">
+      <div id="article-form">
+        <form>
           <div class="block" id="action-buttons-top">
             <input type="submit" name="preview" id="preview-button-top" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="publish-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>

--- a/Page.html
+++ b/Page.html
@@ -161,6 +161,9 @@
         var articleHeadline = document.getElementById('article-headline');
         articleHeadline.value = translationData.headline;
 
+        var slugDiv = document.getElementById('slug');
+        slugDiv.innerHTML = articleData.slug;
+
         setValueOrDefault('article-custom-byline', translationData.custom_byline, "");
         setValueOrDefault('article-search-title', translationData.search_title, translationData.headline);
         setValueOrDefault('article-search-description', translationData.search_description, translationData.headline);

--- a/Page.html
+++ b/Page.html
@@ -40,16 +40,6 @@
         "ru-RU": "🇷🇺"
       }
 
-      function showConfigForm() {
-        var scriptForm = document.getElementById('script-config-form')
-        scriptForm.style.display = "block";
-      }
-
-      function hideConfigForm() {
-        var scriptForm = document.getElementById('script-config-form')
-        scriptForm.style.display = "none";
-      }
-
       function onSuccessNewDoc(contents) {
         var configDiv = document.getElementById('config');
         configDiv.style.display = 'none';
@@ -412,29 +402,29 @@
         // isPublishedSpan.innerHTML = isPublishedYesNo;
       }
 
-      function onSuccessConfig(data) {
-        // hideLoading();
-        var loadingDiv = document.getElementById('loading');
-        if (data !== null && data !== {} && Object.keys(data).length > 0) {
-          loadingDiv.innerHTML = "<div class='success'>Loading publishing tools...</div><hr/>"
-          hideConfigForm();
-        } else {
-          showConfigForm();
-          loadingDiv.innerHTML = "<div class='error'>No script config found. Fill in the form to use publishing tools.</div><hr/>"
-        }
-      }
+      // function onSuccessConfig(data) {
+      //   // hideLoading();
+      //   var loadingDiv = document.getElementById('loading');
+      //   if (data !== null && data !== {} && Object.keys(data).length > 0) {
+      //     loadingDiv.innerHTML = "<div class='success'>Loading publishing tools...</div><hr/>"
+      //     hideConfigForm();
+      //   } else {
+      //     showConfigForm();
+      //     loadingDiv.innerHTML = "<div class='error'>No script config found. Fill in the form to use publishing tools.</div><hr/>"
+      //   }
+      // }
 
-      function onFailureConfig(error) {
-        var configDiv = document.getElementById('loading');
-        configDiv.innerHTML = "<p class='error'>An error occurred. This may be due to being logged into multiple google accounts at once. Try opening this doc in an incognito window.</p>";
-      }
+      // function onFailureConfig(error) {
+      //   var configDiv = document.getElementById('loading');
+      //   configDiv.innerHTML = "<p class='error'>An error occurred. This may be due to being logged into multiple google accounts at once. Try opening this doc in an incognito window.</p>";
+      // }
 
       function createNewDoc(locale) {
          google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessNewDoc).createNewDoc(locale);
       }
-      function handleScriptConfig() {
-         google.script.run.withFailureHandler(onFailureConfig).withSuccessHandler(onSuccessConfig).getScriptConfig();
-      }
+      // function handleScriptConfig() {
+      //    google.script.run.withFailureHandler(onFailureConfig).withSuccessHandler(onSuccessConfig).getScriptConfig();
+      // }
 
       function handleMetaPreserveLoading() {
          google.script.run.withFailureHandler(onFailureMeta).withSuccessHandler(onSuccessMetaPreserveLoading).getArticleMeta();
@@ -469,30 +459,30 @@
       window.onload = (function(){
         var form = document.getElementById('article-meta-form');
         form.style.display = "none";
-        hideConfigForm();
+        // hideConfigForm();
 
         var buttonsDivBottom = document.getElementById('action-buttons-bottom')
         buttonsDivBottom.style.display = "none";
         var buttonsDivTop = document.getElementById('action-buttons-top')
         buttonsDivTop.style.display = "none";
 
-        handleScriptConfig();
+        // handleScriptConfig();
 
         handleMeta();
 
 
       });
 
-      function displayConfigFormMessage(text) {
-        var configDiv = document.getElementById('loading');
-        configDiv.innerHTML = text;
+      // function displayConfigFormMessage(text) {
+      //   var configDiv = document.getElementById('loading');
+      //   configDiv.innerHTML = text;
 
-        hideConfigForm();
-      }
+      //   hideConfigForm();
+      // }
 
-      function handleScriptConfigSubmit(formObject) {
-        google.script.run.withSuccessHandler(displayConfigFormMessage).setScriptConfig(formObject);
-      }
+      // function handleScriptConfigSubmit(formObject) {
+      //   google.script.run.withSuccessHandler(displayConfigFormMessage).setScriptConfig(formObject);
+      // }
 
       // Prevent forms from submitting.
       function preventFormSubmit() {
@@ -532,60 +522,6 @@
       <div class="block gray" id="loading">Loading...</div>
 
       <div id="config"></div>
-      <div id="script-config-form-output" class="block secondary"></div>
-      <form id="script-config-form" onsubmit="handleScriptConfigSubmit(this)">
-        <div class="block form-group">
-          <label for="access-token">
-            <b>Content API Access Token</b>
-          </label>
-          <input id="access-token" name="ACCESS_TOKEN" type="text" />
-        </div>
-        <div class="block form-group">
-          <label for="content-api">
-            <b>Content API URL</b>
-          </label>
-          <input id="content-api" name="CONTENT_API" type="text" />
-        </div>
-        <div class="block form-group">
-          <label for="preview-url">
-            <b>Preview Host URL</b>
-          </label>
-          <input id="preview-url" name="PREVIEW_URL" type="text" placeholder="http://localhost:3000/api/preview" />
-        </div>
-        <div class="block form-group">
-          <label for="preview-secret">
-            <b>Preview Secret Param</b>
-          </label>
-          <input id="preview-secret" name="PREVIEW_SECRET" type="text" />
-        </div>
-        <div class="block form-group">
-          <label for="aws-access-key">
-            <b>AWS Access Key ID</b>
-          </label>
-          <input id="aws-access-key" name="AWS_ACCESS_KEY_ID" type="text" />
-        </div>
-        <div class="block form-group">
-          <label for="aws-secret-key">
-            <b>AWS Secret Key</b>
-          </label>
-          <input id="aws-secret-key" name="AWS_SECRET_KEY" type="text" />
-        </div>
-        <div class="block form-group">
-          <label for="aws-bucket">
-            <b>AWS Bucket</b>
-          </label>
-          <input id="aws-bucket" name="AWS_BUCKET" type="text" />
-        </div>
-        <div class="block form-group">
-          <label for="deploy-hook">
-            <b>Vercel Deploy Hook</b>
-          </label>
-          <input id="deploy-hook" name="VERCEL_DEPLOY_HOOK_URL" type="text" />
-        </div>
-        <div class="block">
-          <button class="blue">Save Config</button>
-        </div>
-      </form>
 
       <div id="article-meta-form">
         <form onsubmit="handleClick(this)">


### PR DESCRIPTION
Closes #197 

This PR replaces the function "getArticleMeta" and all related code (hopefully - I'll do a bigger sweep of the code when I've gotten all the functionality done) with a version backed by Hasura:

1. opening the "Publishing Tools" sidebar sends a request to look up article data based on the google doc ID and locale
2. this uses the new tables I added this morning that link an article with a google document in Hasura 
3. the following article data is requested: translations of content, slug, tags, authors and category
4. additional data: locales for the org, all categories, all tags, all authors (to populate various select menus)
5. the data is filled into the sidebar form elements where appropriate

Note: this is the first of many PRs for porting the sidebar publishing tools to Hasura. This is complicated so I'm trying to do it step by step. I'm also deleting as much code as possible in an effort to clean things up and keep it all straightforward. You can't currently do anything other than open the sidebar, see the data, and select a tag at the moment. Publishing buttons, preview, translate tools all coming soon.

To test:

because I haven't written the code to save into Hasura yet, you have to use this particular google doc that I've setup data for: "Here’s how Philadelphia public schools will operate this fall"

* Open [the script editor](https://script.google.com/a/newscatalyst.org/d/1ILURq69o3cYUy6k1n1X6HwxdMfl9xWNhILYuZxgLfeblb3IR15WCMZSj/edit)
* Run > Test as add-on... -> select the one option and [Test]
* Open the Publishing Tools Sidebar
* Hopefully, see the data (currently authors are blank; tags aren't assigned; custom byline is blank; the rest are set)

<img width="321" alt="Screen Shot 2021-02-15 at 10 47 27 am" src="https://user-images.githubusercontent.com/3397/107892739-3c675e80-6f7b-11eb-8289-a7c1c72e203a.png">
