### PR TITLE
Bugfix: pass value of page/article slug from form

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -673,6 +673,23 @@ const lookupArticleByGoogleDocQuery = `query MyQuery($document_id: String) {
   }
 }`;
 
+const insertPageGoogleDocsMutation = `mutation MyMutation($slug: String!, $locale_code: String!, $document_id: String, $url: String, $facebook_title: String, $facebook_description: String, $search_title: String, $search_description: String, $headline: String, $twitter_title: String, $twitter_description: String, $content: jsonb, $published: Boolean) {
+  insert_pages(objects: {page_google_documents: {data: {google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: document_id}}}, on_conflict: {constraint: page_google_documents_page_id_google_document_id_key, update_columns: google_document_id}}, slug: $slug, page_translations: {data: {published: $published, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, locale_code: $locale_code, headline: $headline, facebook_title: $facebook_title, facebook_description: $facebook_description, content: $content}}}) {
+    returning {
+      id
+      slug
+      page_google_documents {
+        id
+        google_document {
+          document_id
+          locale_code
+          url
+        }
+      }
+    }
+  }
+}`;
+
 const insertArticleGoogleDocMutation = `mutation MyMutation($locale_code: String!, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String) {
   insert_articles(objects: {article_translations: {data: {headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title}}, category_id: $category_id, slug: $slug, article_google_documents: {data: {google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: locale_code}}}, on_conflict: {constraint: article_google_documents_article_id_google_document_id_key, update_columns: google_document_id}}}, on_conflict: {constraint: articles_slug_category_id_organization_id_key, update_columns: updated_at}) {
     returning {
@@ -702,7 +719,33 @@ const insertArticleGoogleDocMutation = `mutation MyMutation($locale_code: String
   }
 }`;
 
+function insertPageGoogleDocs(data) {
+  var documentID = DocumentApp.getActiveDocument().getId();
+  var documentURL = DocumentApp.getActiveDocument().getUrl();
+  var content = getCurrentDocContents();
 
+  let pageData = {
+    "slug": data['article-slug'],
+    "document_id": documentID,
+    "url": documentURL,
+    "locale_code": data['article-locale'],
+    "headline": data['article-headline'],
+    "published": false,
+    "content": content,
+    "search_description": data['article-search-description'],
+    "search_title": data['article-search-title'],
+    "twitter_title": data['article-twitter-title'],
+    "twitter_description": data['article-twitter-description'],
+    "facebook_title": data['article-facebook-title'],
+    "facebook_description": data['article-facebook-description'],
+  };
+  Logger.log("page data:" + JSON.stringify(pageData));
+  return fetchGraphQL(
+    insertPageGoogleDocsMutation,
+    "MyMutation",
+    pageData
+  );
+}
 
 function insertArticleGoogleDocs(data) {
   var documentID = DocumentApp.getActiveDocument().getId();
@@ -731,6 +774,23 @@ function insertArticleGoogleDocs(data) {
     insertArticleGoogleDocMutation,
     "MyMutation",
     articleData
+  );
+}
+
+const insertAuthorPageMutation = `mutation MyMutation($page_id: Int!, $author_id: Int!) {
+  insert_author_pages(objects: {page_id: $page_id, author_id: $author_id}, on_conflict: {constraint: author_pages_page_id_author_id_key, update_columns: page_id}) {
+    affected_rows
+  }
+}`;
+
+async function hasuraCreateAuthorPage(authorId, pageId) {
+  return fetchGraphQL(
+    insertAuthorPageMutation,
+    "MyMutation",
+    {
+      page_id: pageId,
+      author_id: authorId
+    }
   );
 }
 
@@ -788,47 +848,78 @@ async function hasuraHandlePreview(formObject) {
     formObject['article-slug'] = slug;
   }
 
-  // insert or update article
-  var articleResult = await insertArticleGoogleDocs(formObject);
-  var articleID = articleResult.data.insert_articles.returning[0].id;
+  var data;
 
-  Logger.log("articleResult: " + JSON.stringify(articleResult))
-  if (articleID && formObject['article-tags']) {
-    var tags;
-    // ensure this is an array; selecting one in the UI results in a string being sent
-    if (typeof(formObject['article-tags']) === 'string') {
-      tags = [formObject['article-tags']]
-    } else {
-      tags = formObject['article-tags'];
-    }
-    Logger.log("Found tags: " + JSON.stringify(tags));
-    for (var index = 0; index < tags.length; index++) {
-      var tag = tags[index];
-      var slug = slugify(tag);
-      var result = await hasuraCreateTag({
-        slug: slug, 
-        title: tag,
-        article_id: articleID,
-        locale_code: formObject['article-locale']
-      });
-      Logger.log("create tag result:" + JSON.stringify(result))
-    }
-  }
+  var documentID = DocumentApp.getActiveDocument().getId();
+  var isStaticPage = isPage(documentID);
 
-  if (articleID && formObject['article-authors']) {
-    var authors;
-    // ensure this is an array; selecting one in the UI results in a string being sent
-    if (typeof(formObject['article-authors']) === 'string') {
-      authors = [formObject['article-authors']]
-    } else {
-      authors = formObject['article-authors'];
+  if (isStaticPage) {
+    // insert or update page
+    var data = await insertPageGoogleDocs(formObject);
+    Logger.log("pageResult: " + JSON.stringify(data))
+
+    var pageID = data.data.insert_pages.returning[0].id;
+
+    if (pageID && formObject['article-authors']) {
+      var authors;
+      // ensure this is an array; selecting one in the UI results in a string being sent
+      if (typeof(formObject['article-authors']) === 'string') {
+        authors = [formObject['article-authors']]
+      } else {
+        authors = formObject['article-authors'];
+      }
+      Logger.log("Found authors: " + JSON.stringify(authors));
+      for (var index = 0; index < authors.length; index++) {
+        var author = authors[index];
+        Logger.log("creating author page link: " + author + " -- " + pageID)
+        var result = await hasuraCreateAuthorPage(author, pageID);
+        Logger.log("create author page result:" + JSON.stringify(result))
+      }
     }
-    Logger.log("Found authors: " + JSON.stringify(authors));
-    for (var index = 0; index < authors.length; index++) {
-      var author = authors[index];
-      Logger.log("creating author article link: " + author + " -- " + articleID)
-      var result = await hasuraCreateAuthorArticle(author, articleID);
-      Logger.log("create article author result:" + JSON.stringify(result))
+
+  } else {
+    // insert or update article
+    var data = await insertArticleGoogleDocs(formObject);
+    var articleID = data.data.insert_articles.returning[0].id;
+
+    Logger.log("articleResult: " + JSON.stringify(data))
+    if (articleID && formObject['article-tags']) {
+      var tags;
+      // ensure this is an array; selecting one in the UI results in a string being sent
+      if (typeof(formObject['article-tags']) === 'string') {
+        tags = [formObject['article-tags']]
+      } else {
+        tags = formObject['article-tags'];
+      }
+      Logger.log("Found tags: " + JSON.stringify(tags));
+      for (var index = 0; index < tags.length; index++) {
+        var tag = tags[index];
+        var slug = slugify(tag);
+        var result = await hasuraCreateTag({
+          slug: slug, 
+          title: tag,
+          article_id: articleID,
+          locale_code: formObject['article-locale']
+        });
+        Logger.log("create tag result:" + JSON.stringify(result))
+      }
+    }
+
+    if (articleID && formObject['article-authors']) {
+      var authors;
+      // ensure this is an array; selecting one in the UI results in a string being sent
+      if (typeof(formObject['article-authors']) === 'string') {
+        authors = [formObject['article-authors']]
+      } else {
+        authors = formObject['article-authors'];
+      }
+      Logger.log("Found authors: " + JSON.stringify(authors));
+      for (var index = 0; index < authors.length; index++) {
+        var author = authors[index];
+        Logger.log("creating author article link: " + author + " -- " + articleID)
+        var result = await hasuraCreateAuthorArticle(author, articleID);
+        Logger.log("create article author result:" + JSON.stringify(result))
+      }
     }
   }
 
@@ -838,7 +929,7 @@ async function hasuraHandlePreview(formObject) {
 
   return {
     message: message,
-    data: articleResult,
+    data: data,
     status: "success"
   }
 }
@@ -1030,6 +1121,20 @@ async function getArticleForGoogleDoc(doc_id, locale_code) {
   return data;
 }
 
+function isPage(documentID) {
+  // determine if this is a static page or an article - it will usually be an article
+  var driveFile = DriveApp.getFileById(documentID)
+  var fileParents = driveFile.getParents();
+  var isStaticPage = false;
+  while ( fileParents.hasNext() ) {
+    var folder = fileParents.next();
+    if (folder.getName() === "pages") {
+      isStaticPage = true;
+    }
+  }
+  return isStaticPage;
+}
+
 /*
 . * Returns metadata about the article, including its id, whether it was published
 . * headline and byline
@@ -1041,23 +1146,15 @@ async function hasuraGetArticle() {
     data: {}
   };
 
-  var documentID = DocumentApp.getActiveDocument().getId();
-  Logger.log("documentID: " + documentID);
   var locale = getSelectedLocaleName();
   if (!locale) {
     locale = "en-US"
   }
 
-  // determine if this is a static page or an article - it will usually be an article
-  var driveFile = DriveApp.getFileById(documentID)
-  var fileParents = driveFile.getParents();
-  var isStaticPage = false;
-  while ( fileParents.hasNext() ) {
-    var folder = fileParents.next();
-    if (folder.getName() === "pages") {
-      isStaticPage = true;
-    }
-  }
+  var documentID = DocumentApp.getActiveDocument().getId();
+  Logger.log("documentID: " + documentID);
+
+  var isStaticPage = isPage(documentID);
 
   var data;
   try {

--- a/Code.js
+++ b/Code.js
@@ -628,9 +628,6 @@ async function fetchGraphQL(operationsDoc, operationName, variables) {
   var ORG_SLUG = scriptConfig['ACCESS_TOKEN'];
   var API_URL = scriptConfig['CONTENT_API'];
 
-  Logger.log("api url: " + API_URL)
-  Logger.log("variables: " + JSON.stringify(variables))
-  Logger.log("query: " + operationsDoc);
   var options = {
     method: 'POST',
     muteHttpExceptions: true,
@@ -845,6 +842,7 @@ async function hasuraHandlePreview(formObject) {
 
   if (slug === "" || slug === null || slug === undefined) {
     slug = slugify(headline)
+    Logger.log("no slug found, generated from headline: " + headline + " -> " + slug)
     formObject['article-slug'] = slug;
   }
 
@@ -916,9 +914,7 @@ async function hasuraHandlePreview(formObject) {
       Logger.log("Found authors: " + JSON.stringify(authors));
       for (var index = 0; index < authors.length; index++) {
         var author = authors[index];
-        Logger.log("creating author article link: " + author + " -- " + articleID)
         var result = await hasuraCreateAuthorArticle(author, articleID);
-        Logger.log("create article author result:" + JSON.stringify(result))
       }
     }
   }
@@ -1264,8 +1260,7 @@ function handlePreview(formObject) {
 . */
 function getCurrentDocContents() {
   var formattedElements = formatElements();
-  return formatElements;
-
+  return formattedElements;
 }
 
 

--- a/Page.html
+++ b/Page.html
@@ -211,6 +211,8 @@
 
         if (data) {
           var slugDiv = document.getElementById('slug');
+          var slugHiddenField = document.getElementById('article-slug');
+          slugHiddenField.value = data.slug;
           slugDiv.innerHTML = data.slug;
         }
 

--- a/Page.html
+++ b/Page.html
@@ -71,10 +71,20 @@
         var buttonsDivTop = document.getElementById('action-buttons-top')
         buttonsDivTop.style.display = "block";
 
-        var articleData = contents.data.articles[0];
-        var translationData; 
-        if (articleData) {
-         translationData = articleData.article_translations[0];
+        var data;
+        var translationData;
+        var documentType = "article";
+        if (contents.data.articles) {
+          if (contents.data.articles[0]) {
+            data = contents.data.articles[0]
+            translationData = data.article_translations[0];
+          }
+        } else if (contents.data.pages) {
+          documentType = "page"
+          if (contents.data.pages[0]) {
+            data = contents.data.pages[0]
+            translationData = data.page_translations[0];
+          }
         }
 
         var articleLocaleSelect = document.getElementById('article-locale');
@@ -99,41 +109,74 @@
             articleLocaleSelect.add(option);
           }
         })
-        var articleCategorySelect = document.getElementById('article-category');
-        var categoriesSorted = contents.data.categories.sort(function (a, b) {
-          let comparison = 0;
-          let aTitle, bTitle;
-          if (a.category_translations && a.category_translations[0] && a.category_translations[0].title) {
-            aTitle = a.category_translations[0].title
-          }
-          if (b.category_translations && b.category_translations[0] && b.category_translations[0].title) {
-            bTitle = b.category_translations[0].title
-          }
-          if (aTitle > bTitle) {
-            comparison = 1;
-          } else if (aTitle < bTitle) {
-            comparison = -1;
-          }
-          return comparison;
-        });
-        categoriesSorted.forEach(category => {
-          // first check if this option already exists; don't add dupes!
-          var selectorString = "#article-category option[value='" + category.id + "']";
-          if ( $(selectorString).length <= 0 ) {
-            var option = document.createElement("option");
-            if (category.category_translations && category.category_translations[0] && category.category_translations[0].title) {
-              option.text = category.category_translations[0].title
-            } else {
-              option.text = "(BUG) unknown title";
+        if (documentType === "article") {
+          var articleCategorySelect = document.getElementById('article-category');
+          var categoriesSorted = contents.data.categories.sort(function (a, b) {
+            let comparison = 0;
+            let aTitle, bTitle;
+            if (a.category_translations && a.category_translations[0] && a.category_translations[0].title) {
+              aTitle = a.category_translations[0].title
             }
-            option.value = category.id;
+            if (b.category_translations && b.category_translations[0] && b.category_translations[0].title) {
+              bTitle = b.category_translations[0].title
+            }
+            if (aTitle > bTitle) {
+              comparison = 1;
+            } else if (aTitle < bTitle) {
+              comparison = -1;
+            }
+            return comparison;
+          });
+          categoriesSorted.forEach(category => {
+            // first check if this option already exists; don't add dupes!
+            var selectorString = "#article-category option[value='" + category.id + "']";
+            if ( $(selectorString).length <= 0 ) {
+              var option = document.createElement("option");
+              if (category.category_translations && category.category_translations[0] && category.category_translations[0].title) {
+                option.text = category.category_translations[0].title
+              } else {
+                option.text = "(BUG) unknown title";
+              }
+              option.value = category.id;
 
-            if (articleData && articleData.category && articleData.category.id !== null && articleData.category.id == category.id) {
-              option.selected = true;
+              if (articleData && articleData.category && articleData.category.id !== null && articleData.category.id == category.id) {
+                option.selected = true;
+              }
+              articleCategorySelect.add(option);
             }
-            articleCategorySelect.add(option);
+          })
+
+          var articleTagsSelect = document.getElementById('article-tags');
+
+          // first clear out previous tags - without doing this, we end up with dupes of all the tags
+          // after previewing or publishing
+          var length = articleTagsSelect.options.length;
+          for (i = length-1; i >= 0; i--) {
+            articleTagsSelect.options[i] = null;
           }
-        })
+
+          contents.data.tags.forEach(tag => {
+            // first check if this option already exists; don't add dupes!
+            var selectorString = "#article-tags option[value='" + tag.slug + "']";
+            if ( $(selectorString).length <= 0 ) {
+              var option = document.createElement("option");
+              if (tag.tag_translations && tag.tag_translations[0] && tag.tag_translations[0].title) {
+                option.text = tag.tag_translations[0].title;
+              } else {
+                option.text = "(BUG) unknown title";
+              }
+              option.value = tag.slug;
+
+              if (articleData) {
+                const result = articleData.tag_articles.find( ({ tag_id }) => tag_id === tag.id );
+                if (result !== undefined) {
+                  option.selected = true;
+                }
+              }
+              articleTagsSelect.add(option);
+            }
+          })
+        }
 
         var articleAuthorSelect = document.getElementById('article-authors');
         contents.data.authors.forEach(author => {
@@ -148,49 +191,25 @@
             }
             option.value = author.id;
 
-            if (articleData && articleData.author_articles) {
-              console.log("looking for author with id " + author.id + " in ", articleData.author_articles)
-              var foundAuthor = articleData.author_articles.find( (aa) => aa.author.id === author.id);
+            var authorJoinData;
+            if (data && data.author_articles) {
+              authorJoinData = data.author_articles;
+            } else if (data && data.author_pages) {
+              authorJoinData = data.author_pages;
+            }
+            if (authorJoinData !== undefined) {
+              console.log("looking for author with id " + author.id + " in ", authorJoinData)
+              var foundAuthor = authorJoinData.find( (aa) => aa.author.id === author.id);
               if (foundAuthor) {
                 console.log("foundAuthor:", foundAuthor);
                 option.selected = true;
               }
             }
-            articleAuthorSelect.add(option);
           }
-        })
-        var articleTagsSelect = document.getElementById('article-tags');
-
-        // first clear out previous tags - without doing this, we end up with dupes of all the tags
-        // after previewing or publishing
-        var length = articleTagsSelect.options.length;
-        for (i = length-1; i >= 0; i--) {
-          articleTagsSelect.options[i] = null;
-        }
-
-        contents.data.tags.forEach(tag => {
-          // first check if this option already exists; don't add dupes!
-          var selectorString = "#article-tags option[value='" + tag.slug + "']";
-          if ( $(selectorString).length <= 0 ) {
-            var option = document.createElement("option");
-            if (tag.tag_translations && tag.tag_translations[0] && tag.tag_translations[0].title) {
-              option.text = tag.tag_translations[0].title;
-            } else {
-              option.text = "(BUG) unknown title";
-            }
-            option.value = tag.slug;
-
-            if (articleData) {
-              const result = articleData.tag_articles.find( ({ tag_id }) => tag_id === tag.id );
-              if (result !== undefined) {
-                option.selected = true;
-              }
-            }
-            articleTagsSelect.add(option);
-          }
+          articleAuthorSelect.add(option);
         })
 
-        if (articleData) {
+        if (data) {
           var slugDiv = document.getElementById('slug');
           slugDiv.innerHTML = articleData.slug;
         }
@@ -202,14 +221,12 @@
           articleHeadline.value = translationData.headline;
 
           setValueOrDefault('article-custom-byline', translationData.custom_byline, "");
-          setValueOrDefault('article-search-title', translationData.search_title, translationData.headline);
-          setValueOrDefault('article-search-description', translationData.search_description, translationData.headline);
-          setValueOrDefault('article-facebook-title', translationData.facebook_title, translationData.headline);
-          setValueOrDefault('article-facebook-description', translationData.facebook_description, translationData.headline);
-          setValueOrDefault('article-twitter-title', translationData.twitter_title, translationData.headline);
-          setValueOrDefault('article-twitter-description', translationData.twitter_description, translationData.headline);
-          setValueOrDefault('article-slug', articleData.slug, "");
-
+          setValueOrDefault('article-search-title', translationData.search_title, translationData.search_title);
+          setValueOrDefault('article-search-description', translationData.search_description, translationData.search_description);
+          setValueOrDefault('article-facebook-title', translationData.facebook_title, translationData.facebook_title);
+          setValueOrDefault('article-facebook-description', translationData.facebook_description, translationData.facebook_description);
+          setValueOrDefault('article-twitter-title', translationData.twitter_title, translationData.twitter_title);
+          setValueOrDefault('article-twitter-description', translationData.twitter_description, translationData.twitter_description);
         }
 
         $('#article-authors').select2({

--- a/Page.html
+++ b/Page.html
@@ -139,7 +139,7 @@
               }
               option.value = category.id;
 
-              if (articleData && articleData.category && articleData.category.id !== null && articleData.category.id == category.id) {
+              if (data && data.category && data.category.id !== null && data.category.id == category.id) {
                 option.selected = true;
               }
               articleCategorySelect.add(option);
@@ -167,8 +167,8 @@
               }
               option.value = tag.slug;
 
-              if (articleData) {
-                const result = articleData.tag_articles.find( ({ tag_id }) => tag_id === tag.id );
+              if (data) {
+                const result = data.tag_articles.find( ({ tag_id }) => tag_id === tag.id );
                 if (result !== undefined) {
                   option.selected = true;
                 }
@@ -211,7 +211,7 @@
 
         if (data) {
           var slugDiv = document.getElementById('slug');
-          slugDiv.innerHTML = articleData.slug;
+          slugDiv.innerHTML = data.slug;
         }
 
         if (translationData) {
@@ -273,8 +273,13 @@
           div.innerHTML = "<p class='error'>An error occurred: " + JSON.stringify(response.data.errors) + '</p>';
         } else {
           div.innerHTML = '<p style="color: #48C774;">' + response.message + "</p>";
-          console.log("article ID:", response.data.data.insert_articles.returning[0].id)
+          if (response.data.data.insert_articles) {
+            console.log("article ID:", response.data.data.insert_articles.returning[0].id)
+          } else if (response.data.data.insert_pages) {
+            console.log("page ID:", response.data.data.insert_pages.returning[0].id)
+          }
         }
+
         var form = document.getElementById('article-form');
         form.style.display = "block";
       }


### PR DESCRIPTION
Noticed this while working on https://github.com/news-catalyst/next-tinynewsdemo/issues/326

the slug value should stored in a hidden field in the form so we're not regenerating it every save. small code change - i had added the hidden field in a prior PR but forgot to set the value :-/ 