### PR TITLE
Feature/publish page

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -671,7 +671,7 @@ const lookupArticleByGoogleDocQuery = `query MyQuery($document_id: String) {
 }`;
 
 const insertPageGoogleDocsMutation = `mutation MyMutation($slug: String!, $locale_code: String!, $document_id: String, $url: String, $facebook_title: String, $facebook_description: String, $search_title: String, $search_description: String, $headline: String, $twitter_title: String, $twitter_description: String, $content: jsonb, $published: Boolean) {
-  insert_pages(objects: {page_google_documents: {data: {google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: document_id}}}, on_conflict: {constraint: page_google_documents_page_id_google_document_id_key, update_columns: google_document_id}}, slug: $slug, page_translations: {data: {published: $published, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, locale_code: $locale_code, headline: $headline, facebook_title: $facebook_title, facebook_description: $facebook_description, content: $content}}}) {
+  insert_pages(objects: {page_google_documents: {data: {google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: document_id}}}, on_conflict: {constraint: page_google_documents_page_id_google_document_id_key, update_columns: google_document_id}}, slug: $slug, page_translations: {data: {published: $published, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, locale_code: $locale_code, headline: $headline, facebook_title: $facebook_title, facebook_description: $facebook_description, content: $content}}}, on_conflict: {constraint: pages_slug_organization_id_key, update_columns: updated_at}) {
     returning {
       id
       slug
@@ -766,7 +766,6 @@ function insertArticleGoogleDocs(data) {
     "facebook_description": data['article-facebook-description'],
     "custom_byline": data['article-custom-byline'],
   };
-  Logger.log("article data:" + JSON.stringify(articleData));
   return fetchGraphQL(
     insertArticleGoogleDocMutation,
     "MyMutation",
@@ -889,6 +888,7 @@ async function hasuraHandlePublish(formObject) {
     documentType = "article";
     // insert or update article
     var data = await insertArticleGoogleDocs(formObject);
+    Logger.log("data: " + JSON.stringify(data))
     var articleID = data.data.insert_articles.returning[0].id;
     var categorySlug = data.data.insert_articles.returning[0].category.slug;
     var articleSlug = data.data.insert_articles.returning[0].slug;

--- a/Page.html
+++ b/Page.html
@@ -198,10 +198,8 @@
               authorJoinData = data.author_pages;
             }
             if (authorJoinData !== undefined) {
-              console.log("looking for author with id " + author.id + " in ", authorJoinData)
               var foundAuthor = authorJoinData.find( (aa) => aa.author.id === author.id);
               if (foundAuthor) {
-                console.log("foundAuthor:", foundAuthor);
                 option.selected = true;
               }
             }
@@ -271,6 +269,7 @@
         configDiv.style.display = 'none';
         var div = document.getElementById('loading');
         div.style.display = 'block';
+
         if (response.data.errors) {
           div.innerHTML = "<p class='error'>An error occurred: " + JSON.stringify(response.data.errors) + '</p>';
         } else {
@@ -300,8 +299,8 @@
           loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
           google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePreview(formObject);
         } else if ( (formObject.submitted === "Publish") || (formObject.submitted === "Re-publish") ) {
-          loadingDiv.innerHTML = "<p class='gray'>Publishing article... TODO</p>"
-          // google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handlePublish(formObject);
+          loadingDiv.innerHTML = "<p class='gray'>Publishing article... </p>"
+          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(formObject);
         } else {
           loadingDiv.innerHTML = "<p class='gray'>Unpublishing article... TODO</p>"
           // google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).handleUnpublish(formObject);


### PR DESCRIPTION
similar to #218 this PR adds support for publishing pages. I had already done most of the work to support this in PR #218 and this one adds a constraint check to prevent dupe entries in the pages table.

I think we might want to allow editing of the page slug in the sidebar - I've ended up with an auto-generated "about-oaklyn" instead of the expected "about". I actually don't remember where we ended up on the whole slug issue, or if it should be handled differently for pages instead of articles.