### PR TITLE
Feature/display published info

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -724,6 +724,14 @@ const insertArticleGoogleDocMutation = `mutation MyMutation($locale_code: String
         locale_code
         published
       }
+      published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
+        article_translation {
+          id
+          first_published_at
+          last_published_at
+          locale_code
+        }
+      }
     }
   }
 }`;
@@ -1388,6 +1396,14 @@ const getArticleTranslationForIdAndLocale = `query MyQuery($doc_id: String!, $ar
     slug
     tag_translations(where: {locale_code: {_eq: $locale_code}}) {
       title
+    }
+  }
+  published_article_translations(where: {locale_code: {_eq: $locale_code}, article_id: {_eq: $article_id}}) {
+    article_translation {
+      id
+      first_published_at
+      last_published_at
+      locale_code
     }
   }
 }`

--- a/Code.js
+++ b/Code.js
@@ -691,10 +691,13 @@ const upsertPublishedArticleTranslationMutation = `mutation MyMutation($article_
   insert_published_article_translations(objects: {article_id: $article_id, article_translation_id: $article_translation_id, locale_code: $locale_code}, on_conflict: {constraint: published_article_translations_article_id_locale_code_key, update_columns: article_translation_id}) {
     affected_rows
     returning {
-      article_id
-      article_translation_id
-      id
-      locale_code
+      article_translation {
+        id
+        first_published_at
+        last_published_at
+        locale_code
+        article_id
+      }
     }
   }
 }`;
@@ -1016,7 +1019,12 @@ async function hasuraHandlePublish(formObject) {
 
     if (articleID) {
       var publishedArticleData = await upsertPublishedArticle(articleID, translationID, formObject['article-locale'])
-      Logger.log("Published article data: " + JSON.stringify(publishedArticleData));
+      if (publishedArticleData) {
+        Logger.log("Published article data: " + JSON.stringify(publishedArticleData));
+        Logger.log("Insert1: " + JSON.stringify(data.data.insert_articles.returning[0].published_article_translations));
+        data.data.insert_articles.returning[0].published_article_translations = publishedArticleData.data.insert_published_article_translations.returning;
+        Logger.log("Insert2: " + JSON.stringify(data.data.insert_articles.returning[0].published_article_translations));
+      }
     }
     Logger.log("articleSlug: " + articleSlug + " || articleResult: " + JSON.stringify(data));
     if (articleID && formObject['article-tags']) {

--- a/Page.html
+++ b/Page.html
@@ -9,6 +9,13 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
 
     <script>
+      // thanks stack overflow 
+      // https://stackoverflow.com/questions/8888491/how-do-you-display-javascript-datetime-in-12-hour-am-pm-format
+      function formatDate(dateString) {
+        var d = new Date(dateString);
+        return d.toLocaleString();
+      }
+
       function setValueOrDefault(elementId, value, defaultValue) {
         var element = document.getElementById(elementId);
         if (value !== undefined && value !== null && value !== "") {
@@ -16,6 +23,22 @@
         } else {
           element.value = defaultValue;
         }
+      }
+
+      function displayPublishedInfo(publishedInfo, translationData) {
+          var pubInfoDiv = document.getElementById("published-info");
+          var firstSpan = document.getElementById("first-published-at");
+          firstSpan.innerHTML = formatDate(publishedInfo.first_published_at);
+          var lastSpan = document.getElementById("last-published-at");
+          lastSpan.innerHTML = formatDate(publishedInfo.last_published_at);
+
+          var translationIdSpan = document.getElementById("translation-id");
+          if (translationData && publishedInfo.id === translationData.id) {
+            translationIdSpan.innerHTML = "This translation was published at:";
+          } else {
+            translationIdSpan.innerHTML = "Another translation with id " + publishedInfo.id + " was published at:";
+          }
+          pubInfoDiv.style.display = "block";
       }
 
       function setPublishedFlag(value) {
@@ -75,6 +98,7 @@
         var data;
         var googleDocs;
         var translationData;
+        var publishedInfo;
         var documentType = "article";
         var localeCode = contents.localeCode;
         if (contents.data.articles) {
@@ -87,6 +111,10 @@
           if (contents.data.article_google_documents) {
             googleDocs = contents.data.article_google_documents;
           }
+          if (contents.data.published_article_translations) {
+            publishedInfo = contents.data.published_article_translations[0].article_translation;
+            console.log("Pub Info: ", publishedInfo);
+          }
         } else if (contents.data.pages) {
           documentType = "page"
           if (contents.data.pages[0]) {
@@ -97,6 +125,9 @@
           }
         }
 
+        if (publishedInfo) {
+          displayPublishedInfo(publishedInfo, translationData);
+        }
         var articleLocaleSelect = document.getElementById('article-locale');
         contents.data.organization_locales.forEach(localeData => {
           // first check if this option already exists; don't add dupes!
@@ -316,6 +347,11 @@
               console.log("Published: ", translations[0].published);
               setPublishedFlag(translations[0].published);
             }
+            var publishedInfo = response.data.data.insert_articles.returning[0].published_article_translations;
+            console.log("publishedInfo:", publishedInfo);
+            if (publishedInfo && publishedInfo[0]) {
+              displayPublishedInfo(publishedInfo[0].article_translation, translations[0]);
+            }
 
           } else if (response.data && response.data.data && response.data.data.insert_pages) {
             console.log("page ID:", response.data.data.insert_pages.returning[0].id)
@@ -437,6 +473,9 @@
       input:invalid:required, textarea:invalid:required {
         border: 1px solid red;
       }
+      #published-info {
+        display: none;
+      }
 
     </style>
   </head>
@@ -549,6 +588,11 @@
             <input type="submit" name="preview" id="preview-button-bottom" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="publish-button-bottom" value="Publish" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="unpublish-button-bottom" value="Unpublish" onclick="this.form.submitted=this.value;"/>
+          </div>
+          <div class="block" id="published-info">
+            <div class="small" id="translation-id"></div>
+            <div class="small" style="width: 100%" id="published-info-first"><b>Initial:</b> <span id="first-published-at"></span></div>
+            <div class="small" style="width: 100%" id="published-info-last"><b>Updated:</b> <span id="last-published-at"></span></div>
           </div>
         </form>
       </div>


### PR DESCRIPTION
Relates to #231 

This PR adds retrieval and display of the article published data to the sidebar:

* on open, retrieves the last published version including first/last published dates
* if the current version is the most recent published version, display "This translation was published at:" plus dates
* if a previous version was published, display: "Another translation with id # was published at:" plus dates
* previewing a published article should change the text to read "Another translation.."
* publishing the same article should then update it to read "This translation was published at..."

right now this info is at the bottom of the publishing tools sidebar as I thought it should be out of the way. It could go elsewhere - I considered that bottom "Powered by News Catalyst" area as it's always visible without scrolling... 