### PR TITLE
Associate article, Hasura version

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -724,6 +724,14 @@ const insertArticleGoogleDocMutation = `mutation MyMutation($locale_code: String
         locale_code
         published
       }
+      published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
+        article_translation {
+          id
+          first_published_at
+          last_published_at
+          locale_code
+        }
+      }
     }
   }
 }`;
@@ -1388,6 +1396,14 @@ const getArticleTranslationForIdAndLocale = `query MyQuery($doc_id: String!, $ar
     slug
     tag_translations(where: {locale_code: {_eq: $locale_code}}) {
       title
+    }
+  }
+  published_article_translations(where: {locale_code: {_eq: $locale_code}, article_id: {_eq: $article_id}}) {
+    article_translation {
+      id
+      first_published_at
+      last_published_at
+      locale_code
     }
   }
 }`

--- a/Code.js
+++ b/Code.js
@@ -691,10 +691,13 @@ const upsertPublishedArticleTranslationMutation = `mutation MyMutation($article_
   insert_published_article_translations(objects: {article_id: $article_id, article_translation_id: $article_translation_id, locale_code: $locale_code}, on_conflict: {constraint: published_article_translations_article_id_locale_code_key, update_columns: article_translation_id}) {
     affected_rows
     returning {
-      article_id
-      article_translation_id
-      id
-      locale_code
+      article_translation {
+        id
+        first_published_at
+        last_published_at
+        locale_code
+        article_id
+      }
     }
   }
 }`;
@@ -1016,7 +1019,12 @@ async function hasuraHandlePublish(formObject) {
 
     if (articleID) {
       var publishedArticleData = await upsertPublishedArticle(articleID, translationID, formObject['article-locale'])
-      Logger.log("Published article data: " + JSON.stringify(publishedArticleData));
+      if (publishedArticleData) {
+        Logger.log("Published article data: " + JSON.stringify(publishedArticleData));
+        Logger.log("Insert1: " + JSON.stringify(data.data.insert_articles.returning[0].published_article_translations));
+        data.data.insert_articles.returning[0].published_article_translations = publishedArticleData.data.insert_published_article_translations.returning;
+        Logger.log("Insert2: " + JSON.stringify(data.data.insert_articles.returning[0].published_article_translations));
+      }
     }
     Logger.log("articleSlug: " + articleSlug + " || articleResult: " + JSON.stringify(data));
     if (articleID && formObject['article-tags']) {

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -27,12 +27,22 @@
         var articleId;
         var localeCode;
         
-        try {
+        if (data && data.data && data.data.articles && data.data.articles[0]) {
           articleId = data.data.articles[0].id;
-          localeCode = data.data.articles[0].article_google_documents[0].google_document.locale_code;
+          if (
+            data.data.articles[0] && 
+            data.data.articles[0].article_google_documents && 
+            data.data.articles[0].article_google_documents[0] && 
+            data.data.articles[0].article_google_documents[0].google_document) {
+              localeCode = data.data.articles[0].article_google_documents[0].google_document.locale_code;
+            }
+        }
+        if (articleId && localeCode) {
           google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessGetArticle).hasuraGetTranslations(articleId, localeCode);
-        } catch (err) {
-          console.error(err);
+        } else {
+          var div = document.getElementById('loading');
+          div.style.display = 'block';
+          div.innerHTML = data.message;
         }
       }
 
@@ -100,7 +110,6 @@
         if (googleDocs) {
           // loop over each locale available for this org
           contents.data.organization_locales.forEach( (orgLocale) => {
-            console.log("looking for doc in locale", orgLocale.locale.code);
             var foundLocaleDoc = false;
             // loop over each google doc associated with this article
             googleDocs.forEach( (doc) => {
@@ -131,20 +140,17 @@
           var existingDocItems = [];
           existingDocsOtherLocales.forEach(doc => {
             var item = "<a target='_new' href='" + doc.url + "'>" + doc.locale_code + "</a>";
-            console.log(item);
             existingDocItems.push(item)
           });
           existingTranslationsDiv.innerHTML = existingDocItems.join(', ');
         }
 
-        console.log("headline: ", headline);
         if (availableLocales.length > 0) {
           var availableLocaleLinks = [];
           availableLocales.forEach(availableLocale => {
             var item = "<a data-headline='" + headline + "' data-article-id='" + data.id + "' data-locale='" + availableLocale.code + "' onClick='handleCreateDoc(this)'>" + availableLocale.name + "</a>";
             availableLocaleLinks.push(item);
           });
-          console.log("availableLocale links: ", availableLocaleLinks);
           availableLocalesElement.innerHTML = availableLocaleLinks.join(', ');
         }
 
@@ -187,8 +193,6 @@
       }
 
       function onSuccessSearch(contents) {
-
-        console.log("contents.data:", contents.data);
 
         hideConfigForm();
         hideLoading();
@@ -249,7 +253,9 @@
         var div = document.getElementById('loading');
         div.style.display = 'block';
         console.log(contents);
-        div.innerHTML = '<p style="color: #48C774;">Success! This document is now associated with article ID#' + contents.id + '. You should now <input type="button" value="close" onclick="google.script.host.close()" /> this sidebar and open the Publishing Tools menu item to work with the article.</p>';
+        var articleId = contents.data.data.insert_article_google_documents.returning[0].article_id;
+        var articleSlug = contents.data.data.insert_article_google_documents.returning[0].article.slug;
+        div.innerHTML = '<p style="color: #48C774;">Success! This document is now associated with article ID#' + articleId + ' and slug "' + articleSlug + '". <input type="button" value="Close" onclick="google.script.host.close()" /> this sidebar and open the Publishing Tools menu item to work with the article.</p>';
       }
 
       function onFailure(error) {
@@ -398,7 +404,6 @@
       function handleAssociate(formObject) {
         if (window.confirm("Are you sure you want to do this? Any content in the linked article in this locale will be replaced by your document!")) { 
           hideLoading();
-          console.log("associating article...", formObject);
 
           hideConfigForm();
 

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -403,7 +403,7 @@
           hideConfigForm();
 
           showLoading();
-          google.script.run.withSuccessHandler(onSuccess).withFailureHandler(onFailure).associateArticle(formObject);
+          google.script.run.withSuccessHandler(onSuccess).withFailureHandler(onFailure).hasuraAssociateArticle(formObject);
         }
       }
 

--- a/Page.html
+++ b/Page.html
@@ -25,6 +25,128 @@
         }
       }
 
+      function displayCategories(categories, selectedCategory) {
+        var articleCategorySelect = document.getElementById('article-category');
+        var categoriesSorted = categories.sort(function (a, b) {
+          let comparison = 0;
+          let aTitle, bTitle;
+          if (a.category_translations && a.category_translations[0] && a.category_translations[0].title) {
+            aTitle = a.category_translations[0].title
+          }
+          if (b.category_translations && b.category_translations[0] && b.category_translations[0].title) {
+            bTitle = b.category_translations[0].title
+          }
+          if (aTitle > bTitle) {
+            comparison = 1;
+          } else if (aTitle < bTitle) {
+            comparison = -1;
+          }
+          return comparison;
+        });
+        categoriesSorted.forEach(category => {
+          // first check if this option already exists; don't add dupes!
+          var selectorString = "#article-category option[value='" + category.id + "']";
+          if ( $(selectorString).length <= 0 ) {
+            var option = document.createElement("option");
+            if (category.category_translations && category.category_translations[0] && category.category_translations[0].title) {
+              option.text = category.category_translations[0].title
+            } else {
+              option.text = "(BUG) unknown title";
+            }
+            option.value = category.id;
+
+            if (selectedCategory && selectedCategory.id !== null && selectedCategory.id == category.id) {
+              option.selected = true;
+            }
+            articleCategorySelect.add(option);
+          }
+        })
+      }
+
+      function displayTags(tags, articleTags) {
+        var articleTagsSelect = document.getElementById('article-tags');
+
+        // first clear out previous tags - without doing this, we end up with dupes of all the tags
+        // after previewing or publishing
+        var length = articleTagsSelect.options.length;
+        for (i = length-1; i >= 0; i--) {
+          articleTagsSelect.options[i] = null;
+        }
+
+        tags.forEach(tag => {
+          // first check if this option already exists; don't add dupes!
+          var selectorString = "#article-tags option[value='" + tag.slug + "']";
+          if ( $(selectorString).length <= 0 ) {
+            var option = document.createElement("option");
+            if (tag.tag_translations && tag.tag_translations[0] && tag.tag_translations[0].title) {
+              option.text = tag.tag_translations[0].title;
+            } else {
+              option.text = "(BUG) unknown title";
+            }
+            option.value = tag.slug;
+
+            if (articleTags) {
+              const result = articleTags.find( ({ tag_id }) => tag_id === tag.id );
+              if (result !== undefined) {
+                option.selected = true;
+              }
+            }
+            articleTagsSelect.add(option);
+          }
+        })
+      }
+
+      function displayLocales(locales, currentLocale) {
+        var articleLocaleSelect = document.getElementById('article-locale');
+        locales.forEach(localeData => {
+          // first check if this option already exists; don't add dupes!
+          var selectorString = "#article-locale option[value='" + localeData.locale.code + "']";
+          if ( $(selectorString).length <= 0 ) {
+            var option = document.createElement("option");
+            if (localeData.locale.code) {
+              option.text = localeData.locale.code;
+            } else {
+              option.text = "(BUG) unknown locale";
+            }
+            // mark this locale as selected if it's the article's locale ID -or- is the default locale
+            if (currentLocale === localeData.locale.code) {
+              option.selected = true;
+            }
+            option.value = localeData.locale.code;
+            articleLocaleSelect.add(option);
+          }
+        })
+      }
+
+      function displayAuthors(authors, articleAuthors) {
+        var articleAuthorSelect = document.getElementById('article-authors');
+        authors.forEach(author => {
+          // first check if this option already exists; don't add dupes!
+          var selectorString = "#article-authors option[value='" + author.id + "']";
+          if ( $(selectorString).length <= 0 ) {
+            var option = document.createElement("option");
+            if (author && author.name) {
+              option.text = author.name
+            } else {
+              option.text = "(BUG) unknown name";
+            }
+            option.value = author.id;
+
+            var authorJoinData;
+            if (articleAuthors) {
+              authorJoinData = articleAuthors;
+            }
+            if (authorJoinData !== undefined) {
+              var foundAuthor = authorJoinData.find( (aa) => aa.author.id === author.id);
+              if (foundAuthor) {
+                option.selected = true;
+              }
+            }
+          }
+          articleAuthorSelect.add(option);
+        })
+      }
+
       function displayPublishedInfo(publishedInfo, translationData) {
           var pubInfoDiv = document.getElementById("published-info");
           var firstSpan = document.getElementById("first-published-at");
@@ -81,14 +203,14 @@
         configDiv.style.display = 'none';
         var div = document.getElementById('loading');
         div.style.display = 'block';
+        var form = document.getElementById('article-form');
+        form.style.display = "block";
+
         if (contents && contents.status && contents.status === "error") {
           div.innerHTML = "<p class='error'>An error occurred: " + contents.message + '</p>';
         } else {
           div.innerHTML = '<p style="color: #48C774;">' + contents.message + "</p>";
         }
-
-        var form = document.getElementById('article-form');
-        form.style.display = "block";
 
         var buttonsDivBottom = document.getElementById('action-buttons-bottom')
         buttonsDivBottom.style.display = "block";
@@ -128,124 +250,14 @@
         if (publishedInfo) {
           displayPublishedInfo(publishedInfo, translationData);
         }
-        var articleLocaleSelect = document.getElementById('article-locale');
-        contents.data.organization_locales.forEach(localeData => {
-          // first check if this option already exists; don't add dupes!
-          var selectorString = "#article-locale option[value='" + localeData.locale.code + "']";
-          if ( $(selectorString).length <= 0 ) {
-            var option = document.createElement("option");
-            if (localeData.locale.code) {
-              option.text = localeData.locale.code;
-            } else {
-              option.text = "(BUG) unknown locale";
-            }
-            // mark this locale as selected if it's the article's locale ID -or- is the default locale
-            if (localeCode === localeData.locale.code) {
-              option.selected = true;
-            }
-            option.value = localeData.locale.code;
 
-            articleLocaleSelect.add(option);
-          }
-        })
+        displayLocales(contents.data.organization_locales, localeCode);
         
         if (documentType === "article") {
-          var articleCategorySelect = document.getElementById('article-category');
-          var categoriesSorted = contents.data.categories.sort(function (a, b) {
-            let comparison = 0;
-            let aTitle, bTitle;
-            if (a.category_translations && a.category_translations[0] && a.category_translations[0].title) {
-              aTitle = a.category_translations[0].title
-            }
-            if (b.category_translations && b.category_translations[0] && b.category_translations[0].title) {
-              bTitle = b.category_translations[0].title
-            }
-            if (aTitle > bTitle) {
-              comparison = 1;
-            } else if (aTitle < bTitle) {
-              comparison = -1;
-            }
-            return comparison;
-          });
-          categoriesSorted.forEach(category => {
-            // first check if this option already exists; don't add dupes!
-            var selectorString = "#article-category option[value='" + category.id + "']";
-            if ( $(selectorString).length <= 0 ) {
-              var option = document.createElement("option");
-              if (category.category_translations && category.category_translations[0] && category.category_translations[0].title) {
-                option.text = category.category_translations[0].title
-              } else {
-                option.text = "(BUG) unknown title";
-              }
-              option.value = category.id;
-
-              if (data && data.category && data.category.id !== null && data.category.id == category.id) {
-                option.selected = true;
-              }
-              articleCategorySelect.add(option);
-            }
-          })
-
-          var articleTagsSelect = document.getElementById('article-tags');
-
-          // first clear out previous tags - without doing this, we end up with dupes of all the tags
-          // after previewing or publishing
-          var length = articleTagsSelect.options.length;
-          for (i = length-1; i >= 0; i--) {
-            articleTagsSelect.options[i] = null;
-          }
-
-          contents.data.tags.forEach(tag => {
-            // first check if this option already exists; don't add dupes!
-            var selectorString = "#article-tags option[value='" + tag.slug + "']";
-            if ( $(selectorString).length <= 0 ) {
-              var option = document.createElement("option");
-              if (tag.tag_translations && tag.tag_translations[0] && tag.tag_translations[0].title) {
-                option.text = tag.tag_translations[0].title;
-              } else {
-                option.text = "(BUG) unknown title";
-              }
-              option.value = tag.slug;
-
-              if (data && data.tag_articles) {
-                const result = data.tag_articles.find( ({ tag_id }) => tag_id === tag.id );
-                if (result !== undefined) {
-                  option.selected = true;
-                }
-              }
-              articleTagsSelect.add(option);
-            }
-          })
+          displayCategories(contents.data.categories, data.category);
+          displayTags(contents.data.tags, data.tag_articles);
+          displayAuthors(contents.data.authors, data.author_articles);
         }
-
-        var articleAuthorSelect = document.getElementById('article-authors');
-        contents.data.authors.forEach(author => {
-          // first check if this option already exists; don't add dupes!
-          var selectorString = "#article-authors option[value='" + author.id + "']";
-          if ( $(selectorString).length <= 0 ) {
-            var option = document.createElement("option");
-            if (author && author.name) {
-              option.text = author.name
-            } else {
-              option.text = "(BUG) unknown name";
-            }
-            option.value = author.id;
-
-            var authorJoinData;
-            if (data && data.author_articles) {
-              authorJoinData = data.author_articles;
-            } else if (data && data.author_pages) {
-              authorJoinData = data.author_pages;
-            }
-            if (authorJoinData !== undefined) {
-              var foundAuthor = authorJoinData.find( (aa) => aa.author.id === author.id);
-              if (foundAuthor) {
-                option.selected = true;
-              }
-            }
-          }
-          articleAuthorSelect.add(option);
-        })
 
         if (data) {
           var slugDiv = document.getElementById('slug');
@@ -314,12 +326,54 @@
         var articleId;
         var localeCode;
         
-        try {
+        if (data && data.data && data.data.articles && data.data.articles[0]) {
+          console.log("found article")
           articleId = data.data.articles[0].id;
-          localeCode = data.data.articles[0].article_google_documents[0].google_document.locale_code;
+          if (
+            data.data.articles[0] && 
+            data.data.articles[0].article_google_documents && 
+            data.data.articles[0].article_google_documents[0] && 
+            data.data.articles[0].article_google_documents[0].google_document) {
+              localeCode = data.data.articles[0].article_google_documents[0].google_document.locale_code;
+            }
+        }
+        if (articleId && localeCode) {
+          console.log("looking up translations")
           google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessGetArticle).hasuraGetTranslations(articleId, localeCode);
-        } catch (err) {
-          console.error(err);
+        } else {
+          console.log("didn't find article...")
+          var configDiv = document.getElementById('config');
+          configDiv.style.display = 'none';
+          var div = document.getElementById('loading');
+          div.style.display = 'block';
+          div.innerHTML = data.message;
+          var form = document.getElementById('article-form');
+          form.style.display = "block";
+          displayLocales(data.data.organization_locales, localeCode);
+          displayCategories(data.data.categories, null);
+          displayTags(data.data.tags, null);
+          displayAuthors(data.data.authors, null);
+          $('#article-authors').select2({
+            width: 'resolve',
+          });
+
+          $('#article-tags').select2({
+            width: 'resolve',
+            tags: true,
+            createTag: function (params) {
+              var term = $.trim(params.term);
+
+              if (term === '') {
+                return null;
+              }
+
+              return {
+                id: term,
+                text: term,
+                newTag: true // add additional parameters
+              }
+            }
+          });
         }
       }
 

--- a/Page.html
+++ b/Page.html
@@ -9,6 +9,13 @@
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
 
     <script>
+      // thanks stack overflow 
+      // https://stackoverflow.com/questions/8888491/how-do-you-display-javascript-datetime-in-12-hour-am-pm-format
+      function formatDate(dateString) {
+        var d = new Date(dateString);
+        return d.toLocaleString();
+      }
+
       function setValueOrDefault(elementId, value, defaultValue) {
         var element = document.getElementById(elementId);
         if (value !== undefined && value !== null && value !== "") {
@@ -16,6 +23,22 @@
         } else {
           element.value = defaultValue;
         }
+      }
+
+      function displayPublishedInfo(publishedInfo, translationData) {
+          var pubInfoDiv = document.getElementById("published-info");
+          var firstSpan = document.getElementById("first-published-at");
+          firstSpan.innerHTML = formatDate(publishedInfo.first_published_at);
+          var lastSpan = document.getElementById("last-published-at");
+          lastSpan.innerHTML = formatDate(publishedInfo.last_published_at);
+
+          var translationIdSpan = document.getElementById("translation-id");
+          if (translationData && publishedInfo.id === translationData.id) {
+            translationIdSpan.innerHTML = "This translation was published at:";
+          } else {
+            translationIdSpan.innerHTML = "Another translation with id " + publishedInfo.id + " was published at:";
+          }
+          pubInfoDiv.style.display = "block";
       }
 
       function setPublishedFlag(value) {
@@ -75,6 +98,7 @@
         var data;
         var googleDocs;
         var translationData;
+        var publishedInfo;
         var documentType = "article";
         var localeCode = contents.localeCode;
         if (contents.data.articles) {
@@ -87,6 +111,10 @@
           if (contents.data.article_google_documents) {
             googleDocs = contents.data.article_google_documents;
           }
+          if (contents.data.published_article_translations) {
+            publishedInfo = contents.data.published_article_translations[0].article_translation;
+            console.log("Pub Info: ", publishedInfo);
+          }
         } else if (contents.data.pages) {
           documentType = "page"
           if (contents.data.pages[0]) {
@@ -97,6 +125,9 @@
           }
         }
 
+        if (publishedInfo) {
+          displayPublishedInfo(publishedInfo, translationData);
+        }
         var articleLocaleSelect = document.getElementById('article-locale');
         contents.data.organization_locales.forEach(localeData => {
           // first check if this option already exists; don't add dupes!
@@ -316,6 +347,11 @@
               console.log("Published: ", translations[0].published);
               setPublishedFlag(translations[0].published);
             }
+            var publishedInfo = response.data.data.insert_articles.returning[0].published_article_translations;
+            console.log("publishedInfo:", publishedInfo);
+            if (publishedInfo && publishedInfo[0]) {
+              displayPublishedInfo(publishedInfo[0].article_translation, translations[0]);
+            }
 
           } else if (response.data && response.data.data && response.data.data.insert_pages) {
             console.log("page ID:", response.data.data.insert_pages.returning[0].id)
@@ -437,6 +473,9 @@
       input:invalid:required, textarea:invalid:required {
         border: 1px solid red;
       }
+      #published-info {
+        display: none;
+      }
 
     </style>
   </head>
@@ -549,6 +588,11 @@
             <input type="submit" name="preview" id="preview-button-bottom" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="publish-button-bottom" value="Publish" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="unpublish-button-bottom" value="Unpublish" onclick="this.form.submitted=this.value;"/>
+          </div>
+          <div class="block" id="published-info">
+            <div class="small" id="translation-id"></div>
+            <div class="small" style="width: 100%" id="published-info-first"><b>Initial:</b> <span id="first-published-at"></span></div>
+            <div class="small" style="width: 100%" id="published-info-last"><b>Updated:</b> <span id="last-published-at"></span></div>
           </div>
         </form>
       </div>


### PR DESCRIPTION
Closes #207 

This PR implements the Admin Tools link (part 2 of the article search in that sidebar) feature for Hasura:

1. Create a new google doc
2. Open script editor, Run > Test as add on > add the new document as a test case & save
3. Run the add-on test on the new doc with latest code
4. Open Admin Tools
5. Search for another article: try "philadelphia"
6. Select the "Here's how..." philadelphia article and "en-US" locale: this article is associated with a test doc I've made in en-US, fyi
7. Click link.

What this does:

* Removes the link between the philly article (ID 19) and my test google doc
* Adds your new google doc to the db for en-US
* Links article ID 19 (philly) to your new doc

Once this is done, you should be able to open the publishing tools and see all the philly article data as defined before.

NOTE: this does not fill in the contents of the google doc. Going from article contents JSON to properly formatted Google Doc would be pretty difficult. What should we do about this? Include instructions to copy & paste the rendered HTML from the site into the doc?