### PR TITLE
check if article is featured on homepage; hide 'unpublish' button if so

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -783,6 +783,37 @@ function fetchPageForGoogleDoc(doc_id) {
   );
 }
 
+function fetchFeaturedArticles() {
+  return fetchGraphQL(
+    getHomepageFeaturedArticles,
+    "MyQuery"
+  );
+}
+
+async function isArticleFeatured(articleId) {
+  const { errors, data } = await fetchFeaturedArticles();
+
+  if (errors) {
+    console.error("errors:" + JSON.stringify(errors));
+    throw errors;
+  }
+
+  Logger.log("data: " + JSON.stringify(data))
+  var isFeatured = false;
+  if (data && data.homepage_layout_datas) {
+    data.homepage_layout_datas.fo
+    data.homepage_layout_datas.forEach(hpData => {
+      var values = Object.values(hpData);
+      Logger.log(values);
+      if (values.includes(articleId)){
+        isFeatured = true;
+        Logger.log(articleId + " article is featured")
+      }
+    });
+  }
+  return isFeatured;
+}
+
 /*
 .* called from ManualPage.html, this function searches for a matching article by headline
 .*/

--- a/Code.js
+++ b/Code.js
@@ -798,6 +798,9 @@ async function isArticleFeatured(articleId) {
     throw errors;
   }
 
+  var scriptConfig = getScriptConfig();
+  var editorUrl = scriptConfig['EDITOR_URL'];
+
   Logger.log("data: " + JSON.stringify(data))
   var isFeatured = false;
   if (data && data.homepage_layout_datas) {
@@ -811,7 +814,10 @@ async function isArticleFeatured(articleId) {
       }
     });
   }
-  return isFeatured;
+  return {
+    featured: isFeatured,
+    editorUrl: editorUrl
+  };
 }
 
 /*

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -377,3 +377,11 @@ const searchArticlesByHeadlineQuery = `query MyQuery($locale_code: String!, $ter
     }
   }
 }`;
+
+const getHomepageFeaturedArticles = `query MyQuery {
+  homepage_layout_datas {
+    article_priority_1
+    article_priority_2
+    article_priority_3
+  }
+}`

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -288,6 +288,9 @@
         var contentApi = document.getElementById('content-api');
         contentApi.value = data.contentApi ? data.contentApi : data['CONTENT_API'];
 
+        var editorUrl = document.getElementById('editor-url');
+        editorUrl.value = data.editorUrl ? data.editorUrl : data['EDITOR_URL'];
+
         var publishUrl = document.getElementById('publish-url');
         publishUrl.value = data.publishUrl ? data.publishUrl : data['PUBLISH_URL'];
 
@@ -479,6 +482,14 @@
           </label>
           <input id="content-api" name="CONTENT_API" type="text" />
         </div>
+
+        <div class="block form-group">
+          <label for="editor-url">
+            <b>Homepage Editor URL</b>
+          </label>
+          <input id="editor-url" name="EDITOR_URL" type="text" placeholder="http://localhost:3000/tinycms/homepage" />
+        </div>
+
         <div class="block form-group">
           <label for="publish-url">
             <b>Publish Host URL</b>

--- a/Page.html
+++ b/Page.html
@@ -331,8 +331,30 @@
             }
           }
         });
+
+        if (data && documentType === "article") {
+          google.script.run.withFailureHandler(onFailureFeatured).withSuccessHandler(onSuccessFeatured).isArticleFeatured(data.id);
+        }
       }
       
+      function onSuccessFeatured(result) {
+        if (result) {
+          var div = document.getElementById('featured');
+          div.style.display = "block";
+          div.innerHTML = "<b>Featured on the homepage</b>";
+
+          // hide the unpublish button
+          var unpublishButtonTop = document.getElementById('unpublish-button-top');
+          unpublishButtonTop.style.display = "none";
+          var unpublishButtonBottom = document.getElementById('unpublish-button-bottom');
+          unpublishButtonBottom.style.display = "none";
+        }
+      }
+
+      function onFailureFeatured(error) {
+        console.log("onFailureFeatured error:", error);
+      }
+
       function onFailure(error) {
         console.log("onFailure error:", error);
         var loadingDiv = document.getElementById('loading');
@@ -605,6 +627,7 @@
             <input type="submit" class="blue" id="publish-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="unpublish-button-top" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>
+          <div class="block" id="featured"></div>
 
           <div class="block form-group">
             <label for="article-locale">

--- a/Page.html
+++ b/Page.html
@@ -34,7 +34,6 @@
             aTitle = a.category_translations[0].title
           }
           if (b.category_translations && b.category_translations[0] && b.category_translations[0].title) {
-            console.log("doc is an article")
             bTitle = b.category_translations[0].title
           }
           if (aTitle > bTitle) {
@@ -183,7 +182,6 @@
           unpublishButtonBottom.style.display = "inline";
 
         } else {
-          console.log("Unpublished article, resetting buttons")
           var publishButtonTop = document.getElementById('publish-button-top');
           publishButtonTop.value = "Publish";
           var publishButtonBottom = document.getElementById('publish-button-bottom');
@@ -196,7 +194,6 @@
           unpublishButtonBottom.style.display = "none";
 
           var pubInfoDiv = document.getElementById("published-info");
-          console.log("pubInfoDiv:", pubInfoDiv);
           var translationIdSpan = document.getElementById("translation-id");
           translationIdSpan.innerHTML = "";
           pubInfoDiv.style.display = "none";
@@ -205,7 +202,6 @@
       }
 
       function onSuccessGetArticle(contents) {
-        console.log("onSuccessGetArticle: ", contents);
 
         var configDiv = document.getElementById('config');
         configDiv.style.display = 'none';
@@ -227,7 +223,6 @@
 
         var typeHiddenField = document.getElementById('document-type');
         var documentType = typeHiddenField.value;
-        console.log("documentType: " + documentType);
 
         // hide form fields that are relevant for articles only from documents that are static pages
         if (documentType !== "article") {
@@ -273,7 +268,6 @@
         }
         
         if (documentType === "article") {
-          console.log("doc is an article")
           displayCategories(contents.data.categories, data.category);
           displayTags(contents.data.tags, data.tag_articles);
           displayAuthors(contents.data.authors, data.author_articles);
@@ -290,7 +284,6 @@
         }
 
         // var selectedLocale = document.getElementById('selected-locale');
-        console.log("translationData:", translationData);
         if (translationData) {
           setPublishedFlag(translationData.published);
 
@@ -338,10 +331,15 @@
       }
       
       function onSuccessFeatured(result) {
-        if (result) {
+        if (result && result.featured) {
+          console.log("result: ", result);
           var div = document.getElementById('featured');
           div.style.display = "block";
-          div.innerHTML = "<b>Featured on the homepage</b>";
+          var message = "<b>This article is featured on the homepage</b>";
+          if (result.editorUrl) {
+            message += ": <a target='_new' href='" + result.editorUrl + "'>edit</a>"
+          }
+          div.innerHTML = message;
 
           // hide the unpublish button
           var unpublishButtonTop = document.getElementById('unpublish-button-top');
@@ -369,7 +367,6 @@
           onFailure(data.message);
           return;
         }
-        console.log("data:", data);
         var articleId;
         var pageId;
         var localeCode;
@@ -451,7 +448,6 @@
       }
 
       function onSuccessPreviewPublish(response) {
-        console.log("success preview/publish:", response);
         var configDiv = document.getElementById('config');
         configDiv.style.display = 'none';
         var div = document.getElementById('loading');
@@ -620,6 +616,8 @@
 
       <div id="config"></div>
 
+      <div class="block" id="featured"></div>
+
       <div id="article-form">
         <form onsubmit="handleClick(this)">
           <div class="block" id="action-buttons-top">
@@ -627,7 +625,6 @@
             <input type="submit" class="blue" id="publish-button-top" value="Publish" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="unpublish-button-top" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>
-          <div class="block" id="featured"></div>
 
           <div class="block form-group">
             <label for="article-locale">


### PR DESCRIPTION
Closes https://github.com/news-catalyst/next-tinynewsdemo/issues/336

Opening the sidebar now checks if the document corresponds to an article currently featured on homepage. If it is featured, a short message is printed saying so, a link to the homepage editor (configured in the 'Admin Tools') is included, and the "unpublish" button is hidden.

Example of a doc for a featured article: https://docs.google.com/document/d/1cZjl65RWJhBfzngaoV7XgsfoI0GRZfuSOriUzveSCXo/edit?addon_dry_run=AAnXSK_noR3moBAAaYyb4aCJAnRLhVdPPLCry0b-ZZunpnhHPbEGTiXeaLnByCA5BrbgJmykAH6rcr6qzpMrvrl7NMW4up1wx0lEYmPBjp_lHIFv5KAsyHk3tn26nrw4pRTHSNgLr-C-

Otherwise, the "unpublish" button appears as before. 