### PR TITLE
Republish site on publish/unpublish article

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -524,6 +524,9 @@ async function hasuraHandleUnpublish(formObject) {
     returnValue.status = "error";
     returnValue.message = "An unexpected error occurred trying to unpublish the article";
     returnValue.data = response.errors;
+  } else {
+    // trigger republish of the site to reflect this article no longer being live
+    rebuildSite();
   }
   return returnValue;
 }
@@ -646,6 +649,9 @@ async function hasuraHandlePublish(formObject) {
       fullPublishUrl = publishUrl + "/articles/" + categorySlug + "/" + articleSlug;
     }
   }
+
+  // trigger republish of the site to reflect new article
+  rebuildSite();
 
   // open preview url in new window
   var message = "Published the " + documentType + ". <a href='" + fullPublishUrl + "' target='_blank'>Click to view</a>."
@@ -1283,7 +1289,7 @@ function formatElements() {
  */
 function rebuildSite() {
   var scriptConfig = getScriptConfig();
-  var DEPLOY_HOOK = scriptConfig['VERCEL_DEPLOY_HOOK_URL'];
+  var WEBHOOK = scriptConfig['VERCEL_WEBHOOK'];
 
   var options = {
     method: 'post',
@@ -1292,7 +1298,7 @@ function rebuildSite() {
   };
 
   var response = UrlFetchApp.fetch(
-    DEPLOY_HOOK,
+    WEBHOOK,
     options
   );
   var responseText = response.getContentText();

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -309,6 +309,9 @@
         var awsBucket = document.getElementById('aws-bucket');
         awsBucket.value = data.awsBucket ? data.awsBucket : data['AWS_BUCKET'];
 
+        var vercelWebhook = document.getElementById('vercel-webhook');
+        vercelWebhook.value = data.vercelWebhook ? data.vercelWebhook : data['VERCEL_WEBHOOK'];
+
         showConfigForm();
       }
 
@@ -522,6 +525,12 @@
             <b>AWS Bucket</b>
           </label>
           <input id="aws-bucket" name="AWS_BUCKET" type="text" />
+        </div>
+        <div class="block form-group">
+          <label for="vercel-webhook">
+            <b>Vercel Webhook</b>
+          </label>
+          <input id="vercel-webhook" name="VERCEL_WEBHOOK" type="text" />
         </div>
         <div class="block">
           <button class="blue">Save Config</button>


### PR DESCRIPTION
Closes https://github.com/news-catalyst/next-tinynewsdemo/issues/389

This adds a vercel webhook field back to the configuration form (admin tools) and posts to it after any article publish or unpublish by posting to the webhook URL.