### PR TITLE
Feature/store slug versions

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -617,6 +617,11 @@ async function hasuraHandlePublish(formObject) {
 
     var pageID = data.data.insert_pages.returning[0].id;
 
+    // store slug + page ID in slug versions table
+    var result = await storePageIdAndSlug(pageID, slug);
+    Logger.log("stored page id + slug: " + JSON.stringify(result));
+
+
     if (pageID && formObject['article-authors']) {
       var authors;
       // ensure this is an array; selecting one in the UI results in a string being sent
@@ -647,6 +652,10 @@ async function hasuraHandlePublish(formObject) {
     var translationID = data.data.insert_articles.returning[0].article_translations[0].id;
 
     if (articleID) {
+      // store slug + article ID in slug versions table
+      var result = await storeArticleIdAndSlug(articleID, slug);
+      Logger.log("stored article id + slug: " + JSON.stringify(result));
+
       var publishedArticleData = await upsertPublishedArticle(articleID, translationID, formObject['article-locale'])
       if (publishedArticleData) {
         data.data.insert_articles.returning[0].published_article_translations = publishedArticleData.data.insert_published_article_translations.returning;

--- a/Code.js
+++ b/Code.js
@@ -308,6 +308,28 @@ async function fetchGraphQL(operationsDoc, operationName, variables) {
   return responseData;
 }
 
+function storeArticleIdAndSlug(id, slug) {
+  return fetchGraphQL(
+    insertArticleSlugVersion,
+    "MyMutation",
+    {
+      article_id: id,
+      slug: slug
+    }
+  );
+}
+
+function storePageIdAndSlug(id, slug) {
+  return fetchGraphQL(
+    insertPageSlugVersion,
+    "MyMutation",
+    {
+      page_id: id,
+      slug: slug
+    }
+  );
+}
+
 function insertPageGoogleDocs(data) {
   var documentID = DocumentApp.getActiveDocument().getId();
   var documentURL = DocumentApp.getActiveDocument().getUrl();
@@ -725,6 +747,10 @@ async function hasuraHandlePreview(formObject) {
 
     var pageID = data.data.insert_pages.returning[0].id;
 
+    // store slug + page ID in slug versions table
+    var result = await storePageIdAndSlug(pageID, slug);
+    Logger.log("stored page id + slug: " + JSON.stringify(result));
+
     if (pageID && formObject['article-authors']) {
       var authors;
       // ensure this is an array; selecting one in the UI results in a string being sent
@@ -745,6 +771,10 @@ async function hasuraHandlePreview(formObject) {
     var data = await insertArticleGoogleDocs(formObject);
     Logger.log("articleResult: " + JSON.stringify(data))
     var articleID = data.data.insert_articles.returning[0].id;
+
+    // store slug + article ID in slug versions table
+    var result = await storeArticleIdAndSlug(articleID, slug);
+    Logger.log("stored article id + slug: " + JSON.stringify(result));
 
     if (articleID && formObject['article-tags']) {
       var tags;

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -1,5 +1,17 @@
 /* Mutations */
 
+const insertArticleSlugVersion = `mutation MyMutation($article_id: Int!, $slug: String!) {
+  insert_article_slug_versions(objects: {article_id: $article_id, slug: $slug}, on_conflict: {constraint: slug_versions_pkey, update_columns: article_id}) {
+    affected_rows
+  }
+}`;
+
+const insertPageSlugVersion = `mutation MyMutation($slug: String!, $page_id: Int!) {
+  insert_page_slug_versions(objects: {page_id: $page_id, slug: $slug}, on_conflict: {constraint: page_slug_versions_pkey, update_columns: page_id}) {
+    affected_rows
+  }
+}`;
+
 const insertAuthorArticleMutation = `mutation MyMutation($article_id: Int!, $author_id: Int!) {
   insert_author_articles(objects: {article_id: $article_id, author_id: $author_id}, on_conflict: {constraint: author_articles_article_id_author_id_key, update_columns: article_id}) {
     affected_rows


### PR DESCRIPTION
Closes #261 

The page ID + slug, or article ID + slug, are stored on both preview & publish. There's a unique constraint on the combination in both `*_slug_versions` tables so this operation can happen repeatedly without issue.