### PR TITLE
label unpublished sections as "(hidden)"

### DIFF
--- a/GraphQL.js
+++ b/GraphQL.js
@@ -336,7 +336,7 @@ const getArticleTranslationForIdAndLocale = `query MyQuery($doc_id: String!, $ar
     slug
     name
   }
-  categories {
+  categories(where: {published: {_eq: true}}) {
     id
     slug
     category_translations(where: {locale_code: {_eq: $locale_code}}) {

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -336,8 +336,9 @@ const getArticleTranslationForIdAndLocale = `query MyQuery($doc_id: String!, $ar
     slug
     name
   }
-  categories(where: {published: {_eq: true}}) {
+  categories {
     id
+    published
     slug
     category_translations(where: {locale_code: {_eq: $locale_code}}) {
       title

--- a/Page.html
+++ b/Page.html
@@ -49,7 +49,11 @@
           if ( $(selectorString).length <= 0 ) {
             var option = document.createElement("option");
             if (category.category_translations && category.category_translations[0] && category.category_translations[0].title) {
-              option.text = category.category_translations[0].title
+              var optionText = category.category_translations[0].title;
+              if (!category.published) {
+                optionText += " (hidden)";
+              }
+              option.text = optionText;
             } else {
               option.text = "(BUG) unknown title";
             }


### PR DESCRIPTION
Closes #263 

We discussed this on slack, but to recap:

* sections are either shown in the nav ("published" in the db) or not
* articles can be assigned to an unpublished/hidden section
* articles will load on the front-end if assigned to a hidden section

In the sidebar, all sections are listed and the ones hidden from the nav say "(hidden)" as of the latest code in this PR - should be testable in the sidebar using run > test > latest code and look like the screenshot below:

<img width="355" alt="Screen Shot 2021-05-06 at 8 18 46 am" src="https://user-images.githubusercontent.com/3397/117217185-557a0000-ae44-11eb-9d03-a77b2841b4ce.png">

with the following sections setup in the tinycms (I'm using oaklyn):

<img width="1312" alt="Screen Shot 2021-05-06 at 8 18 57 am" src="https://user-images.githubusercontent.com/3397/117217213-5f9bfe80-ae44-11eb-8616-c8daf6f8ab93.png">

