### PR TITLE
Dynamical source fields

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -404,8 +404,7 @@ function insertArticleGoogleDocs(data) {
     "locale_code": data['article-locale'],
     "headline": data['article-headline'],
     "published": data['published'],
-    // TODO DON'T FORGET TO UNCOMMENT THE ARTICLE CONTENT!
-    // "content": content,
+    "content": content,
     "search_description": data['article-search-description'],
     "search_title": data['article-search-title'],
     "twitter_title": data['article-twitter-title'],
@@ -417,7 +416,6 @@ function insertArticleGoogleDocs(data) {
   };
 
   if (data["source-name"]) {
-    // let sources = [];
     let source = {
       name: data['source-name'],
       affiliation: data['source-affiliation'],
@@ -434,19 +432,12 @@ function insertArticleGoogleDocs(data) {
     if (data['source-id']) {
       source.id = data['source-id'];
     }
-    // sources.push(source);
     articleData["article_sources"] = source;
-    // {
-    //   "data": {
-    //      "source": { "data": source }
-    //   }
-    // };
     Logger.log("pushed sources onto article data:" + JSON.stringify(source));
   }
 
   Logger.log("article data:" + JSON.stringify(articleData));
   if (data["article-id"] === "") {
-    // articleData.delete("id")
     return fetchGraphQL(
       insertArticleGoogleDocMutationWithoutId,
       "MyMutation",

--- a/Code.js
+++ b/Code.js
@@ -431,12 +431,16 @@ function insertArticleGoogleDocs(data) {
       sexual_orientation: data['source-sexual-orientation'],
       zip: data['source-zip']
     }
+    if (data['source-id']) {
+      source.id = data['source-id'];
+    }
     // sources.push(source);
-    articleData["article_sources"] = {
-      "data": {
-         "source": { "data": source }
-      }
-    };
+    articleData["article_sources"] = source;
+    // {
+    //   "data": {
+    //      "source": { "data": source }
+    //   }
+    // };
     Logger.log("pushed sources onto article data:" + JSON.stringify(source));
   }
 

--- a/Code.js
+++ b/Code.js
@@ -415,23 +415,23 @@ function insertArticleGoogleDocs(data) {
     "created_by_email": data['created_by_email'],
   };
 
-  if (data["source-name"]) {
-    let source = {
-      name: data['source-name'],
-      affiliation: data['source-affiliation'],
-      age: data['source-age'],
-      email: data['source-email'],
-      ethnicity: data['source-ethnicity'],
-      gender: data['source-gender'],
-      phone: data['source-phone'],
-      race: data['source-race'],
-      role: data['source-role'],
-      sexual_orientation: data['source-sexual-orientation'],
-      zip: data['source-zip']
+  let source = {};
+  
+  Object.keys(data).forEach(key => {
+    let keyMatch = key.match(/source\[(.*?)\]\.(.*?)$/);
+    if (keyMatch) {
+      Logger.log(key, JSON.stringify(keyMatch));
+      var id = keyMatch[1];
+      var fieldName = keyMatch[2];
+      var val = data[key];
+
+      source["id"] = id;
+      source[fieldName] = val;
+      Logger.log("id #" + id + ": " + fieldName + " => " + val);
     }
-    if (data['source-id']) {
-      source.id = data['source-id'];
-    }
+  })
+
+  if (source !== {} && Object.keys(source).length > 0) {
     articleData["article_sources"] = source;
     Logger.log("pushed sources onto article data:" + JSON.stringify(source));
   }

--- a/Code.js
+++ b/Code.js
@@ -404,7 +404,8 @@ function insertArticleGoogleDocs(data) {
     "locale_code": data['article-locale'],
     "headline": data['article-headline'],
     "published": data['published'],
-    "content": content,
+    // TODO DON'T FORGET TO UNCOMMENT THE ARTICLE CONTENT!
+    // "content": content,
     "search_description": data['article-search-description'],
     "search_title": data['article-search-title'],
     "twitter_title": data['article-twitter-title'],
@@ -414,8 +415,32 @@ function insertArticleGoogleDocs(data) {
     "custom_byline": data['article-custom-byline'],
     "created_by_email": data['created_by_email'],
   };
-  Logger.log("article data:" + JSON.stringify(articleData));
 
+  if (data["source-name"]) {
+    // let sources = [];
+    let source = {
+      name: data['source-name'],
+      affiliation: data['source-affiliation'],
+      age: data['source-age'],
+      email: data['source-email'],
+      ethnicity: data['source-ethnicity'],
+      gender: data['source-gender'],
+      phone: data['source-phone'],
+      race: data['source-race'],
+      role: data['source-role'],
+      sexual_orientation: data['source-sexual-orientation'],
+      zip: data['source-zip']
+    }
+    // sources.push(source);
+    articleData["article_sources"] = {
+      "data": {
+         "source": { "data": source }
+      }
+    };
+    Logger.log("pushed sources onto article data:" + JSON.stringify(source));
+  }
+
+  Logger.log("article data:" + JSON.stringify(articleData));
   if (data["article-id"] === "") {
     // articleData.delete("id")
     return fetchGraphQL(
@@ -786,6 +811,8 @@ async function hasuraHandlePreview(formObject) {
   } else {
     documentType = "article";
     // insert or update article
+    Logger.log("formObject:" + JSON.stringify(formObject));
+
     var data = await insertArticleGoogleDocs(formObject);
     Logger.log("articleResult: " + JSON.stringify(data))
     var articleID = data.data.insert_articles.returning[0].id;

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -60,7 +60,8 @@ const insertArticleGoogleDocMutationWithoutId = `mutation MyMutation($locale_cod
     }
   }
 }`;
-const insertArticleGoogleDocMutation = `mutation MyMutation($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $article_sources: article_source_arr_rel_insert_input) {
+const insertArticleGoogleDocMutation = `mutation MyMutation($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, 
+  $article_sources: sources_insert_input!) {
   insert_articles(
     objects: {
       article_translations: {
@@ -68,7 +69,17 @@ const insertArticleGoogleDocMutation = `mutation MyMutation($id: Int!, $locale_c
           created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title
         }
       }, 
-      article_sources: $article_sources,
+      article_sources: {
+        data: {
+          source: {
+            data: $article_sources, 
+            on_conflict: {
+              constraint: sources_pkey, 
+              update_columns: [name, affiliation, age, phone, zip, race, gender, sexual_orientation, ethnicity, role, email]
+            }
+          }
+        }
+      },
       category_id: $category_id, 
       id: $id, 
       slug: $slug, 

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -146,7 +146,8 @@ const insertArticleGoogleDocMutation = `mutation MyMutation($id: Int!, $locale_c
               update_columns: [name, affiliation, age, phone, zip, race, gender, sexual_orientation, ethnicity, role, email]
             }
           }
-        }
+        },
+        on_conflict: {constraint: article_source_article_id_source_id_key, update_columns: article_id}
       },
       category_id: $category_id, 
       id: $id, 

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -24,8 +24,60 @@ const insertAuthorPageMutation = `mutation MyMutation($page_id: Int!, $author_id
   }
 }`;
 
-const insertArticleGoogleDocMutationWithoutId = `mutation MyMutation($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String) {
-  insert_articles(objects: {article_translations: {data: {created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title}}, category_id: $category_id, slug: $slug, article_google_documents: {data: {google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: locale_code}}}, on_conflict: {constraint: article_google_documents_article_id_google_document_id_key, update_columns: google_document_id}}}, on_conflict: {constraint: articles_slug_category_id_organization_id_key, update_columns: [slug, updated_at]}) {
+const insertArticleGoogleDocMutationWithoutId = `mutation MyMutation($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $article_sources: sources_insert_input!) {
+  insert_articles(
+    objects: {
+      article_translations: {
+        data: {
+          created_by_email: $created_by_email, 
+          headline: $headline, 
+          locale_code: $locale_code, 
+          published: $published, 
+          content: $content, 
+          custom_byline: $custom_byline, 
+          facebook_description: $facebook_description, 
+          facebook_title: $facebook_title, 
+          search_description: $search_description, 
+          search_title: $search_title, 
+          twitter_description: $twitter_description, 
+          twitter_title: $twitter_title
+        }
+      }, 
+      category_id: $category_id, 
+      slug: $slug, 
+      article_sources: {
+        data: {
+          source: {
+            data: $article_sources, 
+            on_conflict: {
+              constraint: sources_pkey, 
+              update_columns: [name, affiliation, age, phone, zip, race, gender, sexual_orientation, ethnicity, role, email]
+            }
+          }
+        }
+      },
+      article_google_documents: {
+        data: {
+          google_document: {
+            data: {
+              document_id: $document_id, 
+              locale_code: $locale_code, 
+              url: $url
+            }, 
+            on_conflict: {
+              constraint: google_documents_organization_id_document_id_key, update_columns: locale_code
+            }
+          }
+        }, 
+        on_conflict: {
+          constraint: article_google_documents_article_id_google_document_id_key, update_columns: google_document_id
+        }
+      }
+    }, 
+    on_conflict: {
+      constraint: articles_slug_category_id_organization_id_key, update_columns: [slug, updated_at]
+    }
+  ) {
     returning {
       id
       slug
@@ -38,6 +90,22 @@ const insertArticleGoogleDocMutationWithoutId = `mutation MyMutation($locale_cod
           locale_code
           url
           id
+        }
+      }
+      article_sources {
+        source {
+          affiliation
+          age
+          email
+          ethnicity
+          gender
+          id
+          name
+          phone
+          race
+          role
+          sexual_orientation
+          zip
         }
       }
       category {

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -60,8 +60,38 @@ const insertArticleGoogleDocMutationWithoutId = `mutation MyMutation($locale_cod
     }
   }
 }`;
-const insertArticleGoogleDocMutation = `mutation MyMutation($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String) {
-  insert_articles(objects: {article_translations: {data: {created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title}}, category_id: $category_id, id: $id, slug: $slug, article_google_documents: {data: {google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: locale_code}}}, on_conflict: {constraint: article_google_documents_article_id_google_document_id_key, update_columns: google_document_id}}}, on_conflict: {constraint: articles_pkey, update_columns: [category_id, slug, updated_at]}) {
+const insertArticleGoogleDocMutation = `mutation MyMutation($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $article_sources: article_source_arr_rel_insert_input) {
+  insert_articles(
+    objects: {
+      article_translations: {
+        data: {
+          created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title
+        }
+      }, 
+      article_sources: $article_sources,
+      category_id: $category_id, 
+      id: $id, 
+      slug: $slug, 
+      article_google_documents: {
+        data: {
+          google_document: {
+            data: {
+              document_id: $document_id, locale_code: $locale_code, url: $url
+            }, 
+            on_conflict: {
+              constraint: google_documents_organization_id_document_id_key, update_columns: locale_code
+            }
+          }
+        }, 
+        on_conflict: {
+          constraint: article_google_documents_article_id_google_document_id_key, update_columns: google_document_id
+        }
+      }
+    }, 
+    on_conflict: {
+      constraint: articles_pkey, update_columns: [category_id, slug, updated_at]
+    }
+  ) {
     returning {
       id
       slug
@@ -74,6 +104,22 @@ const insertArticleGoogleDocMutation = `mutation MyMutation($id: Int!, $locale_c
           locale_code
           url
           id
+        }
+      }
+      article_sources {
+        source {
+          affiliation
+          age
+          email
+          ethnicity
+          gender
+          id
+          name
+          phone
+          race
+          role
+          sexual_orientation
+          zip
         }
       }
       category {
@@ -204,6 +250,24 @@ const getArticleByGoogleDocQuery = `query MyQuery($doc_id: String!) {
         document_id
         locale_code
         url
+      }
+    }
+    article_sources {
+      source {
+        affiliation
+        age
+        created_at
+        email
+        ethnicity
+        gender
+        id
+        name
+        phone
+        race
+        role
+        sexual_orientation
+        updated_at
+        zip
       }
     }
   }

--- a/Page.html
+++ b/Page.html
@@ -783,7 +783,7 @@
             <textarea id="article-twitter-description" name="article-twitter-description"></textarea>
           </div>
 
-          <div id="source-tracking-form">
+          <div id="source-tracking-form" class="articles-only">
             <h2 class="title">Source Tracking</h2>
             <div class="block form-group">
               <label for="source-name">

--- a/Page.html
+++ b/Page.html
@@ -366,6 +366,24 @@
         form.style.display = "none";
       }
 
+      function fillInTextField(fieldName, fieldValue) {
+        var field = document.getElementById(fieldName);
+        if (field) {
+          field.value = fieldValue
+        }
+      }
+
+      function selectOption(fieldName, fieldValue) {
+        var field = document.getElementById(fieldName);
+        var opts = field.options;
+        for (var opt, i = 0; opt = opts[i]; i++) {
+          if (opt.value == fieldValue) {
+            field.selectedIndex = i;
+            break;
+          }
+        }
+      }
+
       function handleGetTranslationsForArticle(data) {
         if (data && data.status === "error") {
           onFailure(data.message);
@@ -394,7 +412,29 @@
             data.data.articles[0].article_google_documents[0].google_document) {
               localeCode = data.data.articles[0].article_google_documents[0].google_document.locale_code;
             }
+
+            if (
+              data.data.articles[0] &&
+              data.data.articles[0].article_sources &&
+              data.data.articles[0].article_sources[0] &&
+              data.data.articles[0].article_sources[0].source
+              ) {
+              var source = data.data.articles[0].article_sources[0].source;
+              console.log("found source: ", source);
+              fillInTextField('source-name', source.name);
+              fillInTextField('source-affiliation', source.affiliation);
+              fillInTextField('source-zip-code', source.zip);
+              fillInTextField('source-email', source.email);
+              fillInTextField('source-phone', source.phone);
+              selectOption('source-race', source.race);
+              selectOption('source-ethnicity', source.ethnicity);
+              selectOption('source-gender', source.gender);
+              selectOption('source-sexual-orientation', source.sexual_orientation);
+              selectOption('source-age', source.age);
+              selectOption('source-role', source.role);
+            }
         }
+
         if (documentType === "page" && data.data.pages[0]) {
           typeHiddenField.value = documentType;
           pageId = data.data.pages[0].id;
@@ -864,6 +904,14 @@
               </label>
             </div>
           </div>
+
+          <div class="block">
+            <p>
+              Add another source (to-do)
+            </p>
+          </div>
+
+          <hr class="block" />
 
           <div class="block" id="action-buttons-bottom">
             <input type="submit" name="preview" id="preview-button-bottom" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>

--- a/Page.html
+++ b/Page.html
@@ -378,21 +378,14 @@
         form.style.display = "none";
       }
 
-      function fillInTextField(fieldName, fieldValue) {
-        var field = document.getElementById(fieldName);
-        if (field) {
-          field.value = fieldValue
-        }
-      }
-
-      function createTextInputDiv(id, name, value) {
-        var fieldName = "source[" + id + "].name";
+      function createTextInputDiv(id, label, name, value) {
+        var fieldName = "source[" + id + "]." + name;
         var div = document.createElement("div");
         div.class = "block form-group"
-        var label = document.createElement("label");
-        label.setAttribute("for", fieldName);
-        label.innerHTML = "<b>" + name + ":</b>";
-        div.appendChild(label);
+        var labelTag = document.createElement("label");
+        labelTag.setAttribute("for", fieldName);
+        labelTag.innerHTML = "<b>" + label + ":</b>";
+        div.appendChild(labelTag);
         var input = document.createElement("input");
         input.type = "text";
         input.name = fieldName;
@@ -401,16 +394,16 @@
         return div
       }
 
-      function createSelectDiv(id, name, value, choices) {
+      function createSelectDiv(id, label, name, value, choices) {
         var fieldName = "source[" + id + "]." + name;
 
         var div = document.createElement("div");
         div.class = "block form-group"
 
-        var label = document.createElement("label");
-        label.setAttribute("for", fieldName);
-        label.innerHTML = "<b>" + name + ":</b>";
-        div.appendChild(label);
+        var labelTag = document.createElement("label");
+        labelTag.setAttribute("for", fieldName);
+        labelTag.innerHTML = "<b>" + label + ":</b>";
+        div.appendChild(labelTag);
 
         var select = document.createElement("select");
         select.style = "width: 100%";
@@ -488,10 +481,10 @@
 
                   var sourceContainer = document.getElementById('sources-container');
 
-                  var nameDiv = createTextInputDiv(source.id, "name", source.name);
+                  var nameDiv = createTextInputDiv(source.id, "Name", "name", source.name);
                   sourceContainer.appendChild(nameDiv);
 
-                  var affDiv = createTextInputDiv(source.id, "affiliation", source.affiliation);
+                  var affDiv = createTextInputDiv(source.id, "Affiliation", "affiliation", source.affiliation);
                   sourceContainer.appendChild(affDiv);
 
                   var races = [
@@ -505,7 +498,7 @@
                     "Prefer not to say"
                   ];
 
-                  var raceDiv = createSelectDiv(source.id, "race", source.race, races);
+                  var raceDiv = createSelectDiv(source.id, "Race", "race", source.race, races);
                   sourceContainer.appendChild(raceDiv);
 
                   var ethnicities = [
@@ -519,7 +512,7 @@
                     "Prefer to self-describe",
                     "Prefer not to say"
                   ];
-                  var ethnicityDiv = createSelectDiv(source.id, "ethnicity", source.ethnicity, ethnicities);
+                  var ethnicityDiv = createSelectDiv(source.id, "Ethnicity", "ethnicity", source.ethnicity, ethnicities);
                   sourceContainer.appendChild(ethnicityDiv);
 
                   var genders = [
@@ -532,7 +525,7 @@
                     "Prefer to self-describe",
                     "Prefer not to say"
                   ];
-                  var genderDiv = createSelectDiv(source.id, "gender", source.gender, genders);
+                  var genderDiv = createSelectDiv(source.id, "Gender", "gender", source.gender, genders);
                   sourceContainer.appendChild(genderDiv);
 
                   var sexOrientations = [
@@ -544,7 +537,7 @@
                     "Prefer to self-describe",
                     "Prefer not to say"
                   ];
-                  var sexOrientationDiv = createSelectDiv(source.id, "sexual_orientation", source.sexual_orientation, sexOrientations);
+                  var sexOrientationDiv = createSelectDiv(source.id, 'Sexual Orientation', "sexual_orientation", source.sexual_orientation, sexOrientations);
                   sourceContainer.appendChild(sexOrientationDiv);
 
                   var ages = [
@@ -555,16 +548,16 @@
                     "50-59",
                     "60 or older"
                   ];
-                  var ageDiv = createSelectDiv(source.id, "age", source.age, ages);
+                  var ageDiv = createSelectDiv(source.id, "Age", "age", source.age, ages);
                   sourceContainer.appendChild(ageDiv);
 
-                  var zipDiv = createTextInputDiv(source.id, "zip", source.zip);
+                  var zipDiv = createTextInputDiv(source.id, "Zip Code", "zip", source.zip);
                   sourceContainer.appendChild(zipDiv);
 
-                  var emailDiv = createTextInputDiv(source.id, "email", source.email);
+                  var emailDiv = createTextInputDiv(source.id, "Contact Email Address", "email", source.email);
                   sourceContainer.appendChild(emailDiv);
 
-                  var phoneDiv = createTextInputDiv(source.id, "phone", source.phone);
+                  var phoneDiv = createTextInputDiv(source.id, "Contact Phone Number", "phone", source.phone);
                   sourceContainer.appendChild(phoneDiv);
 
                   var roles = [
@@ -572,21 +565,8 @@
                     "Mentioned",
                     "Background"
                   ];
-                  var roleDiv = createSelectDiv(source.id, "role", source.role, roles);
+                  var roleDiv = createSelectDiv(source.id, "Role", "role", source.role, roles);
                   sourceContainer.appendChild(roleDiv);
-
-                  // fillInTextField('source-id', source.id);
-                  // fillInTextField('source-name', source.name);
-                  // fillInTextField('source-affiliation', source.affiliation);
-                  // fillInTextField('source-zip-code', source.zip);
-                  // fillInTextField('source-email', source.email);
-                  // fillInTextField('source-phone', source.phone);
-                  // selectOption('source-race', source.race);
-                  // selectOption('source-ethnicity', source.ethnicity);
-                  // selectOption('source-gender', source.gender);
-                  // selectOption('source-sexual-orientation', source.sexual_orientation);
-                  // selectOption('source-age', source.age);
-                  // selectOption('source-role', source.role);
                 });
             }
         }
@@ -940,130 +920,6 @@
 
           <div id="sources-container" class="articles-only">
             <h2 class="title">Source Tracking</h2>
-          </div>
-
-          <div id="source-tracking-form" class="articles-only">
-            <h2 class="title">Source Tracking</h2>
-            <div class="block form-group">
-              <label for="source-name">
-                <b>Name</b>
-              </label>
-              <input id="source-id" name="source-id" type="hidden" />
-              <input id="source-name" name="source-name" type="text" />
-            </div>
-            <div class="block form-group">
-              <label for="source-affiliation">
-                <b>Affiliation</b>
-              </label>
-              <input id="source-affiliation" name="source-affiliation" type="text" />
-            </div>
-            <div class="block form-group">
-              <label for="source-race">
-                <b>Race</b>
-                <select style="width: 100%" id="source-race" name="source-race">
-                  <option value="" disabled selected>Please choose</option>
-                  <option value="White">White</option>
-                  <option value="Black or African-American">Black or African-American</option>
-                  <option value="American Indian or Alaskan Native">American Indian or Alaskan Native</option>
-                  <option value="Asian">Asian</option>
-                  <option value="Native Hawaiian or other Pacific Islander">Native Hawaiian or other Pacific Islander</option>
-                  <option value="From multiple races">From multiple races</option>
-                  <option value="Prefer to self-describe">Prefer to self-describe</option>
-                  <option value="Prefer not to say">Prefer not to say</option>
-                </select>
-              </label>
-            </div>
-            <div class="block form-group">
-              <label for="source-ethnicity">
-                <b>Ethnicity</b>
-                <select style="width: 100%" id="source-ethnicity" name="source-ethnicity">
-                  <option value="" disabled selected>Please choose</option>
-                  <option value="African, African-American">African, African-American</option>
-                  <option value="Asian, Asian-American">Asian, Asian-American</option>
-                  <option value="European, European-American (Caucasian)">European, European-American (Caucasian)</option>
-                  <option value="Latino, Latino-American, Chicano">Latino, Latino-American, Chicano</option>
-                  <option value="Native American or Alaska Native">Native American or Alaska Native</option>
-                  <option value="Middle Eastern">Middle Eastern</option>
-                  <option value="Multiethnic">Multiethnic</option>
-                  <option value="Prefer to self-describe">Prefer to self-describe</option>
-                  <option value="Prefer not to say">Prefer not to say</option>
-                </select>
-              </label>
-            </div>
-            <div class="block form-group">
-              <label for="source-gender">
-                <b>Gender</b>
-                <select style="width: 100%" id="source-gender" name="source-gender">
-                  <option value="" disabled selected>Please choose</option>
-                  <option value="Female">Female</option>
-                  <option value="Male">Male</option>
-                  <option value="Non-binary/third gender">Non-binary/third gender</option>
-                  <option value="Transgender">Transgender</option>
-                  <option value="Agender">Agender</option>
-                  <option value="Genderqueer">Genderqueer</option>
-                  <option value="Prefer to self-describe">Prefer to self-describe</option>
-                  <option value="Prefer not to say">Prefer not to say</option>
-                </select>
-              </label>
-            </div>
-            <div class="block form-group">
-              <label for="source-sexual-orientation">
-                <b>Sexual Orientation</b>
-                <select style="width: 100%" id="source-sexual-orientation" name="source-sexual-orientation">
-                  <option value="" disabled selected>Please choose</option>
-                  <option value="Straight/Heterosexual">Straight/Heterosexual</option>
-                  <option value="Gay or Lesbian">Gay or Lesbian</option>
-                  <option value="Bisexual">Bisexual</option>
-                  <option value="Queer">Queer</option>
-                  <option value="Asexual">Asexual</option>
-                  <option value="Prefer to self-describe">Prefer to self-describe</option>
-                  <option value="Prefer not to say">Prefer not to say</option>
-                </select>
-              </label>
-            </div>
-            <div class="block form-group">
-              <label for="source-age">
-                <b>Age</b>
-                <select style="width: 100%" id="source-age" name="source-age">
-                  <option value="" disabled selected>Please choose</option>
-                  <option value="18-20">18-20</option>
-                  <option value="21-29">21-29</option>
-                  <option value="30-39">30-39</option>
-                  <option value="40-49">40-49</option>
-                  <option value="50-59">50-59</option>
-                  <option value="60 or older">60 or older</option>
-                </select>
-              </label>
-            </div>
-            <div class="block form-group">
-              <label for="source-zip-code">
-                <b>Zip Code</b>
-              </label>
-              <input id="source-zip-code" name="source-zip-code" type="text" />
-            </div>
-            <div class="block form-group">
-              <label for="source-email">
-                <b>Contact email address</b>
-              </label>
-              <input id="source-email" name="source-email" type="text" />
-            </div>
-            <div class="block form-group">
-              <label for="source-phone">
-                <b>Contact phone number</b>
-              </label>
-              <input id="source-phone" name="source-phone" type="text" />
-            </div>
-            <div class="block form-group">
-              <label for="source-role">
-                <b>Role in story</b>
-                <select style="width: 100%" id="source-role" name="source-role">
-                  <option value="" disabled selected>Please choose</option>
-                  <option value="Quoted">Quoted</option>
-                  <option value="Mentioned">Mentioned</option>
-                  <option value="Background">Background</option>
-                </select>
-              </label>
-            </div>
           </div>
 
           <div class="block">

--- a/Page.html
+++ b/Page.html
@@ -421,6 +421,7 @@
               ) {
               var source = data.data.articles[0].article_sources[0].source;
               console.log("found source: ", source);
+              fillInTextField('source-id', source.id);
               fillInTextField('source-name', source.name);
               fillInTextField('source-affiliation', source.affiliation);
               fillInTextField('source-zip-code', source.zip);
@@ -788,6 +789,7 @@
               <label for="source-name">
                 <b>Name</b>
               </label>
+              <input id="source-id" name="source-id" type="hidden" />
               <input id="source-name" name="source-name" type="text" />
             </div>
             <div class="block form-group">

--- a/Page.html
+++ b/Page.html
@@ -25,6 +25,18 @@
         }
       }
 
+      function addAnotherSource() {
+        var container = document.getElementById('sources-container')
+
+        container.appendChild(document.createTextNode("Source: "));
+        // Create an <input> element, set its type and name attributes
+        var input = document.createElement("input");
+        input.type = "text";
+        input.name = "source[].name";
+        container.appendChild(input);
+        // Append a line break 
+      }
+
       function displayCategories(categories, selectedCategory) {
         var articleCategorySelect = document.getElementById('article-category');
         var categoriesSorted = categories.sort(function (a, b) {
@@ -373,6 +385,57 @@
         }
       }
 
+      function createTextInputDiv(id, name, value) {
+        var fieldName = "source[" + id + "].name";
+        var div = document.createElement("div");
+        div.class = "block form-group"
+        var label = document.createElement("label");
+        label.setAttribute("for", fieldName);
+        label.innerHTML = "<b>" + name + ":</b>";
+        div.appendChild(label);
+        var input = document.createElement("input");
+        input.type = "text";
+        input.name = fieldName;
+        input.value = value;
+        div.appendChild(input);
+        return div
+      }
+
+      function createSelectDiv(id, name, value, choices) {
+        var fieldName = "source[" + id + "]." + name;
+
+        var div = document.createElement("div");
+        div.class = "block form-group"
+
+        var label = document.createElement("label");
+        label.setAttribute("for", fieldName);
+        label.innerHTML = "<b>" + name + ":</b>";
+        div.appendChild(label);
+
+        var select = document.createElement("select");
+        select.style = "width: 100%";
+        select.name = fieldName;
+
+        var pleaseChooseOption = document.createElement("option");
+        pleaseChooseOption.setAttribute("disabled", "");
+        pleaseChooseOption.setAttribute("selected", "");
+        pleaseChooseOption.value = "";
+        select.appendChild(pleaseChooseOption);
+
+        choices.forEach(choice => {
+          var option = document.createElement("option");
+          option.value = choice;
+          option.innerHTML = choice;
+          if (value === choice) {
+            option.selected = "selected";
+          }
+          select.appendChild(option);
+        })
+        div.appendChild(select);
+
+        return div;
+      }
+
       function selectOption(fieldName, fieldValue) {
         var field = document.getElementById(fieldName);
         var opts = field.options;
@@ -415,24 +478,116 @@
 
             if (
               data.data.articles[0] &&
-              data.data.articles[0].article_sources &&
-              data.data.articles[0].article_sources[0] &&
-              data.data.articles[0].article_sources[0].source
+              data.data.articles[0].article_sources
               ) {
-              var source = data.data.articles[0].article_sources[0].source;
-              console.log("found source: ", source);
-              fillInTextField('source-id', source.id);
-              fillInTextField('source-name', source.name);
-              fillInTextField('source-affiliation', source.affiliation);
-              fillInTextField('source-zip-code', source.zip);
-              fillInTextField('source-email', source.email);
-              fillInTextField('source-phone', source.phone);
-              selectOption('source-race', source.race);
-              selectOption('source-ethnicity', source.ethnicity);
-              selectOption('source-gender', source.gender);
-              selectOption('source-sexual-orientation', source.sexual_orientation);
-              selectOption('source-age', source.age);
-              selectOption('source-role', source.role);
+                var sources = data.data.articles[0].article_sources;
+                console.log("found " + sources.length + " sources");
+                sources.forEach(sourceData => {
+                  var source = sourceData.source;
+                  console.log("found source id# " + source.id);
+
+                  var sourceContainer = document.getElementById('sources-container');
+
+                  var nameDiv = createTextInputDiv(source.id, "name", source.name);
+                  sourceContainer.appendChild(nameDiv);
+
+                  var affDiv = createTextInputDiv(source.id, "affiliation", source.affiliation);
+                  sourceContainer.appendChild(affDiv);
+
+                  var races = [
+                    "White",
+                    "Black or African-American",
+                    "American Indian or Alaskan Native",
+                    "Asian",
+                    "Native Hawaiian or other Pacific Islander",
+                    "From multiple races",
+                    "Prefer to self-describe",
+                    "Prefer not to say"
+                  ];
+
+                  var raceDiv = createSelectDiv(source.id, "race", source.race, races);
+                  sourceContainer.appendChild(raceDiv);
+
+                  var ethnicities = [
+                    "African, African-American",
+                    "Asian, Asian-American",
+                    "European, European-American (Caucasian)",
+                    "Latino, Latino-American, Chicano",
+                    "Native American or Alaska Native",
+                    "Middle Eastern",
+                    "Multiethnic",
+                    "Prefer to self-describe",
+                    "Prefer not to say"
+                  ];
+                  var ethnicityDiv = createSelectDiv(source.id, "ethnicity", source.ethnicity, ethnicities);
+                  sourceContainer.appendChild(ethnicityDiv);
+
+                  var genders = [
+                    "Female",
+                    "Male",
+                    "Non-binary/third gender",
+                    "Transgender",
+                    "Agender",
+                    "Genderqueer",
+                    "Prefer to self-describe",
+                    "Prefer not to say"
+                  ];
+                  var genderDiv = createSelectDiv(source.id, "gender", source.gender, genders);
+                  sourceContainer.appendChild(genderDiv);
+
+                  var sexOrientations = [
+                    "Straight/Heterosexual",
+                    "Gay or Lesbian",
+                    "Bisexual",
+                    "Queer",
+                    "Asexual",
+                    "Prefer to self-describe",
+                    "Prefer not to say"
+                  ];
+                  var sexOrientationDiv = createSelectDiv(source.id, "sexual_orientation", source.sexual_orientation, sexOrientations);
+                  sourceContainer.appendChild(sexOrientationDiv);
+
+                  var ages = [
+                    "18-20",
+                    "21-29",
+                    "30-39",
+                    "40-49",
+                    "50-59",
+                    "60 or older"
+                  ];
+                  var ageDiv = createSelectDiv(source.id, "age", source.age, ages);
+                  sourceContainer.appendChild(ageDiv);
+
+                  var zipDiv = createTextInputDiv(source.id, "zip", source.zip);
+                  sourceContainer.appendChild(zipDiv);
+
+                  var emailDiv = createTextInputDiv(source.id, "email", source.email);
+                  sourceContainer.appendChild(emailDiv);
+
+                  var phoneDiv = createTextInputDiv(source.id, "phone", source.phone);
+                  sourceContainer.appendChild(phoneDiv);
+
+                  var roles = [
+                    "Quoted",
+                    "Mentioned",
+                    "Background"
+                  ];
+                  var roleDiv = createSelectDiv(source.id, "role", source.role, roles);
+                  sourceContainer.appendChild(roleDiv);
+
+                  // fillInTextField('source-id', source.id);
+                  // fillInTextField('source-name', source.name);
+                  // fillInTextField('source-affiliation', source.affiliation);
+                  // fillInTextField('source-zip-code', source.zip);
+                  // fillInTextField('source-email', source.email);
+                  // fillInTextField('source-phone', source.phone);
+                  // selectOption('source-race', source.race);
+                  // selectOption('source-ethnicity', source.ethnicity);
+                  // selectOption('source-gender', source.gender);
+                  // selectOption('source-sexual-orientation', source.sexual_orientation);
+                  // selectOption('source-age', source.age);
+                  // selectOption('source-role', source.role);
+                });
             }
         }
 
@@ -783,6 +938,10 @@
             <textarea id="article-twitter-description" name="article-twitter-description"></textarea>
           </div>
 
+          <div id="sources-container" class="articles-only">
+            <h2 class="title">Source Tracking</h2>
+          </div>
+
           <div id="source-tracking-form" class="articles-only">
             <h2 class="title">Source Tracking</h2>
             <div class="block form-group">
@@ -909,7 +1068,7 @@
 
           <div class="block">
             <p>
-              Add another source (to-do)
+              <button id="add-another-source" onClick="addAnotherSource()">Add another source</button>
             </p>
           </div>
 

--- a/Page.html
+++ b/Page.html
@@ -741,6 +741,130 @@
             </label>
             <textarea id="article-twitter-description" name="article-twitter-description"></textarea>
           </div>
+
+          <div id="source-tracking-form">
+            <h2 class="title">Source Tracking</h2>
+            <div class="block form-group">
+              <label for="source-name">
+                <b>Name</b>
+              </label>
+              <input id="source-name" name="source-name" type="text" />
+            </div>
+            <div class="block form-group">
+              <label for="source-affiliation">
+                <b>Affiliation</b>
+              </label>
+              <input id="source-affiliation" name="source-affiliation" type="text" />
+            </div>
+            <div class="block form-group">
+              <label for="source-race">
+                <b>Race</b>
+                <select style="width: 100%" id="source-race" name="source-race">
+                  <option value="" disabled selected>Please choose</option>
+                  <option value="White">White</option>
+                  <option value="Black or African-American">Black or African-American</option>
+                  <option value="American Indian or Alaskan Native">American Indian or Alaskan Native</option>
+                  <option value="Asian">Asian</option>
+                  <option value="Native Hawaiian or other Pacific Islander">Native Hawaiian or other Pacific Islander</option>
+                  <option value="From multiple races">From multiple races</option>
+                  <option value="Prefer to self-describe">Prefer to self-describe</option>
+                  <option value="Prefer not to say">Prefer not to say</option>
+                </select>
+              </label>
+            </div>
+            <div class="block form-group">
+              <label for="source-ethnicity">
+                <b>Ethnicity</b>
+                <select style="width: 100%" id="source-ethnicity" name="source-ethnicity">
+                  <option value="" disabled selected>Please choose</option>
+                  <option value="African, African-American">African, African-American</option>
+                  <option value="Asian, Asian-American">Asian, Asian-American</option>
+                  <option value="European, European-American (Caucasian)">European, European-American (Caucasian)</option>
+                  <option value="Latino, Latino-American, Chicano">Latino, Latino-American, Chicano</option>
+                  <option value="Native American or Alaska Native">Native American or Alaska Native</option>
+                  <option value="Middle Eastern">Middle Eastern</option>
+                  <option value="Multiethnic">Multiethnic</option>
+                  <option value="Prefer to self-describe">Prefer to self-describe</option>
+                  <option value="Prefer not to say">Prefer not to say</option>
+                </select>
+              </label>
+            </div>
+            <div class="block form-group">
+              <label for="source-gender">
+                <b>Gender</b>
+                <select style="width: 100%" id="source-gender" name="source-gender">
+                  <option value="" disabled selected>Please choose</option>
+                  <option value="Female">Female</option>
+                  <option value="Male">Male</option>
+                  <option value="Non-binary/third gender">Non-binary/third gender</option>
+                  <option value="Transgender">Transgender</option>
+                  <option value="Agender">Agender</option>
+                  <option value="Genderqueer">Genderqueer</option>
+                  <option value="Prefer to self-describe">Prefer to self-describe</option>
+                  <option value="Prefer not to say">Prefer not to say</option>
+                </select>
+              </label>
+            </div>
+            <div class="block form-group">
+              <label for="source-sexual-orientation">
+                <b>Sexual Orientation</b>
+                <select style="width: 100%" id="source-sexual-orientation" name="source-sexual-orientation">
+                  <option value="" disabled selected>Please choose</option>
+                  <option value="Straight/Heterosexual">Straight/Heterosexual</option>
+                  <option value="Gay or Lesbian">Gay or Lesbian</option>
+                  <option value="Bisexual">Bisexual</option>
+                  <option value="Queer">Queer</option>
+                  <option value="Asexual">Asexual</option>
+                  <option value="Prefer to self-describe">Prefer to self-describe</option>
+                  <option value="Prefer not to say">Prefer not to say</option>
+                </select>
+              </label>
+            </div>
+            <div class="block form-group">
+              <label for="source-age">
+                <b>Age</b>
+                <select style="width: 100%" id="source-age" name="source-age">
+                  <option value="" disabled selected>Please choose</option>
+                  <option value="18-20">18-20</option>
+                  <option value="21-29">21-29</option>
+                  <option value="30-39">30-39</option>
+                  <option value="40-49">40-49</option>
+                  <option value="50-59">50-59</option>
+                  <option value="60 or older">60 or older</option>
+                </select>
+              </label>
+            </div>
+            <div class="block form-group">
+              <label for="source-zip-code">
+                <b>Zip Code</b>
+              </label>
+              <input id="source-zip-code" name="source-zip-code" type="text" />
+            </div>
+            <div class="block form-group">
+              <label for="source-email">
+                <b>Contact email address</b>
+              </label>
+              <input id="source-email" name="source-email" type="text" />
+            </div>
+            <div class="block form-group">
+              <label for="source-phone">
+                <b>Contact phone number</b>
+              </label>
+              <input id="source-phone" name="source-phone" type="text" />
+            </div>
+            <div class="block form-group">
+              <label for="source-role">
+                <b>Role in story</b>
+                <select style="width: 100%" id="source-role" name="source-role">
+                  <option value="" disabled selected>Please choose</option>
+                  <option value="Quoted">Quoted</option>
+                  <option value="Mentioned">Mentioned</option>
+                  <option value="Background">Background</option>
+                </select>
+              </label>
+            </div>
+          </div>
+
           <div class="block" id="action-buttons-bottom">
             <input type="submit" name="preview" id="preview-button-bottom" class="blue" value="Preview" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="publish-button-bottom" value="Publish" onclick="this.form.submitted=this.value;"/>


### PR DESCRIPTION
This PR continues the source tracking work of #270 by:

* rendering all source tracking fields dynamically, keyed off source `id` - note this is for existing sources, I need to do more work for the "add a new source" instance
* saving the source data from the dynamically rendered fields

So, functionally this shouldn't change behavior from PR #270, but it sets up the front- & back-end code to handle a dynamic number of sources.

Test by using version 75 of the add-on, "Source tracking: update source from dynamically rendered form fields".