### PR TITLE
Clickable list of sources

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -451,6 +451,8 @@ function insertArticleGoogleDocs(data) {
     })
     articleData["article_sources"] =  dataSources;
     Logger.log("pushed sources onto article data:" + JSON.stringify(articleData['article_sources']));
+  } else {
+    articleData['article_sources'] = [];
   }
 
   Logger.log("article data:" + JSON.stringify(articleData));
@@ -689,6 +691,7 @@ async function hasuraHandlePublish(formObject) {
     documentType = "article";
     // insert or update article
     var data = await insertArticleGoogleDocs(formObject);
+    console.log(data);
     var articleID = data.data.insert_articles.returning[0].id;
     var categorySlug = data.data.insert_articles.returning[0].category.slug;
     var articleSlug = data.data.insert_articles.returning[0].slug;

--- a/Code.js
+++ b/Code.js
@@ -415,36 +415,11 @@ function insertArticleGoogleDocs(data) {
     "created_by_email": data['created_by_email'],
   };
 
-  let sources = {};
-  
-  Object.keys(data).forEach(key => {
-    let keyMatch = key.match(/source\[(.*?)\]\.(.*?)$/);
-    if (keyMatch) {
-      var id = keyMatch[1];
-      var fieldName = keyMatch[2];
-      var val = data[key];
-
-      if (/new_/.test(id)) {
-        Logger.log("new source! " + id);
-      }
-      if (sources[id] === null || sources[id] === undefined) {
-        if (id === null || id === "" || id === undefined || /new_/.test(id)) {
-          sources[id] = {};
-        } else { // don't set the id for a new source
-          sources[id] = {id: id};
-        }
-        sources[id][fieldName] = val;
-      }
-      sources[id][fieldName] = val;
-      // Logger.log("id #" + id + ": " + fieldName + " => " + val);
-    }
-  })
-
   var dataSources = [];
-  if (sources !== {} && Object.keys(sources).length > 0) {
-    Object.keys(sources).forEach(id => {
+  if (data['sources'] !== {} && Object.keys(data['sources']).length > 0) {
+    Object.keys(data['sources']).forEach(id => {
       Logger.log("id: " + typeof(id) + " -> " + id)
-      var source = sources[id];
+      var source = data['sources'][id];
 
       var sourceData = {
         name: source['name'],
@@ -848,7 +823,7 @@ async function hasuraHandlePreview(formObject) {
   } else {
     documentType = "article";
     // insert or update article
-    Logger.log("formObject:" + JSON.stringify(formObject));
+    Logger.log("sources:" + JSON.stringify(formObject['sources']));
 
     var data = await insertArticleGoogleDocs(formObject);
     Logger.log("articleResult: " + JSON.stringify(data))

--- a/Page.html
+++ b/Page.html
@@ -483,7 +483,7 @@
           "Native Hawaiian or other Pacific Islander",
           "From multiple races",
           "Prefer to self-describe",
-          "Prefer not to say"
+          "Other"
         ];
         var raceDiv = createSelectDiv(id, "Race", "race", data.race, races);
         sourceContainer.appendChild(raceDiv);
@@ -497,7 +497,7 @@
           "Middle Eastern",
           "Multiethnic",
           "Prefer to self-describe",
-          "Prefer not to say"
+          "Other"
         ];
 
         var ethnicityDiv = createSelectDiv(id, "Ethnicity", "ethnicity", data.ethnicity, ethnicities);
@@ -511,7 +511,7 @@
           "Agender",
           "Genderqueer",
           "Prefer to self-describe",
-          "Prefer not to say"
+          "Other"
         ];
 
         var genderDiv = createSelectDiv(id, "Gender", "gender", data.gender, genders);
@@ -524,7 +524,7 @@
           "Queer",
           "Asexual",
           "Prefer to self-describe",
-          "Prefer not to say"
+          "Other"
         ];
 
         var sexOrientationDiv = createSelectDiv(id, 'Sexual Orientation', "sexual_orientation", data.sexual_orientation, sexOrientations);

--- a/Page.html
+++ b/Page.html
@@ -663,7 +663,7 @@
 
                   var sourceListItem = document.createElement("li");
                   sourceListItem.style.cursor = "pointer";
-                  sourceListItem.innerHTML = "<span onClick='expandSource(" + source.id + ")'>" + source.name + "</span>";
+                  sourceListItem.innerHTML = "<a onClick='expandSource(" + source.id + ")'>" + source.name + "</a>";
                   sourceUnorderedList.appendChild(sourceListItem)
                 });
             }
@@ -844,11 +844,20 @@
             var phone = sources[id]['phone'];
             var name = sources[id]['name'];
             
-            if (name && (phone || email)) {
-              console.log(name, "has a phone or email:", phone, email);
+            if (/new_/.test(id) && !name && !email && !phone) {
+              console.log(id, " has a blank source form; omit")
+              // remove blank source from the list
+              delete sources[id]
+              console.log(sources);
+
             } else {
-              errorMessage += "<br>All sources must have either a phone or email.";
-              formIsValid = false;
+              if (name && (phone || email)) {
+                console.log(name, "has a phone or email:", phone, email);
+              } else {
+                console.log(id, name, "is missing a phone/email")
+                errorMessage += "<br>All sources must have either a phone or email.";
+                formIsValid = false;
+              }
             }
           })
 

--- a/Page.html
+++ b/Page.html
@@ -908,6 +908,7 @@
             submitData[key] = value;
           }
         }
+
         submitData["sources"] = sources;
         console.log("submitData:", submitData);
 
@@ -915,8 +916,18 @@
           loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
           google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePreview(submitData);
         } else if ( formIsValid && (formObject.submitted === "Publish") || (formObject.submitted === "Re-publish") ) {
-          loadingDiv.innerHTML = "<p class='gray'>Publishing article... </p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
+          if ($.isEmptyObject(sources)) {
+            if (!window.confirm("You're trying to publish an article without any source tracking info: are you sure?")) { 
+              form.style.display = "block";
+              loadingDiv.innerHTML = "Please enter source tracking info, then try publishing again.";
+            } else {
+              loadingDiv.innerHTML = "<p class='gray'>Publishing article without any sources... </p>"
+              google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
+            }
+          } else {
+            loadingDiv.innerHTML = "<p class='gray'>Publishing article... </p>"
+            google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
+          }
         } else if ( formIsValid) {
           loadingDiv.innerHTML = "<p class='gray'>Unpublishing article... </p>"
           var articleId = document.getElementById('article-id').value;

--- a/Page.html
+++ b/Page.html
@@ -662,6 +662,7 @@
                   addAnotherSource(source.id, source);
 
                   var sourceListItem = document.createElement("li");
+                  sourceListItem.style.cursor = "pointer";
                   sourceListItem.innerHTML = "<span onClick='expandSource(" + source.id + ")'>" + source.name + "</span>";
                   sourceUnorderedList.appendChild(sourceListItem)
                 });

--- a/Page.html
+++ b/Page.html
@@ -817,12 +817,12 @@
         var searchTitle = document.getElementById('article-search-title');
         var searchDescription = document.getElementById('article-search-description');
 
+        var sources = {};
         if (documentType === "article")  {
           var elements = formObject.elements;
 
           // build up an object with source data
           // keys are source ids
-          var sources = {};
           for (var i = 0, element; element = elements[i++];) {
             var elementMatch = element.name.match(/source\[(.*?)\]\.(.*?)$/);
             if (elementMatch) {
@@ -844,22 +844,36 @@
             var phone = sources[id]['phone'];
             var name = sources[id]['name'];
             
-            if (/new_/.test(id) && !name && !email && !phone) {
+            // name is required
+            if (!/new_/.test(id) && !name) {
+              errorMessage += "<br>'Name' is required on all sources.";
+              delete sources[id];
+              formIsValid = false;
+
+            // new source form that lacks a name, email and phone should be omitted
+            } else if (/new_/.test(id) && (!name && !email && !phone) ) {
               console.log(id, " has a blank source form; omit")
               // remove blank source from the list
-              delete sources[id]
+              delete sources[id];
               console.log(sources);
 
             } else {
               if (name && (phone || email)) {
-                console.log(name, "has a phone or email:", phone, email);
+                console.log(name, "has a name + a phone or email:", phone, email);
+              } else if (!name) {
+                errorMessage += "<br>'Name' is required on all sources.";
+                delete sources[id];
+                formIsValid = false;
               } else {
                 console.log(id, name, "is missing a phone/email")
+                delete sources[id];
                 errorMessage += "<br>All sources must have either a phone or email.";
                 formIsValid = false;
               }
             }
           })
+
+          console.log("sources:", sources);
 
           var selectedAuthors = $('#article-authors').select2('data')
           var customByline = document.getElementById("article-custom-byline").value;
@@ -882,12 +896,27 @@
           formIsValid = false;
         }
 
+        // assemble the data to submit - unfortunately we can't pass the form object with any additional data here
+        console.log("formObject:", formObject);
+        var submitData = {};
+        var elements = formObject.elements;
+        for (var i = 0, element; element = elements[i++];) {
+          var key = element.name;
+          var value = element.value;
+          console.log(key, typeof(value), value);
+          if ( !(/source/).test(key) ) {
+            submitData[key] = value;
+          }
+        }
+        submitData["sources"] = sources;
+        console.log("submitData:", submitData);
+
         if (formIsValid && formObject.submitted === "Preview") {
           loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePreview(formObject);
+          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePreview(submitData);
         } else if ( formIsValid && (formObject.submitted === "Publish") || (formObject.submitted === "Re-publish") ) {
           loadingDiv.innerHTML = "<p class='gray'>Publishing article... </p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(formObject);
+          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
         } else if ( formIsValid) {
           loadingDiv.innerHTML = "<p class='gray'>Unpublishing article... </p>"
           var articleId = document.getElementById('article-id').value;

--- a/Page.html
+++ b/Page.html
@@ -439,6 +439,24 @@
         }
       }
 
+      function expandSource(sourceId) {
+        console.log("expanding source: ", sourceId);
+        var sourceContainer = document.getElementById('sources-container');
+        console.log(sourceContainer.children);
+        // first hide all source forms
+        var i;
+        for (i = 0; i < sourceContainer.children.length; i++) {
+        // sourceContainer.children.forEach(el => {
+          var el = sourceContainer.children[i];
+          if (/source-form-/.test(el.id)) {
+            console.log("hiding source form: ", el.id, el.style.display);
+            el.style.display = "none";
+          }
+        }
+        var sourceFormDiv = document.getElementById("source-form-" + sourceId);
+        sourceFormDiv.style.display = "block";
+      }
+
       function addAnotherSourceForm() {
         // determine how many new field sets there are
         // call addAnotherSource with the right id
@@ -463,17 +481,24 @@
         counterField.value = newCount;
         var newId = "new_" + newCount;
         console.log("adding new source with id", newId)
-        addAnotherSource(newId, blankSource);
+        addAnotherSource(newId, blankSource, true);
 
       }
 
-      function addAnotherSource(id, data) {
+      function addAnotherSource(id, data, showForm) {
         var sourceContainer = document.getElementById('sources-container');
+
+        var formDiv = document.createElement("div");
+        if (!showForm) {
+          formDiv.style.display = "none";
+        }
+        formDiv.id = "source-form-" + id;
+
         var nameDiv = createTextInputDiv(id, "Name", "name", data.name);
-        sourceContainer.appendChild(nameDiv);
+        formDiv.appendChild(nameDiv);
 
         var affDiv = createTextInputDiv(id, "Affiliation", "affiliation", data.affiliation)
-        sourceContainer.appendChild(affDiv);
+        formDiv.appendChild(affDiv);
 
         var races = [
           "White",
@@ -486,7 +511,7 @@
           "Other"
         ];
         var raceDiv = createSelectDiv(id, "Race", "race", data.race, races);
-        sourceContainer.appendChild(raceDiv);
+        formDiv.appendChild(raceDiv);
 
         var ethnicities = [
           "African, African-American",
@@ -501,7 +526,7 @@
         ];
 
         var ethnicityDiv = createSelectDiv(id, "Ethnicity", "ethnicity", data.ethnicity, ethnicities);
-        sourceContainer.appendChild(ethnicityDiv);
+        formDiv.appendChild(ethnicityDiv);
 
         var genders = [
           "Female",
@@ -515,7 +540,7 @@
         ];
 
         var genderDiv = createSelectDiv(id, "Gender", "gender", data.gender, genders);
-        sourceContainer.appendChild(genderDiv);
+        formDiv.appendChild(genderDiv);
 
         var sexOrientations = [
           "Straight/Heterosexual",
@@ -528,7 +553,7 @@
         ];
 
         var sexOrientationDiv = createSelectDiv(id, 'Sexual Orientation', "sexual_orientation", data.sexual_orientation, sexOrientations);
-        sourceContainer.appendChild(sexOrientationDiv);
+        formDiv.appendChild(sexOrientationDiv);
 
         var ages = [
           "18-20",
@@ -540,16 +565,16 @@
         ];
 
         var ageDiv = createSelectDiv(id, "Age", "age", data.age, ages);
-        sourceContainer.appendChild(ageDiv);
+        formDiv.appendChild(ageDiv);
 
         var zipDiv = createTextInputDiv(id, "Zip Code", "zip", data.zip);
-        sourceContainer.appendChild(zipDiv);
+        formDiv.appendChild(zipDiv);
 
         var emailDiv = createTextInputDiv(id, "Contact Email Address", "email", data.email);
-        sourceContainer.appendChild(emailDiv);
+        formDiv.appendChild(emailDiv);
 
         var phoneDiv = createTextInputDiv(id, "Contact Phone Number", "phone", data.phone);
-        sourceContainer.appendChild(phoneDiv);
+        formDiv.appendChild(phoneDiv);
 
         var roles = [
           "Quoted",
@@ -558,11 +583,14 @@
         ];
 
         var roleDiv = createSelectDiv(id, "Role", "role", data.role, roles);
-        sourceContainer.appendChild(roleDiv);
+        formDiv.appendChild(roleDiv);
 
         var dividerLine = document.createElement("hr");
         dividerLine.setAttribute("width", "100%");
-        sourceContainer.appendChild(dividerLine);
+        formDiv.appendChild(dividerLine);
+
+        sourceContainer.appendChild(formDiv);
+
       }
 
       function handleGetTranslationsForArticle(data) {
@@ -616,6 +644,9 @@
             addAnotherSource("new_1", blankSource);
             sourcesCounter += 1;
 
+            var sourceListContainer = document.getElementById('sources-list-container');
+            var sourceUnorderedList = document.createElement("ul");
+
             // then loop over existing sources and render the filled-in set of form fields
             if (
               data.data.articles[0] &&
@@ -629,8 +660,14 @@
                   console.log("found source id# " + source.id);
 
                   addAnotherSource(source.id, source);
+
+                  var sourceListItem = document.createElement("li");
+                  sourceListItem.innerHTML = "<span onClick='expandSource(" + source.id + ")'>" + source.name + "</span>";
+                  sourceUnorderedList.appendChild(sourceListItem)
                 });
             }
+
+            sourceListContainer.appendChild(sourceUnorderedList);
 
             var counterField = document.getElementById("source-tracking-counter");
             counterField.value = sourcesCounter;
@@ -1017,8 +1054,12 @@
             <textarea id="article-twitter-description" name="article-twitter-description"></textarea>
           </div>
 
-          <div id="sources-container" class="articles-only">
+          <div id="sources-list-container" class="block form-group">
             <h2 class="title">Source Tracking</h2>
+
+          </div>
+
+          <div id="sources-container" class="articles-only">
             <input type="hidden" name="source-tracking-counter" value="0" id="source-tracking-counter" />
           </div>
 

--- a/Page.html
+++ b/Page.html
@@ -780,6 +780,40 @@
         var searchDescription = document.getElementById('article-search-description');
 
         if (documentType === "article")  {
+          var elements = formObject.elements;
+
+          // build up an object with source data
+          // keys are source ids
+          var sources = {};
+          for (var i = 0, element; element = elements[i++];) {
+            var elementMatch = element.name.match(/source\[(.*?)\]\.(.*?)$/);
+            if (elementMatch) {
+              var id = elementMatch[1];
+              if (sources[id] === undefined) {
+                sources[id] = {};
+              }
+              var fieldName = elementMatch[2];
+              var value = element.value;
+              console.log(id, fieldName, value);
+
+              sources[id][fieldName] = value
+            }
+          }
+
+          // loop over sources and check that each has either an email or phone specified
+          Object.keys(sources).forEach(id => {
+            var email = sources[id]['email'];
+            var phone = sources[id]['phone'];
+            var name = sources[id]['name'];
+            
+            if (name && (phone || email)) {
+              console.log(name, "has a phone or email:", phone, email);
+            } else {
+              errorMessage += "<br>All sources must have either a phone or email.";
+              formIsValid = false;
+            }
+          })
+
           var selectedAuthors = $('#article-authors').select2('data')
           var customByline = document.getElementById("article-custom-byline").value;
           if ( (selectedAuthors === undefined || selectedAuthors.length <= 0) && ( customByline === null || customByline === undefined || customByline === "") ) {


### PR DESCRIPTION
Closes #269 

**UPDATED: this is testable at 'latest code' in the script editor**: responded to feedback on:

* source links not looking like links - you're right, they're now anchor tags
* validation issue: the code was trying to validate the "new source" hidden form(s); I fixed this so any blank source form is not validated & omitted from the list sent to the server
* confirm when trying to publish without any sources: allow to continue (publish anyway) or return to the form for more editing

~This is testable at version 76.~

I think this completes at least the initial version of source tracking for the docs sidebar. This PR adds:

* a list of existing sources to the top of the "Source Tracking" section
* hides all source forms
* adds onclick to each source list item to toggle which source field set is displayed
* ensures that "add another" results in a displayed set of fields