### PR TITLE
Fixed menu item - removed 'webiny'

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -15,7 +15,7 @@ function onInstall(e) {
 function onOpen(e) {
   // display sidebar
   DocumentApp.getUi()
-    .createMenu('TNC Tools')
+    .createMenu('TinyCMS Publishing Tools')
     .addItem('Publishing Tools', 'showSidebar')
     .addItem('Administrator Tools', 'showSidebarManualAssociate')
     .addToUi();

--- a/Code.js
+++ b/Code.js
@@ -10,12 +10,12 @@ function onInstall(e) {
  * The event handler triggered when opening the document.
  * @param {Event} e The onOpen event.
  *
- * This adds a "Webiny" menu option.
+ * This adds a "TNC Tools" menu option.
  */
 function onOpen(e) {
   // display sidebar
   DocumentApp.getUi()
-    .createMenu('Webiny')
+    .createMenu('TNC Tools')
     .addItem('Publishing Tools', 'showSidebar')
     .addItem('Administrator Tools', 'showSidebarManualAssociate')
     .addToUi();


### PR DESCRIPTION
Closes #265 

I think I've covered all the bases where this add-on gets a name, but I also think it needs time to rollout the changes 🤞

* code (in this PR): menu item changed from "Webiny" to "TinyCMS Publishing Tools"
* note: I haven't been able to find a single place, either "run as add-on" or the published version, where either of those menu item labels are used
* [google cloud platform project](https://console.cloud.google.com/apis/api/appsmarket-component.googleapis.com/googleapps_sdk?project=webiny-sidebar-publishing&authuser=0) associated with the app script renamed to "TinyCMS Publishing Tools"
* marketplace listing info updated, new screenshots and logos included - I suspect that's where it was getting the menu item name I was seeing, and still am: "Tiny News Webiny Publishing Sidebar"
* new version of the add-on with this change: 78
* add-on completely published at version 78 (this doesn't include the source tracking)

Hopefully this page will be updated by tomorrow: https://workspace.google.com/marketplace/app/tiny_news_webiny_publishing_sidebar/1027657873629 At the moment I'm seeing very old content and rough placeholder screenshots.

Next thing to try: removing the add-on from our organization's add-ons and adding it back again fresh. I didn't try that because of how much of a pain it was the last time. That would happen here though: https://workspace.google.com/marketplace/mydomainapps