### PR TITLE
Renamed all graphql queries and mutations with descriptive terms

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -311,7 +311,7 @@ async function fetchGraphQL(operationsDoc, operationName, variables) {
 function storeArticleIdAndSlug(id, slug) {
   return fetchGraphQL(
     insertArticleSlugVersion,
-    "MyMutation",
+    "AddonInsertArticleSlugVersion",
     {
       article_id: id,
       slug: slug
@@ -322,7 +322,7 @@ function storeArticleIdAndSlug(id, slug) {
 function storePageIdAndSlug(id, slug) {
   return fetchGraphQL(
     insertPageSlugVersion,
-    "MyMutation",
+    "AddonInsertPageSlugVersion",
     {
       page_id: id,
       slug: slug
@@ -356,7 +356,7 @@ function insertPageGoogleDocs(data) {
     Logger.log("page data:" + JSON.stringify(pageData));
     return fetchGraphQL(
       insertPageGoogleDocsMutationWithoutId,
-      "MyMutation",
+      "AddonInsertPageGoogleDocNoID",
       pageData
     );
 
@@ -365,7 +365,7 @@ function insertPageGoogleDocs(data) {
     Logger.log("page data:" + JSON.stringify(pageData));
     return fetchGraphQL(
       insertPageGoogleDocsMutation,
-      "MyMutation",
+      "AddonInsertPageGoogleDocWithID",
       pageData
     );
   }
@@ -374,7 +374,7 @@ function insertPageGoogleDocs(data) {
 function upsertPublishedArticle(articleId, translationId, localeCode) {
   return fetchGraphQL(
     upsertPublishedArticleTranslationMutation,
-    "MyMutation",
+    "AddonUpsertPublishedArticleTranslation",
     {
       article_id: articleId,
       locale_code: localeCode,
@@ -404,7 +404,7 @@ function insertArticleGoogleDocs(data) {
     "locale_code": data['article-locale'],
     "headline": data['article-headline'],
     "published": data['published'],
-    // "content": content,
+    "content": content,
     "search_description": data['article-search-description'],
     "search_title": data['article-search-title'],
     "twitter_title": data['article-twitter-title'],
@@ -459,14 +459,14 @@ function insertArticleGoogleDocs(data) {
   if (data["article-id"] === "") {
     return fetchGraphQL(
       insertArticleGoogleDocMutationWithoutId,
-      "MyMutation",
+      "AddonInsertArticleGoogleDocNoID",
       articleData
     );
   } else {
     articleData['id'] = data['article-id'];
     return fetchGraphQL(
       insertArticleGoogleDocMutation,
-      "MyMutation",
+      "AddonInsertArticleGoogleDocWithID",
       articleData
     );
   }
@@ -475,7 +475,7 @@ function insertArticleGoogleDocs(data) {
 async function hasuraCreateAuthorPage(authorId, pageId) {
   return fetchGraphQL(
     insertAuthorPageMutation,
-    "MyMutation",
+    "AddonInsertAuthorPage",
     {
       page_id: pageId,
       author_id: authorId
@@ -486,7 +486,7 @@ async function hasuraCreateAuthorPage(authorId, pageId) {
 async function hasuraCreateAuthorArticle(authorId, articleId) {
   return fetchGraphQL(
     insertAuthorArticleMutation,
-    "MyMutation",
+    "AddonInsertAuthorArticle",
     {
       article_id: articleId,
       author_id: authorId
@@ -495,10 +495,9 @@ async function hasuraCreateAuthorArticle(authorId, articleId) {
 }
 
 async function linkDocToArticle(data) {
-  Logger.log("linkDoc params: " + JSON.stringify(data))
   return fetchGraphQL(
     linkDocToArticleMutation,
-    "MyMutation",
+    "AddonLinkGoogleDocToArticle",
     {
       article_id: data['article-id'],
       document_id: data['document-id'],
@@ -511,7 +510,7 @@ async function linkDocToArticle(data) {
 async function hasuraInsertGoogleDoc(articleId, docId, localeCode, url) {
   return fetchGraphQL(
     insertGoogleDocMutation,
-    "MyMutation",
+    "AddonInsertGoogleDoc",
     {
       article_id: articleId,
       document_id: docId,
@@ -580,7 +579,7 @@ async function hasuraUnpublishArticle(articleId, localeCode) {
 
   return fetchGraphQL(
     unpublishArticleMutation,
-    "MyMutation",
+    "AddonUnpublishArticle",
     {
       article_id: articleId,
       locale_code: localeCode
@@ -591,7 +590,7 @@ async function hasuraUnpublishArticle(articleId, localeCode) {
 async function hasuraCreateTag(tagData) {
   return fetchGraphQL(
     insertTagMutation,
-    "MyMutation",
+    "AddonInsertTag",
     tagData
   );
 }
@@ -891,7 +890,7 @@ async function hasuraHandlePreview(formObject) {
 function fetchArticleForGoogleDoc(doc_id) {
   return fetchGraphQL(
     getArticleByGoogleDocQuery,
-    "MyQuery",
+    "AddonGetArticleByGoogleDoc",
     {"doc_id": doc_id}
   );
 }
@@ -899,7 +898,7 @@ function fetchArticleForGoogleDoc(doc_id) {
 function fetchPageForGoogleDoc(doc_id) {
   return fetchGraphQL(
     getPageForGoogleDocQuery,
-    "MyQuery",
+    "AddonGetPageForGoogleDoc",
     {"doc_id": doc_id}
   );
 }
@@ -907,7 +906,7 @@ function fetchPageForGoogleDoc(doc_id) {
 function fetchFeaturedArticles() {
   return fetchGraphQL(
     getHomepageFeaturedArticles,
-    "MyQuery"
+    "AddonGetHomepageFeaturedArticles"
   );
 }
 
@@ -952,7 +951,7 @@ function hasuraSearchArticles(formObject) {
   var term = "%" + formObject["article-search"] + "%";
   return fetchGraphQL(
     searchArticlesByHeadlineQuery,
-    "MyQuery",
+    "AddonSearchArticlesByHeadline",
     {"term": term, "locale_code": localeCode}
   );
 }
@@ -974,7 +973,7 @@ async function getPageForGoogleDoc(doc_id) {
 function fetchTranslationDataForPage(docId, pageId, localeCode) {
   return fetchGraphQL(
     getPageTranslationForIdAndLocale,
-    "MyQuery",
+    "AddonGetPageTranslationByLocaleAndID",
     {"doc_id": docId, "page_id": pageId, "locale_code": localeCode}
   );
 }
@@ -982,7 +981,7 @@ function fetchTranslationDataForPage(docId, pageId, localeCode) {
 function fetchTranslationDataForArticle(docId, articleId, localeCode) {
   return fetchGraphQL(
     getArticleTranslationForIdAndLocale,
-    "MyQuery",
+    "AddonGetArticleTranslationByLocaleAndID",
     {"doc_id": docId, "article_id": articleId, "locale_code": localeCode}
   );
 }

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -1,30 +1,30 @@
 /* Mutations */
 
-const insertArticleSlugVersion = `mutation MyMutation($article_id: Int!, $slug: String!) {
+const insertArticleSlugVersion = `mutation AddonInsertArticleSlugVersion($article_id: Int!, $slug: String!) {
   insert_article_slug_versions(objects: {article_id: $article_id, slug: $slug}, on_conflict: {constraint: slug_versions_pkey, update_columns: article_id}) {
     affected_rows
   }
 }`;
 
-const insertPageSlugVersion = `mutation MyMutation($slug: String!, $page_id: Int!) {
+const insertPageSlugVersion = `mutation AddonInsertPageSlugVersion($slug: String!, $page_id: Int!) {
   insert_page_slug_versions(objects: {page_id: $page_id, slug: $slug}, on_conflict: {constraint: page_slug_versions_pkey, update_columns: page_id}) {
     affected_rows
   }
 }`;
 
-const insertAuthorArticleMutation = `mutation MyMutation($article_id: Int!, $author_id: Int!) {
+const insertAuthorArticleMutation = `mutation AddonInsertAuthorArticle($article_id: Int!, $author_id: Int!) {
   insert_author_articles(objects: {article_id: $article_id, author_id: $author_id}, on_conflict: {constraint: author_articles_article_id_author_id_key, update_columns: article_id}) {
     affected_rows
   }
 }`;
 
-const insertAuthorPageMutation = `mutation MyMutation($page_id: Int!, $author_id: Int!) {
+const insertAuthorPageMutation = `mutation AddonInsertAuthorPage($page_id: Int!, $author_id: Int!) {
   insert_author_pages(objects: {page_id: $page_id, author_id: $author_id}, on_conflict: {constraint: author_pages_page_id_author_id_key, update_columns: page_id}) {
     affected_rows
   }
 }`;
 
-const insertArticleGoogleDocMutationWithoutId = `mutation MyMutation($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $article_sources: [article_source_insert_input!]!) {
+const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoogleDocNoID($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
       article_translations: {
@@ -122,7 +122,7 @@ const insertArticleGoogleDocMutationWithoutId = `mutation MyMutation($locale_cod
     }
   }
 }`;
-const insertArticleGoogleDocMutation = `mutation MyMutation($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, 
+const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, 
   $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
@@ -209,13 +209,13 @@ const insertArticleGoogleDocMutation = `mutation MyMutation($id: Int!, $locale_c
   }
 }`;
 
-const insertGoogleDocMutation = `mutation MyMutation($article_id: Int!, $document_id: String!, $locale_code: String!, $url: String) {
+const insertGoogleDocMutation = `mutation AddonInsertGoogleDoc($article_id: Int!, $document_id: String!, $locale_code: String!, $url: String) {
   insert_article_google_documents(objects: {article_id: $article_id, google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: url}}}, on_conflict: {constraint: article_google_documents_article_id_google_document_id_key, update_columns: google_document_id}) {
     affected_rows
   }
 }`;
 
-const insertPageGoogleDocsMutationWithoutId = `mutation MyMutation($slug: String!, $locale_code: String!, $created_by_email: String, $document_id: String, $url: String, $facebook_title: String, $facebook_description: String, $search_title: String, $search_description: String, $headline: String, $twitter_title: String, $twitter_description: String, $content: jsonb, $published: Boolean) {
+const insertPageGoogleDocsMutationWithoutId = `mutation AddonInsertPageGoogleDocNoID($slug: String!, $locale_code: String!, $created_by_email: String, $document_id: String, $url: String, $facebook_title: String, $facebook_description: String, $search_title: String, $search_description: String, $headline: String, $twitter_title: String, $twitter_description: String, $content: jsonb, $published: Boolean) {
   insert_pages(objects: {page_google_documents: {data: {google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: [document_id]}}}, on_conflict: {constraint: page_google_documents_page_id_google_document_id_key, update_columns: [google_document_id]}}, slug: $slug, page_translations: {data: {created_by_email: $created_by_email, published: $published, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, locale_code: $locale_code, headline: $headline, facebook_title: $facebook_title, facebook_description: $facebook_description, content: $content}}}, on_conflict: {constraint: pages_slug_organization_id_key, update_columns: [slug, updated_at]}) {
     returning {
       id
@@ -231,7 +231,7 @@ const insertPageGoogleDocsMutationWithoutId = `mutation MyMutation($slug: String
     }
   }
 }`;
-const insertPageGoogleDocsMutation = `mutation MyMutation($id: Int!, $slug: String!, $locale_code: String!, $created_by_email: String, $document_id: String, $url: String, $facebook_title: String, $facebook_description: String, $search_title: String, $search_description: String, $headline: String, $twitter_title: String, $twitter_description: String, $content: jsonb, $published: Boolean) {
+const insertPageGoogleDocsMutation = `mutation AddonInsertPageGoogleDocWithID($id: Int!, $slug: String!, $locale_code: String!, $created_by_email: String, $document_id: String, $url: String, $facebook_title: String, $facebook_description: String, $search_title: String, $search_description: String, $headline: String, $twitter_title: String, $twitter_description: String, $content: jsonb, $published: Boolean) {
   insert_pages(objects: {page_google_documents: {data: {google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: [document_id]}}}, on_conflict: {constraint: page_google_documents_page_id_google_document_id_key, update_columns: [google_document_id]}}, id: $id, slug: $slug, page_translations: {data: {created_by_email: $created_by_email, published: $published, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, locale_code: $locale_code, headline: $headline, facebook_title: $facebook_title, facebook_description: $facebook_description, content: $content}}}, on_conflict: {constraint: pages_pkey, update_columns: [slug, updated_at]}) {
     returning {
       id
@@ -248,7 +248,7 @@ const insertPageGoogleDocsMutation = `mutation MyMutation($id: Int!, $slug: Stri
   }
 }`;
 
-const insertTagMutation = `mutation MyMutation($slug: String, $locale_code: String, $title: String, $article_id: Int!) {
+const insertTagMutation = `mutation AddonInsertTag($slug: String, $locale_code: String, $title: String, $article_id: Int!) {
   insert_tag_articles(objects: {article_id: $article_id, tag: {data: {slug: $slug, tag_translations: {data: {locale_code: $locale_code, title: $title}, on_conflict: {constraint: tag_translations_tag_id_locale_code_key, update_columns: locale_code}}, published: true}, on_conflict: {constraint: tags_organization_id_slug_key, update_columns: organization_id}}}, on_conflict: {constraint: tag_articles_article_id_tag_id_key, update_columns: article_id}) {
     returning {
       id
@@ -258,7 +258,7 @@ const insertTagMutation = `mutation MyMutation($slug: String, $locale_code: Stri
   }
 }`;
 
-const linkDocToArticleMutation = `mutation MyMutation($article_id: Int!, $document_id: String!, $locale_code: String!, $url: String) {
+const linkDocToArticleMutation = `mutation AddonLinkGoogleDocToArticle($article_id: Int!, $document_id: String!, $locale_code: String!, $url: String) {
   delete_article_google_documents(where: {article_id: {_eq: $article_id}, google_document: {locale_code: {_eq: $locale_code}}}) {
     affected_rows
   }
@@ -272,7 +272,7 @@ const linkDocToArticleMutation = `mutation MyMutation($article_id: Int!, $docume
   }
 }`;
 
-const upsertPublishedArticleTranslationMutation = `mutation MyMutation($article_id: Int = 10, $article_translation_id: Int = 10, $locale_code: String = "") {
+const upsertPublishedArticleTranslationMutation = `mutation AddonUpsertPublishedArticleTranslation($article_id: Int = 10, $article_translation_id: Int = 10, $locale_code: String = "") {
   insert_published_article_translations(objects: {article_id: $article_id, article_translation_id: $article_translation_id, locale_code: $locale_code}, on_conflict: {constraint: published_article_translations_article_id_locale_code_key, update_columns: article_translation_id}) {
     affected_rows
     returning {
@@ -287,7 +287,7 @@ const upsertPublishedArticleTranslationMutation = `mutation MyMutation($article_
   }
 }`;
 
-const unpublishArticleMutation = `mutation MyMutation($article_id: Int!, $locale_code: String!) {
+const unpublishArticleMutation = `mutation AddonUnpublishArticle($article_id: Int!, $locale_code: String!) {
   update_article_translations(where: {article_id: {_eq: $article_id}, locale_code: {_eq: $locale_code}}, _set: {published: false}) {
     affected_rows
   }
@@ -295,7 +295,7 @@ const unpublishArticleMutation = `mutation MyMutation($article_id: Int!, $locale
 
 /* Queries */
 
-const getArticleByGoogleDocQuery = `query MyQuery($doc_id: String!) {
+const getArticleByGoogleDocQuery = `query AddonGetArticleByGoogleDoc($doc_id: String!) {
   articles(where: {article_google_documents: {google_document: {document_id: {_eq: $doc_id}}}}) {
     id
     slug
@@ -364,7 +364,7 @@ const getArticleByGoogleDocQuery = `query MyQuery($doc_id: String!) {
   }
 }`;
 
-const getPageTranslationForIdAndLocale = `query MyQuery($doc_id: String!, $page_id: Int, $locale_code: String!) {
+const getPageTranslationForIdAndLocale = `query AddonGetPageTranslationByLocaleAndID($doc_id: String!, $page_id: Int, $locale_code: String!) {
   page_translations(where: {page_id: {_eq: $page_id}, locale_code: {_eq: $locale_code}}, limit: 1, order_by: {id: desc}) {
     content
     facebook_description
@@ -420,7 +420,7 @@ const getPageTranslationForIdAndLocale = `query MyQuery($doc_id: String!, $page_
   }
 }`;
 
-const getArticleTranslationForIdAndLocale = `query MyQuery($doc_id: String!, $article_id: Int, $locale_code: String!) {
+const getArticleTranslationForIdAndLocale = `query AddonGetArticleTranslationByLocaleAndID($doc_id: String!, $article_id: Int, $locale_code: String!) {
   article_translations(where: {article_id: {_eq: $article_id}, locale_code: {_eq: $locale_code}}, limit: 1, order_by: {id: desc}) {
     content
     custom_byline
@@ -505,7 +505,7 @@ const getArticleTranslationForIdAndLocale = `query MyQuery($doc_id: String!, $ar
   }
 }`
 
-const getPageForGoogleDocQuery = `query MyQuery($doc_id: String!) {
+const getPageForGoogleDocQuery = `query AddonGetPageForGoogleDoc($doc_id: String!) {
   pages(where: {page_google_documents: {google_document: {document_id: {_eq: $doc_id} }}}) {
     id
     slug
@@ -537,7 +537,7 @@ const getPageForGoogleDocQuery = `query MyQuery($doc_id: String!) {
   }
 }`;
 
-const lookupArticleByGoogleDocQuery = `query MyQuery($document_id: String) {
+const lookupArticleByGoogleDocQuery = `query AddonGetArticleByGoogleDoc($document_id: String) {
   article_google_documents(where: {google_document: {document_id: {_eq: $document_id}}}) {
     google_document {
       document_id
@@ -554,7 +554,7 @@ const lookupArticleByGoogleDocQuery = `query MyQuery($document_id: String) {
   }
 }`;
 
-const searchArticlesByHeadlineQuery = `query MyQuery($locale_code: String!, $term: String!) {
+const searchArticlesByHeadlineQuery = `query AddonSearchArticlesByHeadline($locale_code: String!, $term: String!) {
   articles(where: {article_translations: {headline: {_ilike: $term}, locale_code: {_eq: $locale_code}}}) {
     id
     slug
@@ -573,7 +573,7 @@ const searchArticlesByHeadlineQuery = `query MyQuery($locale_code: String!, $ter
   }
 }`;
 
-const getHomepageFeaturedArticles = `query MyQuery {
+const getHomepageFeaturedArticles = `query AddonGetHomepageFeaturedArticles {
   homepage_layout_datas {
     article_priority_1
     article_priority_2


### PR DESCRIPTION
Closes #277 

This was simple, just involved renaming each of the queries or mutations twice, once in the actual graphql and again in the function calls fetching or inserting data.

I prefixed all of these with "Addon" to distinguish from similar queries in the front-end. I think that makes sense for monitoring and debugging.