### PR TITLE
Stores the main image content in a new jsonb column

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -396,6 +396,8 @@ function insertArticleGoogleDocs(data) {
   }
   var content = getCurrentDocContents();
 
+  var mainImageContent = getMainImage(content);
+
   let articleData = {
     "slug": data['article-slug'],
     "document_id": documentID,
@@ -413,6 +415,7 @@ function insertArticleGoogleDocs(data) {
     "facebook_description": data['article-facebook-description'],
     "custom_byline": data['article-custom-byline'],
     "created_by_email": data['created_by_email'],
+    "main_image": mainImageContent,
   };
 
   var dataSources = [];
@@ -1205,7 +1208,7 @@ function getElements() {
   })
 
   var foundMainImage = false;
-
+ 
   // used to track which images have already been uploaded
   var imageList = getImageList();
 
@@ -1335,7 +1338,6 @@ function getElements() {
 
             var fullImageData = inlineObjects[imageID];
             if (fullImageData) {
-
               var s3Url = imageList[imageID];
               if (s3Url === null || s3Url === undefined) {
                 Logger.log(imageID + " has not been uploaded yet, uploading now...")
@@ -1376,7 +1378,7 @@ function getElements() {
 .*/
 function formatElements() {
   var elements = getElements();
-
+  
   var formattedElements = [];
   elements.sort(function (a, b) {
     if (a.index > b.index) {
@@ -1399,9 +1401,22 @@ function formatElements() {
     }
     formattedElements.push(formattedElement);
   })
+
   return formattedElements;
 }
 
+function getMainImage(elements) {
+  var mainImageContent;
+
+  elements.forEach(element => {
+    if (element.type === "mainImage") {
+      mainImageContent = element;
+      Logger.log("main image content: " + JSON.stringify(mainImageContent))
+    }
+  })
+
+  return mainImageContent;
+}
 /**
  * Rebuilds the site by POSTing to deploy hook
  */

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -24,7 +24,7 @@ const insertAuthorPageMutation = `mutation AddonInsertAuthorPage($page_id: Int!,
   }
 }`;
 
-const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoogleDocNoID($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $article_sources: [article_source_insert_input!]!) {
+const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoogleDocNoID($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb,  $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
       article_translations: {
@@ -40,7 +40,8 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
           search_description: $search_description, 
           search_title: $search_title, 
           twitter_description: $twitter_description, 
-          twitter_title: $twitter_title
+          twitter_title: $twitter_title,
+          main_image: $main_image
         }
       }, 
       category_id: $category_id, 
@@ -122,13 +123,13 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
     }
   }
 }`;
-const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, 
+const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, 
   $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
       article_translations: {
         data: {
-          created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title
+          created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, main_image: $main_image
         }
       }, 
       article_sources: {


### PR DESCRIPTION
https://github.com/news-catalyst/next-tinynewsdemo/issues/682

The main image content remains in the `content` field but is now also stored by itself in a `main_image` field on `article_translations`.

Tested on:

* latest code
* Franny Lou article example
* view the contents of this field in article_translations table id #335 