### PR TITLE
bugfix prevents list items from being labelled as embed links

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1275,7 +1275,7 @@ function getElements() {
             if (subElement.textRun.textStyle && subElement.textRun.textStyle.link) {
               listItemChild.link = subElement.textRun.textStyle.link.url;
             }
-          //  Logger.log("liChild: " + JSON.stringify(listItemChild));
+            // Logger.log("liChild: " + JSON.stringify(listItemChild));
             listElementChildren.push(listItemChild)
           });
           eleData.items.push({
@@ -1304,7 +1304,7 @@ function getElements() {
           linkUrl = subElements[0].textRun.content.trim();
         }
 
-        if ( linkUrl !== null) {
+        if ( linkUrl !== null && eleData.type !== "list") {
           var embeddableUrl = embeddableUrlRegex.test(linkUrl);
           if (embeddableUrl) {
             eleData.type = "embed";


### PR DESCRIPTION
related to #291 this small code change prevents list items from being treated as embeddable links, regardless of URL. they are instead stored as regular links.

tested: latest code, on the 'franny lou' doc which I added a silly 3 item list to; one item is a youtube link the other two are to regular non-embed websites. all three render as linked list items in my local front-end. no youtube video is embedded.