### PR TITLE
Clear article authors and tags before saving

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -486,6 +486,26 @@ async function hasuraCreateAuthorPage(authorId, pageId) {
   );
 }
 
+async function hasuraDeleteTagArticles(articleId) {
+  return fetchGraphQL(
+    deleteTagArticlesMutation,
+    "AddonDeleteTagArticles",
+    {
+      article_id: articleId
+    }
+  );
+}
+
+async function hasuraDeleteAuthorArticles(articleId) {
+  return fetchGraphQL(
+    deleteAuthorArticlesMutation,
+    "AddonDeleteAuthorArticles",
+    {
+      article_id: articleId
+    }
+  );
+}
+
 async function hasuraCreateAuthorArticle(authorId, articleId) {
   return fetchGraphQL(
     insertAuthorArticleMutation,
@@ -699,6 +719,14 @@ async function hasuraHandlePublish(formObject) {
     var articleSlug = data.data.insert_articles.returning[0].slug;
     var translationID = data.data.insert_articles.returning[0].article_translations[0].id;
 
+    // first delete any previously set authors
+    var deleteAuthorsResult = await hasuraDeleteAuthorArticles(articleID);
+    Logger.log("Deleted article authors: " + JSON.stringify(deleteAuthorsResult))
+    
+    // and delete any previously set tags
+    var deleteTagsResult = await hasuraDeleteTagArticles(articleID);
+    Logger.log("Deleted article tags: " + JSON.stringify(deleteTagsResult))
+
     if (articleID) {
       // store slug + article ID in slug versions table
       var result = await storeArticleIdAndSlug(articleID, slug);
@@ -709,6 +737,7 @@ async function hasuraHandlePublish(formObject) {
         data.data.insert_articles.returning[0].published_article_translations = publishedArticleData.data.insert_published_article_translations.returning;
       }
     }
+
     if (articleID && formObject['article-tags']) {
       var tags;
       // ensure this is an array; selecting one in the UI results in a string being sent
@@ -838,6 +867,14 @@ async function hasuraHandlePreview(formObject) {
     var result = await storeArticleIdAndSlug(articleID, slug);
     Logger.log("stored article id + slug: " + JSON.stringify(result));
 
+    // first delete any previously set authors
+    var deleteAuthorsResult = await hasuraDeleteAuthorArticles(articleID);
+    Logger.log("Deleted article authors: " + JSON.stringify(deleteAuthorsResult))
+
+    // and delete any previously set tags
+    var deleteTagsResult = await hasuraDeleteTagArticles(articleID);
+    Logger.log("Deleted article tags: " + JSON.stringify(deleteTagsResult))
+    
     if (articleID && formObject['article-tags']) {
       var tags;
       // ensure this is an array; selecting one in the UI results in a string being sent

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -12,6 +12,12 @@ const insertPageSlugVersion = `mutation AddonInsertPageSlugVersion($slug: String
   }
 }`;
 
+const deleteAuthorArticlesMutation = `mutation AddonDeleteAuthorArticles($article_id: Int) {
+  delete_author_articles(where: {article_id: {_eq: $article_id}}) {
+    affected_rows
+  }
+}`;
+
 const insertAuthorArticleMutation = `mutation AddonInsertAuthorArticle($article_id: Int!, $author_id: Int!) {
   insert_author_articles(objects: {article_id: $article_id, author_id: $author_id}, on_conflict: {constraint: author_articles_article_id_author_id_key, update_columns: article_id}) {
     affected_rows
@@ -246,6 +252,12 @@ const insertPageGoogleDocsMutation = `mutation AddonInsertPageGoogleDocWithID($i
         }
       }
     }
+  }
+}`;
+
+const deleteTagArticlesMutation = `mutation AddonDeleteTagArticles($article_id: Int) {
+  delete_tag_articles(where: {article_id: {_eq: $article_id}}) {
+    affected_rows
   }
 }`;
 


### PR DESCRIPTION
Closes #288 

Before saving the article, clear out the join tables for both article<->authors and article<->tags before saving the article and its related items. (This introduces delete mutations on the joins for both authors and tags, the rest of the logic was being done already.)

Tested on `Local artist Daniel de Jesús releases new album: ‘These songs represent an analysis of my own psyche’` https://docs.google.com/document/d/1M1UZ1BKx1rDdzr7Pu4oH_AU2qS2GirToCQ5uqNBVjVM/edit?addon_dry_run=AAnXSK_ib9KZ-tNjxig-Y-cXxG9j0hMWYADR3Tuen5tJjHZsJMynZNQdyI6Icclt4xaD1HPP_iCvQ-E0ItD4USMBgS50A5f3lks0ppA9ZF_i91rIS0ZKsywYT2lge7uPyO20ELybpwqw using "latest code" in the script editor.