### PR TITLE
Republish articles

### DIFF
--- a/GraphQL.js
+++ b/GraphQL.js
@@ -129,6 +129,7 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
     }
   }
 }`;
+
 const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, 
   $article_sources: [article_source_insert_input!]!) {
   insert_articles(
@@ -212,6 +213,44 @@ const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWith
           locale_code
         }
       }
+    }
+  }
+}`;
+
+const insertArticleGoogleDocMutationWithoutSources = `mutation AddonInsertArticleGoogleDocWithoutSources($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb) {
+  insert_articles(
+    objects: {
+      article_translations: {
+        data: {
+          created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, main_image: $main_image
+        }
+      }, 
+      category_id: $category_id, 
+      id: $id, 
+      slug: $slug, 
+      article_google_documents: {
+        data: {
+          google_document: {
+            data: {
+              document_id: $document_id, locale_code: $locale_code, url: $url
+            }, 
+            on_conflict: {
+              constraint: google_documents_organization_id_document_id_key, update_columns: locale_code
+            }
+          }
+        }, 
+        on_conflict: {
+          constraint: article_google_documents_article_id_google_document_id_key, update_columns: google_document_id
+        }
+      }
+    }, 
+    on_conflict: {
+      constraint: articles_pkey, update_columns: [category_id, slug, updated_at]
+    }
+  ) {
+    returning {
+      id
+      slug
     }
   }
 }`;
@@ -607,6 +646,7 @@ const getPublishedArticles = `query AddonGetPublishedArticles($locale_code: Stri
     article_google_documents {
       google_document {
         document_id
+        url
       }
     }
     article_translations(where: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
@@ -617,6 +657,11 @@ const getPublishedArticles = `query AddonGetPublishedArticles($locale_code: Stri
       main_image
       published
       search_description
+      search_title
+      twitter_description
+      twitter_title
+      facebook_description
+      facebook_title
       updated_at
     }
     author_articles {
@@ -632,6 +677,7 @@ const getPublishedArticles = `query AddonGetPublishedArticles($locale_code: Stri
       }
     }
     category {
+      id
       slug
       category_translations(where: {locale_code: {_eq: $locale_code}}) {
         title

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -594,3 +594,48 @@ const getHomepageFeaturedArticles = `query AddonGetHomepageFeaturedArticles {
     article_priority_3
   }
 }`
+
+const getPublishedArticles = `query AddonGetPublishedArticles($locale_code: String) {
+  articles_aggregate(where: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}) {
+    aggregate {
+      count
+    }
+  }
+  articles(where: {article_translations: {locale_code: {_eq: $locale_code}, published: {_eq: true}}}, order_by: {article_translations_aggregate: {min: {first_published_at: desc}}}) {
+    id
+    slug
+    article_google_documents {
+      google_document {
+        document_id
+      }
+    }
+    article_translations(where: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, order_by: {id: desc}, limit: 1) {
+      custom_byline
+      first_published_at
+      headline
+      last_published_at
+      main_image
+      published
+      search_description
+      updated_at
+    }
+    author_articles {
+      author {
+        name
+        photoUrl
+        slug
+        twitter
+        author_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+          bio
+          title
+        }
+      }
+    }
+    category {
+      slug
+      category_translations(where: {locale_code: {_eq: $locale_code}}) {
+        title
+      }
+    }
+  }
+}`;

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -180,11 +180,18 @@
         }
       }
 
-      function onSuccessRepublish(contents) {
+      function onSuccessRepublish(response) {
         // hideLoading();
+        console.log(response.data[0].data.insert_articles.returning[0])
         var div = document.getElementById('republish-info');
         div.style.display = 'block';
-        div.innerHTML = JSON.stringify(contents);
+        var republishedArticleSlugs = response.data.map((d) => d.data.insert_articles.returning[0].slug);
+        
+        var slugListItems = republishedArticleSlugs.map( (slug) => {
+          return "<li>" + slug + "</li>";
+        }).join("\n");
+        console.log("slugListItems", slugListItems)
+        div.innerHTML = "<p><b>Republished the following articles:</b><br/><ul>" + slugListItems + "</ul></p>";
       }
 
       function onSuccessSearch(contents) {
@@ -398,6 +405,9 @@
 
       function republishArticles() {
         if (window.confirm("This will process all published article google docs and republish to the web: are you sure?")) { 
+          var div = document.getElementById('republish-info');
+          div.style.display = 'block';
+          div.innerHTML = "<p><i>Republishing all articles now, this may take a few minutes...</i></p>";
           google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessRepublish).republishArticles();
         } else {
           console.log("cancelled republish all")

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -397,7 +397,11 @@
       }
 
       function republishArticles() {
-         google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessRepublish).republishArticles();
+        if (window.confirm("This will process all published article google docs and republish to the web: are you sure?")) { 
+          google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessRepublish).republishArticles();
+        } else {
+          console.log("cancelled republish all")
+        }
       }
 
       function handleAssociate(formObject) {

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -47,7 +47,8 @@
       }
 
       function handleGetArticle() {
-         google.script.run.withFailureHandler(onFailure).withSuccessHandler(handleGetTranslationsForArticle).hasuraGetArticle();
+        var localeCode = document.getElementById("current-article-locale").innerText;
+         google.script.run.withFailureHandler(onFailure).withSuccessHandler(handleGetTranslationsForArticle).hasuraGetArticle(localeCode);
       }
 
       function onSuccessCreateDoc(contents) {
@@ -179,15 +180,9 @@
         }
       }
 
-      function onSuccessClear(contents) {
+      function onSuccessRepublish(contents) {
         // hideLoading();
-        var div = document.getElementById('loading');
-        div.style.display = 'block';
-        div.innerHTML = JSON.stringify(contents);
-      }
-      function onFailureClear(contents) {
-        // hideLoading();
-        var div = document.getElementById('loading');
+        var div = document.getElementById('republish-info');
         div.style.display = 'block';
         div.innerHTML = JSON.stringify(contents);
       }
@@ -400,9 +395,9 @@
 
         google.script.run.withSuccessHandler(onSuccessSearch).withFailureHandler(onFailure).hasuraSearchArticles(formObject);
       }
-      
-      function clearCache() {
-         google.script.run.withFailureHandler(onFailureClear).withSuccessHandler(onSuccessClear).clearCache();
+
+      function republishArticles() {
+         google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessRepublish).republishArticles();
       }
 
       function handleAssociate(formObject) {
@@ -579,9 +574,10 @@
         <hr/>
         <button onclick="toggleConfigForm()">Toggle Config Form</button>
         <hr/>
-        <button onclick="clearCache()">Clear Cache</button>
-        <br/>
+        <button onclick="republishArticles()">Republish All</button>
+        <div id="republish-info"></div>
         <hr/>
+        <br/>
         <br/>
         <h3 class="gray">Debugging Info:</h3>
           <p class="gray">


### PR DESCRIPTION
Closes #296 

Adds a "republish all" button to the admin tools sidebar that:

* confirms, then...
* finds all published articles for an org
* opens each article's google doc (behind the scenes) and reprocesses the contents
* reuses the current metadata like search titles
* saves a new published version in hasura
* returns a list of article slugs for all republished articles
