### PR TITLE
Two bugfixes: spaces in slugs and current document processing

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -759,7 +759,11 @@ async function hasuraHandlePublish(formObject) {
   }
 
   if (slug === "" || slug === null || slug === undefined) {
-    slug = slugify(headline)
+    slug = slugify(headline);
+    formObject['article-slug'] = slug;
+  } else {
+    // always ensure the slug is valid, no spaces etc
+    slug = slugify(slug);
     formObject['article-slug'] = slug;
   }
 
@@ -916,6 +920,9 @@ async function hasuraHandlePreview(formObject) {
   if (slug === "" || slug === null || slug === undefined) {
     slug = slugify(headline)
     Logger.log("no slug found, generated from headline: " + headline + " -> " + slug)
+    formObject['article-slug'] = slug;
+  } else {
+    slug = slugify(slug)
     formObject['article-slug'] = slug;
   }
 

--- a/Code.js
+++ b/Code.js
@@ -1325,8 +1325,8 @@ async function hasuraGetArticle() {
 /**
 . * Gets the current document's contents
 . */
-function getCurrentDocContents() {
-  var elements = getElements();
+async function getCurrentDocContents() {
+  var elements = await getElements();
 
   var formattedElements = formatElements(elements);
   return formattedElements;
@@ -1548,13 +1548,12 @@ async function processDocumentContents(activeDoc, document, slug) {
 .* Retrieves "elements" from the google doc - which are headings, images, paragraphs, lists
 .* Preserves order, indicates that order with `index` attribute
 .*/
-function getElements() {
+async function getElements() {
   var activeDoc = DocumentApp.getActiveDocument();
   var documentID = activeDoc.getId();
   var document = Docs.Documents.get(documentID);
 
-  var orderedElements = processDocumentContents(activeDoc, document);
-
+  var orderedElements = await processDocumentContents(activeDoc, document);
   return orderedElements;
 }
 


### PR DESCRIPTION
Closes #298 

This includes two fixes: one that validates a slug (and corrects it) and another that properly awaits when processing the current document. The latter is a bug I introduced with the republish-all-articles work, but hey, now fixed!

Testable via latest code in script editor. Turns a slug like " this  has spaces" into "this-has-spaces"