### PR TITLE
fixes bug where only the first tag is stored

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -967,7 +967,7 @@ async function hasuraHandlePreview(formObject) {
   } else {
     documentType = "article";
     // insert or update article
-    Logger.log("sources:" + JSON.stringify(formObject['sources']));
+    // Logger.log("sources:" + JSON.stringify(formObject['sources']));
 
     var data = await insertArticleGoogleDocs(formObject);
     // Logger.log("articleResult: " + JSON.stringify(data))
@@ -975,11 +975,11 @@ async function hasuraHandlePreview(formObject) {
 
     // store slug + article ID in slug versions table
     var result = await storeArticleIdAndSlug(articleID, slug);
-    Logger.log("stored article id + slug: " + JSON.stringify(result));
+    // Logger.log("stored article id + slug: " + JSON.stringify(result));
 
     // first delete any previously set authors
     var deleteAuthorsResult = await hasuraDeleteAuthorArticles(articleID);
-    Logger.log("Deleted article authors: " + JSON.stringify(deleteAuthorsResult))
+    // Logger.log("Deleted article authors: " + JSON.stringify(deleteAuthorsResult))
 
     // and delete any previously set tags
     var deleteTagsResult = await hasuraDeleteTagArticles(articleID);
@@ -993,7 +993,7 @@ async function hasuraHandlePreview(formObject) {
       } else {
         tags = formObject['article-tags'];
       }
-      Logger.log("Found tags: " + JSON.stringify(tags));
+
       for (var index = 0; index < tags.length; index++) {
         var tag = tags[index];
         var slug = slugify(tag);

--- a/Page.html
+++ b/Page.html
@@ -927,21 +927,22 @@
         }
 
         // assemble the data to submit - unfortunately we can't pass the form object with any additional data here
-        console.log("formObject:", formObject);
         var submitData = {};
         var elements = formObject.elements;
         for (var i = 0, element; element = elements[i++];) {
           var key = element.name;
           var value = element.value;
-          // console.log(key, typeof(value), value);
           if ( !(/source/).test(key) ) {
             submitData[key] = value;
           }
         }
-
+        var selectedTags = $('#article-tags').select2('data');
+        submitData["article-tags"] = [];
+        for (var i = 0, tag; tag = selectedTags[i++];) {
+          submitData["article-tags"].push(tag.text);
+        }
         submitData["sources"] = sources;
-        // console.log("submitData:", submitData);
-
+        
         if (formIsValid && formObject.submitted === "Preview") {
           // console.log("valid form + preview")
           loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"


### PR DESCRIPTION
Closes https://github.com/news-catalyst/next-tinynewsdemo/issues/744

Only the first selected tag was being stored because the sidebar html was naively looping over each form data field and assigning it to a new object - this change happened during the addition of source tracking. I think my tests all had the bare minimum of zero or one tag and I missed this issue until you demo'd to the cohort.

This fixes the problem by looping over the `select2` data and pushing each tag onto an array of tags before saving.

Testable with latest code in the script editor. I created a test document which is available in the "Run > Test as add-on" dialog called "All Tags Should Be Published"

To test:

* select more than one tag
* preview or publish
* view the html (preview version or regular pub'd article), see all tags in the "read more" section