### PR TITLE
Admin Tools delete article feature

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -557,6 +557,19 @@ async function hasuraInsertGoogleDoc(articleId, docId, localeCode, url) {
     }
   );
 }
+
+
+async function hasuraDeleteArticle(articleId) {
+  Logger.log("deleting article ID#" + articleId);
+  return fetchGraphQL(
+    deleteArticleMutation,
+    "AddonDeleteArticleMutation",
+    {
+      article_id: articleId
+    }
+  )
+}
+
 async function hasuraCreateDoc(articleId, newLocale, headline) {
   Logger.log("create new doc for article " + articleId + " and locale " + newLocale);
   // create new document in google docs

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -685,3 +685,30 @@ const getPublishedArticles = `query AddonGetPublishedArticles($locale_code: Stri
     }
   }
 }`;
+
+const deleteArticleMutation = `mutation AddonDeleteArticleMutation($article_id: Int) {
+  delete_published_article_translations(where: {article_id: {_eq: $article_id}}) {
+    affected_rows
+  }
+  delete_article_translations(where: {article_id: {_eq: $article_id}}) {
+    affected_rows
+  }
+  delete_article_slug_versions(where: {article_id: {_eq: $article_id}}) {
+    affected_rows
+  }
+  delete_article_google_documents(where: {article_id: {_eq: $article_id}}) {
+    affected_rows
+  }
+  delete_article_source(where: {article_id: {_eq: $article_id}}) {
+    affected_rows
+  }
+  delete_author_articles(where: {article_id: {_eq: $article_id}}) {
+    affected_rows
+  }
+  delete_tag_articles(where: {article_id: {_eq: $article_id}}) {
+    affected_rows
+  }
+  delete_articles(where: {id: {_eq: $article_id}}) {
+    affected_rows
+  }
+}`;

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -180,6 +180,18 @@
         }
       }
 
+      function onSuccessDelete(response) {
+        // hideLoading();
+        console.log("outcome", response)
+        var div = document.getElementById('republish-info');
+        div.style.display = 'block';
+        if (response && !response.errors) {
+          div.innerHTML = "<p><b>Delete article result:</b><br/><ul>" + JSON.stringify(response) + "</ul></p>";
+        } else {
+          div.innerHTML = "<p><b>Delete article errors:</b><br/><ul>" + JSON.stringify(response.errors) + "</ul></p>";
+        }
+      }
+
       function onSuccessRepublish(response) {
         // hideLoading();
         console.log(response.data[0].data.insert_articles.returning[0])
@@ -413,6 +425,18 @@
           console.log("cancelled republish all")
         }
       }
+      function deleteArticle() {
+        if (window.confirm("Are you sure that you want to completely delete this article? There is no undo!")) { 
+          var articleIdEl = document.getElementById('current-data-id');
+          var articleId = articleIdEl.innerText;
+          var div = document.getElementById('republish-info');
+          div.style.display = 'block';
+          div.innerHTML = "<p><i>Removing article data...</i></p>";
+          google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessDelete).hasuraDeleteArticle(articleId);
+        } else {
+          console.log("cancelled delete article")
+        }
+      }
 
       function handleAssociate(formObject) {
         if (window.confirm("Are you sure you want to do this? Any content in the linked article in this locale will be replaced by your document!")) { 
@@ -590,6 +614,8 @@
         <hr/>
         <button onclick="republishArticles()">Republish All</button>
         <div id="republish-info"></div>
+        <hr/>
+        <button onclick="deleteArticle()">Delete Article</button>
         <hr/>
         <br/>
         <br/>


### PR DESCRIPTION
This is the work I alluded to in https://github.com/news-catalyst/next-tinynewsdemo/pull/774

Not sure if we want a delete article button, but it's here in case we do.

As an alternative, here is the graphql to run in Hasura to manually delete an article, including related content (not metrics), by ID:

```
mutation AddonDeleteArticleMutation($article_id: Int) {
  delete_published_article_translations(where: {article_id: {_eq: $article_id}}) {
    affected_rows
  }
  delete_article_translations(where: {article_id: {_eq: $article_id}}) {
    affected_rows
  }
  delete_article_slug_versions(where: {article_id: {_eq: $article_id}}) {
    affected_rows
  }
  delete_article_google_documents(where: {article_id: {_eq: $article_id}}) {
    affected_rows
  }
  delete_article_source(where: {article_id: {_eq: $article_id}}) {
    affected_rows
  }
  delete_author_articles(where: {article_id: {_eq: $article_id}}) {
    affected_rows
  }
  delete_tag_articles(where: {article_id: {_eq: $article_id}}) {
    affected_rows
  }
  delete_articles(where: {id: {_eq: $article_id}}) {
    affected_rows
  }
}
```