### PR TITLE
Translate/open translation toggle in publishing tools; done for articles AND pages

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -850,6 +850,10 @@ async function hasuraHandlePublish(formObject) {
     var deleteTagsResult = await hasuraDeleteTagArticles(articleID);
     Logger.log("Deleted article tags: " + JSON.stringify(deleteTagsResult))
 
+    var getOrgLocalesResult = await hasuraGetOrganizationLocales();
+    Logger.log("Get Org Locales:" + JSON.stringify(getOrgLocalesResult));
+    data.organization_locales = getOrgLocalesResult.data.organization_locales;
+
     if (articleID) {
       // store slug + article ID in slug versions table
       var result = await storeArticleIdAndSlug(articleID, slug);
@@ -1001,6 +1005,10 @@ async function hasuraHandlePreview(formObject) {
     var deleteTagsResult = await hasuraDeleteTagArticles(articleID);
     Logger.log("Deleted article tags: " + JSON.stringify(deleteTagsResult))
     
+    var getOrgLocalesResult = await hasuraGetOrganizationLocales();
+    Logger.log("Get Org Locales:" + JSON.stringify(getOrgLocalesResult));
+    data.organization_locales = getOrgLocalesResult.data.organization_locales;
+
     if (articleID && formObject['article-tags']) {
       var tags;
       // ensure this is an array; selecting one in the UI results in a string being sent
@@ -1049,8 +1057,17 @@ async function hasuraHandlePreview(formObject) {
   return {
     message: message,
     data: data,
+    documentID: documentID,
     status: "success"
   }
+}
+
+
+function hasuraGetOrganizationLocales() {
+  return fetchGraphQL(
+    getOrganizationLocalesQuery,
+    "AddonGetOrganizationLocales"
+  );
 }
 
 function fetchArticleForGoogleDoc(doc_id) {

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -121,6 +121,7 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
         article_id
         locale_code
         published
+        headline
       }
       published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
         article_translation {
@@ -212,6 +213,7 @@ const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWith
         article_id
         locale_code
         published
+        headline
       }
       published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
         article_translation {
@@ -259,6 +261,55 @@ const insertArticleGoogleDocMutationWithoutSources = `mutation AddonInsertArticl
     returning {
       id
       slug
+      updated_at
+      created_at
+      article_google_documents {
+        id
+        google_document {
+          document_id
+          locale_code
+          locale {
+            code
+            name
+          }
+          url
+          id
+        }
+      }
+      article_sources {
+        source {
+          affiliation
+          age
+          email
+          ethnicity
+          gender
+          id
+          name
+          phone
+          race
+          role
+          sexual_orientation
+          zip
+        }
+      }
+      category {
+        slug
+      }
+      article_translations(where: { locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+        id
+        article_id
+        locale_code
+        published
+        headline
+      }
+      published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
+        article_translation {
+          id
+          first_published_at
+          last_published_at
+          locale_code
+        }
+      }
     }
   }
 }`;

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -610,6 +610,15 @@ const getPageForGoogleDocQuery = `query AddonGetPageForGoogleDoc($doc_id: String
   }
 }`;
 
+const getOrganizationLocalesQuery = `query AddonGetOrganizationLocales {
+  organization_locales {
+    locale {
+      code
+      name
+    }
+  }
+}`
+
 const lookupArticleByGoogleDocQuery = `query AddonGetArticleByGoogleDoc($document_id: String) {
   article_google_documents(where: {google_document: {document_id: {_eq: $document_id}}}) {
     google_document {

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -89,6 +89,10 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
         google_document {
           document_id
           locale_code
+          locale {
+            code
+            name
+          }
           url
           id
         }
@@ -176,6 +180,10 @@ const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWith
         google_document {
           document_id
           locale_code
+          locale {
+            code
+            name
+          }
           url
           id
         }
@@ -510,6 +518,10 @@ const getArticleTranslationForIdAndLocale = `query AddonGetArticleTranslationByL
       google_document {
         document_id
         locale_code
+        locale {
+          code
+          name
+        }
         url
       }
     }
@@ -531,6 +543,10 @@ const getArticleTranslationForIdAndLocale = `query AddonGetArticleTranslationByL
     google_document {
       document_id
       locale_code
+      locale {
+        code
+        name
+      }
       url
     }
     article_id
@@ -566,6 +582,10 @@ const getPageForGoogleDocQuery = `query AddonGetPageForGoogleDoc($doc_id: String
       google_document {
         document_id
         locale_code
+        locale {
+          code
+          name
+        }
         url
       }
     }
@@ -595,6 +615,10 @@ const lookupArticleByGoogleDocQuery = `query AddonGetArticleByGoogleDoc($documen
     google_document {
       document_id
       locale_code
+      locale {
+        code
+        name
+      }
       id
       organization_id
       url
@@ -647,6 +671,10 @@ const getPublishedArticles = `query AddonGetPublishedArticles($locale_code: Stri
       google_document {
         document_id
         url
+        locale {
+          code
+          name
+        }
       }
     }
     article_translations(where: {locale_code: {_eq: $locale_code}, published: {_eq: true}}, order_by: {id: desc}, limit: 1) {

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -320,6 +320,12 @@ const insertGoogleDocMutation = `mutation AddonInsertGoogleDoc($article_id: Int!
   }
 }`;
 
+const insertPageGoogleDocMutation = `mutation AddonInsertPageGoogleDoc($page_id: Int!, $document_id: String!, $locale_code: String!, $url: String) {
+  insert_page_google_documents(objects: {page_id: $page_id, google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: url}}}, on_conflict: {constraint: page_google_documents_page_id_google_document_id_key, update_columns: google_document_id}) {
+    affected_rows
+  }
+}`;
+
 const insertPageGoogleDocsMutationWithoutId = `mutation AddonInsertPageGoogleDocNoID($slug: String!, $locale_code: String!, $created_by_email: String, $document_id: String, $url: String, $facebook_title: String, $facebook_description: String, $search_title: String, $search_description: String, $headline: String, $twitter_title: String, $twitter_description: String, $content: jsonb, $published: Boolean) {
   insert_pages(objects: {page_google_documents: {data: {google_document: {data: {document_id: $document_id, locale_code: $locale_code, url: $url}, on_conflict: {constraint: google_documents_organization_id_document_id_key, update_columns: [document_id]}}}, on_conflict: {constraint: page_google_documents_page_id_google_document_id_key, update_columns: [google_document_id]}}, slug: $slug, page_translations: {data: {created_by_email: $created_by_email, published: $published, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, locale_code: $locale_code, headline: $headline, facebook_title: $facebook_title, facebook_description: $facebook_description, content: $content}}}, on_conflict: {constraint: pages_slug_organization_id_key, update_columns: [slug, updated_at]}) {
     returning {
@@ -330,6 +336,10 @@ const insertPageGoogleDocsMutationWithoutId = `mutation AddonInsertPageGoogleDoc
         google_document {
           document_id
           locale_code
+          locale {
+            code
+            name
+          }
           url
         }
       }
@@ -346,6 +356,10 @@ const insertPageGoogleDocsMutation = `mutation AddonInsertPageGoogleDocWithID($i
         google_document {
           document_id
           locale_code
+          locale {
+            code
+            name
+          }
           url
         }
       }
@@ -426,6 +440,10 @@ const getArticleByGoogleDocQuery = `query AddonGetArticleByGoogleDoc($doc_id: St
       google_document {
         document_id
         locale_code
+        locale {
+          code
+          name
+        }
         url
       }
     }
@@ -507,6 +525,10 @@ const getPageTranslationForIdAndLocale = `query AddonGetPageTranslationByLocaleA
       google_document {
         document_id
         locale_code
+        locale {
+          code
+          name
+        }
         url
       }
     }
@@ -520,6 +542,10 @@ const getPageTranslationForIdAndLocale = `query AddonGetPageTranslationByLocaleA
     google_document {
       document_id
       locale_code
+      locale {
+        code
+        name
+      }
       url
     }
     page_id

--- a/Page.html
+++ b/Page.html
@@ -234,9 +234,16 @@
 
       function handleCreateDoc(el) {
         var localeCode = $(el).data('locale'); 
-        var articleId = $(el).data('article-id');
+        var docType = $(el).data('doc-type');
         var headline = $(el).data('headline');
-        google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessCreateDoc).hasuraCreateDoc(articleId, localeCode, headline);
+        var id;
+        if (docType === "page") {
+          id = $(el).data('page-id');
+          google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessCreateDoc).hasuraCreatePageDoc(id, localeCode, headline);
+        } else {
+          id = $(el).data('article-id');
+          google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessCreateDoc).hasuraCreateArticleDoc(id, localeCode, headline);
+        }
       }
 
       function onSuccessGetArticle(contents) {
@@ -297,10 +304,14 @@
           if (contents.data.page_translations) {
             translationData = contents.data.page_translations[0];
           }
+
+          if (contents.data.page_google_documents) {
+            googleDocs = contents.data.page_google_documents;
+          }
         }
 
         // displayTranslationTools(id, headline, googleDocs, organization_locales)
-        displayTranslationTools(data.id, contents.documentId, translationData.headline, googleDocs, contents.data.organization_locales);
+        displayTranslationTools(data.id, contents.documentId, documentType, translationData.headline, googleDocs, contents.data.organization_locales);
         
         if (publishedInfo) {
           displayPublishedInfo(publishedInfo, translationData);
@@ -812,7 +823,9 @@
          google.script.run.withFailureHandler(onFailure).withSuccessHandler(handleGetTranslationsForArticle).hasuraGetArticle();
       }
 
-      function displayTranslationTools(id, documentId, headline, googleDocs, organizationLocales) {
+      function displayTranslationTools(id, documentId, documentType, headline, googleDocs, organizationLocales) {
+        console.log("displaying translation tools:", id, documentId, headline, googleDocs, organizationLocales);
+
         var existingDocsOtherLocales = [];
         var availableLocales = [];
 
@@ -858,7 +871,12 @@
                   button.setAttribute("type", "button");
                   button.setAttribute("id", buttonId);
                   button.setAttribute("data-headline", headline);
-                  button.setAttribute("data-article-id", id);
+                  button.setAttribute("data-doc-type", documentType);
+                  if (documentType === "page") {
+                    button.setAttribute("data-page-id", id);
+                  } else {
+                    button.setAttribute("data-article-id", id);
+                  }
                   button.setAttribute("data-locale", availableLocale.code);
                   button.setAttribute("onClick", "handleCreateDoc(this)");
                   button.innerHTML = 'Translate to ' + availableLocale.name;
@@ -872,7 +890,9 @@
 
           if (existingDocsOtherLocales.length > 0) {
             existingDocsOtherLocales.forEach(doc => {
+              console.log("existing doc:", doc)
               if (doc.locale.code !== selectedLocale) {
+                
                 var buttonId = "translate-button-top-" + doc.locale.code;
                 if (!document.getElementById(buttonId)) { // avoid adding multiple instances of the same button
                   var button = document.createElement("button");
@@ -928,15 +948,20 @@
             var organizationLocales = response.data.organization_locales;
             var documentID = response.documentID;
             console.log("googleDocs:", googleDocs, "organizationLocales:", organizationLocales, "documentID:", documentID);
-            // displayTranslationTools(id, documentId, headline, googleDocs, organizationLocales) {
-
-            displayTranslationTools(articleID, documentID, translations[0].headline, googleDocs, organizationLocales);
+        
+            displayTranslationTools(articleID, documentID, "article", translations[0].headline, googleDocs, organizationLocales);
 
           } else if (response.data && response.data.data && response.data.data.insert_pages) {
             var pageID = response.data.data.insert_pages.returning[0].id;
             // console.log("page ID:", pageID)
             var idHiddenField = document.getElementById('article-id');
             idHiddenField.value = pageID;
+
+            var googleDocs = response.data.data.insert_pages.returning[0].page_google_documents;
+            var organizationLocales = response.data.organization_locales;
+            var documentID = response.documentID;
+
+            displayTranslationTools(pageID, documentID, "page", translations[0].headline, googleDocs, organizationLocales);
 
           } else if (response.data && response.data.data && response.data.data.update_article_translations) {
             // console.log("unpublished article:", response.data);

--- a/Page.html
+++ b/Page.html
@@ -337,7 +337,7 @@
               button.setAttribute("data-article-id", data.id);
               button.setAttribute("data-locale", availableLocale.code);
               button.setAttribute("onClick", "handleCreateDoc(this)");
-              button.innerHTML = 'Translate ' + availableLocale.name;
+              button.innerHTML = 'Translate to ' + availableLocale.name;
               console.log(availableLocale, "button:", button);
               var buttonsTopContainer = document.getElementById('action-buttons-top');
               buttonsTopContainer.appendChild(button);
@@ -352,7 +352,7 @@
               button.setAttribute("type", "button");
               var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
               button.setAttribute("onClick", buttonOpenLink);
-              button.innerHTML = "Open " + doc.locale_code;
+              button.innerHTML = "Open in " + doc.locale.name;
               var buttonsTopContainer = document.getElementById('action-buttons-top');
               buttonsTopContainer.appendChild(button);
             });

--- a/Page.html
+++ b/Page.html
@@ -214,6 +214,27 @@
         // isPublishedSpan.innerHTML = isPublishedYesNo;
       }
 
+      function onSuccessCreateDoc(contents) {
+        console.log("onSuccessCreateDoc: ", contents);
+
+        var button = document.getElementById('translate-button-top');
+        button.innerHTML = "Open Translation";
+
+        button.setAttribute("class", "blue");
+        button.setAttribute("type", "button");
+        var buttonOpenLink = "window.open('" + contents.url + "', '_blank')";
+        button.setAttribute("onClick", buttonOpenLink);
+        // button.innerHTML = "Open " + doc.locale_code;
+        button.href = contents.url;
+      }
+
+      function handleCreateDoc(el) {
+        var localeCode = $(el).data('locale'); 
+        var articleId = $(el).data('article-id');
+        var headline = $(el).data('headline');
+        google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessCreateDoc).hasuraCreateDoc(articleId, localeCode, headline);
+      }
+
       function onSuccessGetArticle(contents) {
 
         var configDiv = document.getElementById('config');
@@ -271,6 +292,70 @@
           }
           if (contents.data.page_translations) {
             translationData = contents.data.page_translations[0];
+          }
+        }
+
+        var existingDocsOtherLocales = [];
+        var availableLocales = [];
+
+        if (googleDocs) {
+          contents.data.organization_locales.forEach( (orgLocale) => {
+            var foundLocaleDoc = false;
+            // loop over each google doc associated with this article
+            googleDocs.forEach( (doc) => {
+              // if google doc is not the current one we have open...
+              if (doc.google_document.document_id !== contents.documentId) {
+                // ... and this org locale is equal to the google doc's locale
+                if (orgLocale.locale.code === doc.google_document.locale_code) {
+                  // add it to the list of documents available that are translations of this article
+                  existingDocsOtherLocales.push(doc.google_document);
+                  foundLocaleDoc = true;
+                }
+              // current document
+              } else {
+                if (orgLocale.locale.code === doc.google_document.locale_code) {
+                  foundLocaleDoc = true;
+                }
+              }
+            });
+            // if we didn't find a google document for this org locale, mark it as available
+            if (!foundLocaleDoc) {
+              availableLocales.push(orgLocale.locale);
+            }
+          })
+
+          console.log("availableLocales:", availableLocales, "existingDocsOtherLocales:", existingDocsOtherLocales);
+
+          if (availableLocales && availableLocales.length > 0) {
+            availableLocales.forEach(availableLocale => {
+              // TODO: make another version of this button for the bottom of the sidebar?
+              var button = document.createElement("button");
+              button.setAttribute("class", "blue");
+              button.setAttribute("type", "button");
+              button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
+              button.setAttribute("data-headline", translationData.headline);
+              button.setAttribute("data-article-id", data.id);
+              button.setAttribute("data-locale", availableLocale.code);
+              button.setAttribute("onClick", "handleCreateDoc(this)");
+              button.innerHTML = 'Translate ' + availableLocale.name;
+              console.log(availableLocale, "button:", button);
+              var buttonsTopContainer = document.getElementById('action-buttons-top');
+              buttonsTopContainer.appendChild(button);
+            })
+          }
+
+          if (existingDocsOtherLocales.length > 0) {
+            existingDocsOtherLocales.forEach(doc => {
+              var button = document.createElement("button");
+              button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
+              button.setAttribute("class", "blue");
+              button.setAttribute("type", "button");
+              var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
+              button.setAttribute("onClick", buttonOpenLink);
+              button.innerHTML = "Open " + doc.locale_code;
+              var buttonsTopContainer = document.getElementById('action-buttons-top');
+              buttonsTopContainer.appendChild(button);
+            });
           }
         }
 
@@ -857,7 +942,7 @@
 
         var sources = {};
 
-        console.log("handling click - doc type is " + documentType);
+        console.log("handling click - doc type is " + documentType, "formObject.submitted:", formObject.submitted);
         if (documentType !== "page")  {
           var elements = formObject.elements;
 
@@ -971,7 +1056,7 @@
             loadingDiv.innerHTML = "<p class='gray'>Publishing... </p>"
             google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
           }
-        } else if ( documentType === "article" && formIsValid) {
+        } else if ( documentType === "article" && formIsValid && formObject.submitted === "Unpublish") {
           // console.log("valid form + unpublish")
           loadingDiv.innerHTML = "<p class='gray'>Unpublishing article... </p>"
           var articleId = document.getElementById('article-id').value;
@@ -1171,6 +1256,7 @@
             <input type="submit" class="blue" id="publish-button-bottom" value="Publish" onclick="this.form.submitted=this.value;"/>
             <input type="submit" class="blue" id="unpublish-button-bottom" value="Unpublish" onclick="this.form.submitted=this.value;"/>
           </div>
+
           <div class="block" id="published-info">
             <div class="small" id="translation-id"></div>
             <div class="small" style="width: 100%" id="published-info-first"><b>Initial:</b> <span id="first-published-at"></span></div>

--- a/Page.html
+++ b/Page.html
@@ -217,7 +217,8 @@
       function onSuccessCreateDoc(contents) {
         console.log("onSuccessCreateDoc: ", contents);
 
-        var button = document.getElementById('translate-button-top');
+        var buttonId = 'translate-button-top-' + contents.locale;
+        var button = document.getElementById(buttonId);
         button.innerHTML = "Open Translation";
 
         button.setAttribute("class", "blue");
@@ -297,70 +298,7 @@
 
         // displayTranslationTools(id, headline, googleDocs, organization_locales)
         displayTranslationTools(data.id, contents.documentId, translationData.headline, googleDocs, contents.data.organization_locales);
-        // var existingDocsOtherLocales = [];
-        // var availableLocales = [];
-
-        // if (googleDocs) {
-        //   contents.data.organization_locales.forEach( (orgLocale) => {
-        //     var foundLocaleDoc = false;
-        //     // loop over each google doc associated with this article
-        //     googleDocs.forEach( (doc) => {
-        //       // if google doc is not the current one we have open...
-        //       if (doc.google_document.document_id !== contents.documentId) {
-        //         // ... and this org locale is equal to the google doc's locale
-        //         if (orgLocale.locale.code === doc.google_document.locale_code) {
-        //           // add it to the list of documents available that are translations of this article
-        //           existingDocsOtherLocales.push(doc.google_document);
-        //           foundLocaleDoc = true;
-        //         }
-        //       // current document
-        //       } else {
-        //         if (orgLocale.locale.code === doc.google_document.locale_code) {
-        //           foundLocaleDoc = true;
-        //         }
-        //       }
-        //     });
-        //     // if we didn't find a google document for this org locale, mark it as available
-        //     if (!foundLocaleDoc) {
-        //       availableLocales.push(orgLocale.locale);
-        //     }
-        //   })
-
-        //   console.log("availableLocales:", availableLocales, "existingDocsOtherLocales:", existingDocsOtherLocales);
-
-        //   if (availableLocales && availableLocales.length > 0) {
-        //     availableLocales.forEach(availableLocale => {
-        //       // TODO: make another version of this button for the bottom of the sidebar?
-        //       var button = document.createElement("button");
-        //       button.setAttribute("class", "blue");
-        //       button.setAttribute("type", "button");
-        //       button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
-        //       button.setAttribute("data-headline", translationData.headline);
-        //       button.setAttribute("data-article-id", data.id);
-        //       button.setAttribute("data-locale", availableLocale.code);
-        //       button.setAttribute("onClick", "handleCreateDoc(this)");
-        //       button.innerHTML = 'Translate to ' + availableLocale.name;
-        //       console.log(availableLocale, "button:", button);
-        //       var buttonsTopContainer = document.getElementById('action-buttons-top');
-        //       buttonsTopContainer.appendChild(button);
-        //     })
-        //   }
-
-        //   if (existingDocsOtherLocales.length > 0) {
-        //     existingDocsOtherLocales.forEach(doc => {
-        //       var button = document.createElement("button");
-        //       button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
-        //       button.setAttribute("class", "blue");
-        //       button.setAttribute("type", "button");
-        //       var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
-        //       button.setAttribute("onClick", buttonOpenLink);
-        //       button.innerHTML = "Open in " + doc.locale.name;
-        //       var buttonsTopContainer = document.getElementById('action-buttons-top');
-        //       buttonsTopContainer.appendChild(button);
-        //     });
-        //   }
-        // }
-
+        
         if (publishedInfo) {
           displayPublishedInfo(publishedInfo, translationData);
         }
@@ -871,12 +809,15 @@
          google.script.run.withFailureHandler(onFailure).withSuccessHandler(handleGetTranslationsForArticle).hasuraGetArticle();
       }
 
-      function displayTranslationTools(id, documentId, headline, googleDocs, organization_locales) {
+      function displayTranslationTools(id, documentId, headline, googleDocs, organizationLocales) {
         var existingDocsOtherLocales = [];
         var availableLocales = [];
 
+        var selectedLocale = document.getElementById('article-locale').value;
+
+        console.log("organizationLocales:", organizationLocales)
         if (googleDocs) {
-          organization_locales.forEach( (orgLocale) => {
+          organizationLocales.forEach( (orgLocale) => {
             var foundLocaleDoc = false;
             // loop over each google doc associated with this article
             googleDocs.forEach( (doc) => {
@@ -905,33 +846,43 @@
 
           if (availableLocales && availableLocales.length > 0) {
             availableLocales.forEach(availableLocale => {
-              // TODO: make another version of this button for the bottom of the sidebar?
-              var button = document.createElement("button");
-              button.setAttribute("class", "blue");
-              button.setAttribute("type", "button");
-              button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
-              button.setAttribute("data-headline", headline);
-              button.setAttribute("data-article-id", id);
-              button.setAttribute("data-locale", availableLocale.code);
-              button.setAttribute("onClick", "handleCreateDoc(this)");
-              button.innerHTML = 'Translate to ' + availableLocale.name;
-              console.log(availableLocale, "button:", button);
-              var buttonsTopContainer = document.getElementById('action-buttons-top');
-              buttonsTopContainer.appendChild(button);
+              if (availableLocale.code !== selectedLocale) {
+                // TODO: make another version of this button for the bottom of the sidebar?
+                var buttonId = "translate-button-top-" + availableLocale.code;
+                if (!document.getElementById(buttonId)) { // avoid adding multiple instances of the same button
+                  var button = document.createElement("button");
+                  button.setAttribute("class", "blue");
+                  button.setAttribute("type", "button");
+                  button.setAttribute("id", buttonId);
+                  button.setAttribute("data-headline", headline);
+                  button.setAttribute("data-article-id", id);
+                  button.setAttribute("data-locale", availableLocale.code);
+                  button.setAttribute("onClick", "handleCreateDoc(this)");
+                  button.innerHTML = 'Translate to ' + availableLocale.name;
+                  console.log(availableLocale, "button:", button);
+                  var buttonsTopContainer = document.getElementById('action-buttons-top');
+                  buttonsTopContainer.appendChild(button);
+                }
+              }
             })
           }
 
           if (existingDocsOtherLocales.length > 0) {
             existingDocsOtherLocales.forEach(doc => {
-              var button = document.createElement("button");
-              button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
-              button.setAttribute("class", "blue");
-              button.setAttribute("type", "button");
-              var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
-              button.setAttribute("onClick", buttonOpenLink);
-              button.innerHTML = "Open in " + doc.locale.name;
-              var buttonsTopContainer = document.getElementById('action-buttons-top');
-              buttonsTopContainer.appendChild(button);
+              if (doc.locale.code !== selectedLocale) {
+                var buttonId = "translate-button-top-" + doc.locale.code;
+                if (!document.getElementById(buttonId)) { // avoid adding multiple instances of the same button
+                  var button = document.createElement("button");
+                  button.setAttribute("id", buttonId);
+                  button.setAttribute("class", "blue");
+                  button.setAttribute("type", "button");
+                  var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
+                  button.setAttribute("onClick", buttonOpenLink);
+                  button.innerHTML = "Open in " + doc.locale.name;
+                  var buttonsTopContainer = document.getElementById('action-buttons-top');
+                  buttonsTopContainer.appendChild(button);
+                }
+              }
             });
           }
         }
@@ -968,6 +919,15 @@
             if (publishedInfo && publishedInfo[0]) {
               displayPublishedInfo(publishedInfo[0].article_translation, translations[0]);
             }
+
+            console.log("response:", response);
+            var googleDocs = response.data.data.insert_articles.returning[0].article_google_documents;
+            var organizationLocales = response.data.organization_locales;
+            var documentID = response.documentID;
+            console.log("googleDocs:", googleDocs, "organizationLocales:", organizationLocales, "documentID:", documentID);
+            // displayTranslationTools(id, documentId, headline, googleDocs, organizationLocales) {
+
+            displayTranslationTools(articleID, documentID, translations[0].headline, googleDocs, organizationLocales);
 
           } else if (response.data && response.data.data && response.data.data.insert_pages) {
             var pageID = response.data.data.insert_pages.returning[0].id;

--- a/Page.html
+++ b/Page.html
@@ -295,69 +295,71 @@
           }
         }
 
-        var existingDocsOtherLocales = [];
-        var availableLocales = [];
+        // displayTranslationTools(id, headline, googleDocs, organization_locales)
+        displayTranslationTools(data.id, contents.documentId, translationData.headline, googleDocs, contents.data.organization_locales);
+        // var existingDocsOtherLocales = [];
+        // var availableLocales = [];
 
-        if (googleDocs) {
-          contents.data.organization_locales.forEach( (orgLocale) => {
-            var foundLocaleDoc = false;
-            // loop over each google doc associated with this article
-            googleDocs.forEach( (doc) => {
-              // if google doc is not the current one we have open...
-              if (doc.google_document.document_id !== contents.documentId) {
-                // ... and this org locale is equal to the google doc's locale
-                if (orgLocale.locale.code === doc.google_document.locale_code) {
-                  // add it to the list of documents available that are translations of this article
-                  existingDocsOtherLocales.push(doc.google_document);
-                  foundLocaleDoc = true;
-                }
-              // current document
-              } else {
-                if (orgLocale.locale.code === doc.google_document.locale_code) {
-                  foundLocaleDoc = true;
-                }
-              }
-            });
-            // if we didn't find a google document for this org locale, mark it as available
-            if (!foundLocaleDoc) {
-              availableLocales.push(orgLocale.locale);
-            }
-          })
+        // if (googleDocs) {
+        //   contents.data.organization_locales.forEach( (orgLocale) => {
+        //     var foundLocaleDoc = false;
+        //     // loop over each google doc associated with this article
+        //     googleDocs.forEach( (doc) => {
+        //       // if google doc is not the current one we have open...
+        //       if (doc.google_document.document_id !== contents.documentId) {
+        //         // ... and this org locale is equal to the google doc's locale
+        //         if (orgLocale.locale.code === doc.google_document.locale_code) {
+        //           // add it to the list of documents available that are translations of this article
+        //           existingDocsOtherLocales.push(doc.google_document);
+        //           foundLocaleDoc = true;
+        //         }
+        //       // current document
+        //       } else {
+        //         if (orgLocale.locale.code === doc.google_document.locale_code) {
+        //           foundLocaleDoc = true;
+        //         }
+        //       }
+        //     });
+        //     // if we didn't find a google document for this org locale, mark it as available
+        //     if (!foundLocaleDoc) {
+        //       availableLocales.push(orgLocale.locale);
+        //     }
+        //   })
 
-          console.log("availableLocales:", availableLocales, "existingDocsOtherLocales:", existingDocsOtherLocales);
+        //   console.log("availableLocales:", availableLocales, "existingDocsOtherLocales:", existingDocsOtherLocales);
 
-          if (availableLocales && availableLocales.length > 0) {
-            availableLocales.forEach(availableLocale => {
-              // TODO: make another version of this button for the bottom of the sidebar?
-              var button = document.createElement("button");
-              button.setAttribute("class", "blue");
-              button.setAttribute("type", "button");
-              button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
-              button.setAttribute("data-headline", translationData.headline);
-              button.setAttribute("data-article-id", data.id);
-              button.setAttribute("data-locale", availableLocale.code);
-              button.setAttribute("onClick", "handleCreateDoc(this)");
-              button.innerHTML = 'Translate to ' + availableLocale.name;
-              console.log(availableLocale, "button:", button);
-              var buttonsTopContainer = document.getElementById('action-buttons-top');
-              buttonsTopContainer.appendChild(button);
-            })
-          }
+        //   if (availableLocales && availableLocales.length > 0) {
+        //     availableLocales.forEach(availableLocale => {
+        //       // TODO: make another version of this button for the bottom of the sidebar?
+        //       var button = document.createElement("button");
+        //       button.setAttribute("class", "blue");
+        //       button.setAttribute("type", "button");
+        //       button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
+        //       button.setAttribute("data-headline", translationData.headline);
+        //       button.setAttribute("data-article-id", data.id);
+        //       button.setAttribute("data-locale", availableLocale.code);
+        //       button.setAttribute("onClick", "handleCreateDoc(this)");
+        //       button.innerHTML = 'Translate to ' + availableLocale.name;
+        //       console.log(availableLocale, "button:", button);
+        //       var buttonsTopContainer = document.getElementById('action-buttons-top');
+        //       buttonsTopContainer.appendChild(button);
+        //     })
+        //   }
 
-          if (existingDocsOtherLocales.length > 0) {
-            existingDocsOtherLocales.forEach(doc => {
-              var button = document.createElement("button");
-              button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
-              button.setAttribute("class", "blue");
-              button.setAttribute("type", "button");
-              var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
-              button.setAttribute("onClick", buttonOpenLink);
-              button.innerHTML = "Open in " + doc.locale.name;
-              var buttonsTopContainer = document.getElementById('action-buttons-top');
-              buttonsTopContainer.appendChild(button);
-            });
-          }
-        }
+        //   if (existingDocsOtherLocales.length > 0) {
+        //     existingDocsOtherLocales.forEach(doc => {
+        //       var button = document.createElement("button");
+        //       button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
+        //       button.setAttribute("class", "blue");
+        //       button.setAttribute("type", "button");
+        //       var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
+        //       button.setAttribute("onClick", buttonOpenLink);
+        //       button.innerHTML = "Open in " + doc.locale.name;
+        //       var buttonsTopContainer = document.getElementById('action-buttons-top');
+        //       buttonsTopContainer.appendChild(button);
+        //     });
+        //   }
+        // }
 
         if (publishedInfo) {
           displayPublishedInfo(publishedInfo, translationData);
@@ -867,6 +869,72 @@
 
       function handleGetArticle() {
          google.script.run.withFailureHandler(onFailure).withSuccessHandler(handleGetTranslationsForArticle).hasuraGetArticle();
+      }
+
+      function displayTranslationTools(id, documentId, headline, googleDocs, organization_locales) {
+        var existingDocsOtherLocales = [];
+        var availableLocales = [];
+
+        if (googleDocs) {
+          organization_locales.forEach( (orgLocale) => {
+            var foundLocaleDoc = false;
+            // loop over each google doc associated with this article
+            googleDocs.forEach( (doc) => {
+              // if google doc is not the current one we have open...
+              if (doc.google_document.document_id !== documentId) {
+                // ... and this org locale is equal to the google doc's locale
+                if (orgLocale.locale.code === doc.google_document.locale_code) {
+                  // add it to the list of documents available that are translations of this article
+                  existingDocsOtherLocales.push(doc.google_document);
+                  foundLocaleDoc = true;
+                }
+              // current document
+              } else {
+                if (orgLocale.locale.code === doc.google_document.locale_code) {
+                  foundLocaleDoc = true;
+                }
+              }
+            });
+            // if we didn't find a google document for this org locale, mark it as available
+            if (!foundLocaleDoc) {
+              availableLocales.push(orgLocale.locale);
+            }
+          })
+
+          console.log("availableLocales:", availableLocales, "existingDocsOtherLocales:", existingDocsOtherLocales);
+
+          if (availableLocales && availableLocales.length > 0) {
+            availableLocales.forEach(availableLocale => {
+              // TODO: make another version of this button for the bottom of the sidebar?
+              var button = document.createElement("button");
+              button.setAttribute("class", "blue");
+              button.setAttribute("type", "button");
+              button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
+              button.setAttribute("data-headline", headline);
+              button.setAttribute("data-article-id", id);
+              button.setAttribute("data-locale", availableLocale.code);
+              button.setAttribute("onClick", "handleCreateDoc(this)");
+              button.innerHTML = 'Translate to ' + availableLocale.name;
+              console.log(availableLocale, "button:", button);
+              var buttonsTopContainer = document.getElementById('action-buttons-top');
+              buttonsTopContainer.appendChild(button);
+            })
+          }
+
+          if (existingDocsOtherLocales.length > 0) {
+            existingDocsOtherLocales.forEach(doc => {
+              var button = document.createElement("button");
+              button.setAttribute("id", "translate-button-top"); // TODO: figure out how this will work with multiple buttons?
+              button.setAttribute("class", "blue");
+              button.setAttribute("type", "button");
+              var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
+              button.setAttribute("onClick", buttonOpenLink);
+              button.innerHTML = "Open in " + doc.locale.name;
+              var buttonsTopContainer = document.getElementById('action-buttons-top');
+              buttonsTopContainer.appendChild(button);
+            });
+          }
+        }
       }
 
       function onSuccessPreviewPublish(response) {

--- a/Page.html
+++ b/Page.html
@@ -223,10 +223,13 @@
 
         button.setAttribute("class", "blue");
         button.setAttribute("type", "button");
+
         var buttonOpenLink = "window.open('" + contents.url + "', '_blank')";
         button.setAttribute("onClick", buttonOpenLink);
         // button.innerHTML = "Open " + doc.locale_code;
         button.href = contents.url;
+
+        window.open(contents.url, '_blank');
       }
 
       function handleCreateDoc(el) {


### PR DESCRIPTION
Closes #320 
Closes #326 

**Update (Thursday): this  functionality now may be tested with 👉 version 94 👈  in the script editor; includes translations for pages**

**Update (Friday): now displays full locale name, prevents dupe buttons, and opens new translated doc in a new tab in one step**

Based on the locales available for a given organisation and what google documents are associated with an article, this PR updates the publishing tools so, for the Test Diaryo site that publishes in english and filipino:

* a document for an article in english only will display a "Translate to Filipino" button
* upon clicking that "translate" button, a new document will be created and the button updated to "open translation"
* clicking to open will open the new doc in a new browser tab
* subsequent loads of the original english document sidebar will display the "Open in fil" button that opens the translated doc in another tab

So, for each additional locale that a site publishes in:

* if a google doc exists for this article, display an "open" button for the translation
* if no google doc exists, display a "translate" button to create a new translation

This gets a little confusing to test with the code only in the script editor testing mode: opening the sidebar in the newly created translation doc will not show the right buttons as this PR hasn't been published for the add-on yet!

Making all of this work was a bit easier this time around for me, but it's still kinda tricky, so I appreciate the help testing it out.