### PR TITLE
Fixes the 'click to view' link

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -825,12 +825,18 @@ async function hasuraHandlePublish(formObject) {
         var result = await hasuraCreateAuthorPage(author, pageID);
       }
     }
+    var path = "";
     if (formObject['article-locale']) {
-      fullPublishUrl = publishUrl + "/" + formObject['article-locale'] + "/" + slug;
-    } else {
-      fullPublishUrl = publishUrl + "/" + slug;
+      path += formObject['article-locale'];
     }
-    Logger.log("fullPublishUrl: " + fullPublishUrl);
+    if (slug !== 'about' && slug !== 'donate' && slug !== 'thank-you') { // these 3 pages have their own special routes
+      path += "/static/" + slug;
+    } else {
+      path += "/" + slug;
+    }
+    fullPublishUrl = publishUrl + path;
+
+    Logger.log("publishUrl: " + publishUrl + " fullPublishUrl: " + fullPublishUrl);
 
   } else {
     documentType = "article";
@@ -898,9 +904,11 @@ async function hasuraHandlePublish(formObject) {
       }
     }
     if (formObject['article-locale']) {
-      fullPublishUrl = publishUrl + "/" + formObject['article-locale'] + "/articles/" + categorySlug + "/" + articleSlug;
+      var path = formObject['article-locale'] + "/articles/" + categorySlug + "/" + articleSlug;
+      fullPublishUrl = publishUrl + path;
     } else {
-      fullPublishUrl = publishUrl + "/articles/" + categorySlug + "/" + articleSlug;
+      var path = "articles/" + categorySlug + "/" + articleSlug;
+      fullPublishUrl = publishUrl + path;
     }
   }
 


### PR DESCRIPTION
Closes #321

** Test using 👉 version 95 👈  in the script editor **

There are a few variations on the link that gets displayed after publishing an article or page:

* with or without a locale
* specially coded pages (About, Donate, Thank You)
* generic static pages (any other 'page' type)
* articles

This PR, available at **version 95** in the script editor, ensures that the 3 special pages _and_ all other generic pages get the right URL for this link. About should be `/en-US/about`, for instance, while a custom History page would be `/en-US/static/history`.

Tested with Oaklyn & Test Diaryo on an article, an About page and a custom static page.