### PR TITLE
Allow backdating stories by overriding first published at date

### DIFF
--- a/GraphQL.js
+++ b/GraphQL.js
@@ -30,7 +30,7 @@ const insertAuthorPageMutation = `mutation AddonInsertAuthorPage($page_id: Int!,
   }
 }`;
 
-const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoogleDocNoID($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb,  $article_sources: [article_source_insert_input!]!) {
+const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoogleDocNoID($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb,  $first_published_at: timestamptz, $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
       article_translations: {
@@ -47,7 +47,8 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
           search_title: $search_title, 
           twitter_description: $twitter_description, 
           twitter_title: $twitter_title,
-          main_image: $main_image
+          main_image: $main_image,
+          first_published_at: $first_published_at
         }
       }, 
       category_id: $category_id, 
@@ -122,6 +123,8 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
         locale_code
         published
         headline
+        first_published_at
+        last_published_at
       }
       published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
         article_translation {
@@ -135,13 +138,13 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
   }
 }`;
 
-const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, 
+const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamptz,
   $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
       article_translations: {
         data: {
-          created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, main_image: $main_image
+          first_published_at: $first_published_at, created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, main_image: $main_image
         }
       }, 
       article_sources: {
@@ -214,6 +217,8 @@ const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWith
         locale_code
         published
         headline
+        first_published_at
+        last_published_at
       }
       published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
         article_translation {
@@ -227,12 +232,12 @@ const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWith
   }
 }`;
 
-const insertArticleGoogleDocMutationWithoutSources = `mutation AddonInsertArticleGoogleDocWithoutSources($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb) {
+const insertArticleGoogleDocMutationWithoutSources = `mutation AddonInsertArticleGoogleDocWithoutSources($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamptz) {
   insert_articles(
     objects: {
       article_translations: {
         data: {
-          created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, main_image: $main_image
+          created_by_email: $created_by_email, headline: $headline, locale_code: $locale_code, published: $published, content: $content, custom_byline: $custom_byline, facebook_description: $facebook_description, facebook_title: $facebook_title, search_description: $search_description, search_title: $search_title, twitter_description: $twitter_description, twitter_title: $twitter_title, main_image: $main_image, first_published_at: $first_published_at
         }
       }, 
       category_id: $category_id, 
@@ -301,6 +306,8 @@ const insertArticleGoogleDocMutationWithoutSources = `mutation AddonInsertArticl
         locale_code
         published
         headline
+        first_published_at
+        last_published_at
       }
       published_article_translations(where: {locale_code: {_eq: $locale_code}}) {
         article_translation {
@@ -397,7 +404,7 @@ const linkDocToArticleMutation = `mutation AddonLinkGoogleDocToArticle($article_
   }
 }`;
 
-const upsertPublishedArticleTranslationMutation = `mutation AddonUpsertPublishedArticleTranslation($article_id: Int = 10, $article_translation_id: Int = 10, $locale_code: String = "") {
+const upsertPublishedArticleTranslationMutation = `mutation AddonUpsertPublishedArticleTranslation($article_id: Int, $article_translation_id: Int, $locale_code: String) {
   insert_published_article_translations(objects: {article_id: $article_id, article_translation_id: $article_translation_id, locale_code: $locale_code}, on_conflict: {constraint: published_article_translations_article_id_locale_code_key, update_columns: article_translation_id}) {
     affected_rows
     returning {

--- a/Page.html
+++ b/Page.html
@@ -4,11 +4,12 @@
     <base target="_top">
     <link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons1.css">
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vanillajs-datepicker@1.1.4/dist/css/datepicker.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/css/select2.min.css" rel="stylesheet" />
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vanillajs-datepicker@1.1.4/dist/js/datepicker.min.js"></script>
 
     <script>
       // thanks stack overflow 
@@ -382,16 +383,23 @@
           }
         });
 
-        const elem = document.querySelector('input[name="article-first-published-date"]');
-        const datepicker = new Datepicker(elem, {
-          autohide: true
-        }); 
         console.log("publishedInfo:", publishedInfo);
         if (publishedInfo) {
-          // 2021-09-01T00:00:00.000+00:00
-          var firstPubDate = new Date(publishedInfo.first_published_at).toLocaleString('en-US', { timeZone: 'UTC' });
+          var firstPubDate = new Date(publishedInfo.first_published_at);
           console.log("setting published date to ", firstPubDate, publishedInfo.first_published_at);
-          datepicker.setDate(firstPubDate);
+
+          flatpickr('input[name="article-first-published-date"]', {
+            enableTime: true,
+            dateFormat: "Y-m-d H:i K",
+            defaultDate: firstPubDate
+          });
+        } else {
+          var today = new Date();
+          flatpickr('input[name="article-first-published-date"]', {
+            enableTime: true,
+            dateFormat: "Y-m-d H:i K",
+            defaultDate: today
+          });
         }
 
         if (data && documentType === "article") {
@@ -958,16 +966,23 @@
             if (publishedInfo && publishedInfo[0]) {
               var mostRecentPubInfo = publishedInfo[0].article_translation;
               displayPublishedInfo(mostRecentPubInfo, translations[0]);
-
-              const elem = document.querySelector('input[name="article-first-published-date"]');
-              const datepicker = new Datepicker(elem, {
-                autohide: true
-              }); 
+              
               console.log("publishedInfo:", mostRecentPubInfo);
               if (mostRecentPubInfo) {
-                var firstPubDate = new Date(mostRecentPubInfo.first_published_at).toLocaleString('en-US', { timeZone: 'UTC' });
+                var firstPubDate = new Date(mostRecentPubInfo.first_published_at);
                 console.log("setting published date to ", firstPubDate, mostRecentPubInfo.first_published_at);
-                datepicker.setDate(firstPubDate);
+                flatpickr('input[name="article-first-published-date"]', {
+                  enableTime: true,
+                  dateFormat: "Y-m-d H:i K",
+                  defaultDate: firstPubDate
+                });
+              } else {
+                var today = new Date();
+                flatpickr('input[name="article-first-published-date"]', {
+                  enableTime: true,
+                  dateFormat: "Y-m-d H:i K",
+                  defaultDate: today
+                });
               }
             }
 
@@ -1024,11 +1039,10 @@
         var searchTitle = document.getElementById('article-search-title');
         var searchDescription = document.getElementById('article-search-description');
 
-        const elem = document.querySelector('input[name="article-first-published-date"]');
-        const datepicker = new Datepicker(elem, {
-          autohide: true
-        }); 
-        var publishedDate = datepicker.getDate("yyyy-mm-dd");
+        const calendar = flatpickr('input[name="article-first-published-date"]', {});
+        console.log("selected dates:", typeof(calendar.selectedDates), calendar.selectedDates)
+        
+        var publishedDate = calendar.selectedDates[0].toISOString();
         console.log("publishing with date:", publishedDate);
 
         var sources = {};

--- a/Page.html
+++ b/Page.html
@@ -382,14 +382,14 @@
           }
         });
 
-        // IN PROGRESS
         const elem = document.querySelector('input[name="article-first-published-date"]');
         const datepicker = new Datepicker(elem, {
           autohide: true
         }); 
         console.log("publishedInfo:", publishedInfo);
         if (publishedInfo) {
-          var firstPubDate = new Date(publishedInfo.first_published_at);
+          // 2021-09-01T00:00:00.000+00:00
+          var firstPubDate = new Date(publishedInfo.first_published_at).toLocaleString('en-US', { timeZone: 'UTC' });
           console.log("setting published date to ", firstPubDate, publishedInfo.first_published_at);
           datepicker.setDate(firstPubDate);
         }
@@ -965,7 +965,7 @@
               }); 
               console.log("publishedInfo:", mostRecentPubInfo);
               if (mostRecentPubInfo) {
-                var firstPubDate = new Date(mostRecentPubInfo.first_published_at);
+                var firstPubDate = new Date(mostRecentPubInfo.first_published_at).toLocaleString('en-US', { timeZone: 'UTC' });
                 console.log("setting published date to ", firstPubDate, mostRecentPubInfo.first_published_at);
                 datepicker.setDate(firstPubDate);
               }

--- a/Page.html
+++ b/Page.html
@@ -4,9 +4,11 @@
     <base target="_top">
     <link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons1.css">
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vanillajs-datepicker@1.1.4/dist/css/datepicker.min.css">
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/css/select2.min.css" rel="stylesheet" />
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-beta.1/dist/js/select2.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vanillajs-datepicker@1.1.4/dist/js/datepicker.min.js"></script>
 
     <script>
       // thanks stack overflow 
@@ -295,6 +297,7 @@
           }
           if (contents.data.published_article_translations && contents.data.published_article_translations[0]) {
             publishedInfo = contents.data.published_article_translations[0].article_translation;
+            console.log("found publishedInfo:", publishedInfo);
           }
         } else if (contents.data.pages) {
           documentType = "page"
@@ -378,6 +381,18 @@
             }
           }
         });
+
+        // IN PROGRESS
+        const elem = document.querySelector('input[name="article-first-published-date"]');
+        const datepicker = new Datepicker(elem, {
+          autohide: true
+        }); 
+        console.log("publishedInfo:", publishedInfo);
+        if (publishedInfo) {
+          var firstPubDate = new Date(publishedInfo.first_published_at);
+          console.log("setting published date to ", firstPubDate, publishedInfo.first_published_at);
+          datepicker.setDate(firstPubDate);
+        }
 
         if (data && documentType === "article") {
           google.script.run.withFailureHandler(onFailureFeatured).withSuccessHandler(onSuccessFeatured).isArticleFeatured(data.id);
@@ -941,7 +956,19 @@
             }
             var publishedInfo = response.data.data.insert_articles.returning[0].published_article_translations;
             if (publishedInfo && publishedInfo[0]) {
-              displayPublishedInfo(publishedInfo[0].article_translation, translations[0]);
+              var mostRecentPubInfo = publishedInfo[0].article_translation;
+              displayPublishedInfo(mostRecentPubInfo, translations[0]);
+
+              const elem = document.querySelector('input[name="article-first-published-date"]');
+              const datepicker = new Datepicker(elem, {
+                autohide: true
+              }); 
+              console.log("publishedInfo:", mostRecentPubInfo);
+              if (mostRecentPubInfo) {
+                var firstPubDate = new Date(mostRecentPubInfo.first_published_at);
+                console.log("setting published date to ", firstPubDate, mostRecentPubInfo.first_published_at);
+                datepicker.setDate(firstPubDate);
+              }
             }
 
             console.log("response:", response);
@@ -997,9 +1024,15 @@
         var searchTitle = document.getElementById('article-search-title');
         var searchDescription = document.getElementById('article-search-description');
 
+        const elem = document.querySelector('input[name="article-first-published-date"]');
+        const datepicker = new Datepicker(elem, {
+          autohide: true
+        }); 
+        var publishedDate = datepicker.getDate("yyyy-mm-dd");
+        console.log("publishing with date:", publishedDate);
+
         var sources = {};
 
-        console.log("handling click - doc type is " + documentType, "formObject.submitted:", formObject.submitted);
         if (documentType !== "page")  {
           var elements = formObject.elements;
 
@@ -1092,6 +1125,8 @@
           for (var i = 0, tag; tag = selectedTags[i++];) {
             submitData["article-tags"].push(tag.text);
           }
+          submitData["first-published-at"] = publishedDate;
+          console.log('submitData["first-published-at"]', publishedDate);
           submitData["sources"] = sources;
         }
         
@@ -1290,6 +1325,15 @@
             </label>
             <textarea id="article-twitter-description" name="article-twitter-description"></textarea>
           </div>
+
+          <div class="block form-group">
+            <label for="article-first-published-date">
+              <b>Published Date</b>
+            </label>
+
+            <input type="text" name="article-first-published-date">
+          </div>
+
 
           <div id="sources-list-container" class="block form-group">
             <h2 class="title">Source Tracking</h2>


### PR DESCRIPTION
Closes #330 

Selecting a date in the new date picker will override the first published date, which is otherwise automatically set in the database. This is testable using the latest code in the script editor.