### PR TITLE
First published date fixes: time zone, database field type, and new doc date picker

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -431,10 +431,11 @@ async function insertArticleGoogleDocs(data) {
     "main_image": mainImageContent,
   };
 
-  if (data["article-first-published-date"]) {
-    articleData["first_published_at"] = data["article-first-published-date"];
-    Logger.log("* pub date: " + articleData["first_published_at"]);
-  }
+  if (data["first-published-at"]) {
+    articleData["first_published_at"] = data["first-published-at"];
+    Logger.log("* first published at: " + articleData["first_published_at"]);
+  } 
+
   // console.log("*articleData.main_image: " + JSON.stringify(articleData['main_image']))
 
   var dataSources = [];
@@ -892,8 +893,8 @@ async function hasuraHandlePublish(formObject) {
   } else {
     documentType = "article";
     // insert or update article
-    if (formObject["article-first-published-date"]) {
-      formObject["first-published-at"] = formObject["article-first-published-date"];
+    if (formObject["first-published-at"]) {
+      Logger.log("first-published-at datetime: " + formObject["first-published-at"])
     }
     var data = await insertArticleGoogleDocs(formObject);
     Logger.log(JSON.stringify(data));
@@ -1057,10 +1058,6 @@ async function hasuraHandlePreview(formObject) {
     documentType = "article";
     // insert or update article
     // Logger.log("sources:" + JSON.stringify(formObject['sources']));
-
-    if (formObject["article-first-published-date"]) {
-      formObject["first-published-at"] = formObject["article-first-published-date"];
-    }
 
     var data = await insertArticleGoogleDocs(formObject);
     // Logger.log("articleResult: " + JSON.stringify(data))

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -30,7 +30,7 @@ const insertAuthorPageMutation = `mutation AddonInsertAuthorPage($page_id: Int!,
   }
 }`;
 
-const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoogleDocNoID($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb,  $first_published_at: timestamp, $article_sources: [article_source_insert_input!]!) {
+const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoogleDocNoID($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb,  $first_published_at: timestamptz, $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
       article_translations: {
@@ -138,7 +138,7 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
   }
 }`;
 
-const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamp,
+const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamptz,
   $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
@@ -232,7 +232,7 @@ const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWith
   }
 }`;
 
-const insertArticleGoogleDocMutationWithoutSources = `mutation AddonInsertArticleGoogleDocWithoutSources($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamp) {
+const insertArticleGoogleDocMutationWithoutSources = `mutation AddonInsertArticleGoogleDocWithoutSources($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamptz) {
   insert_articles(
     objects: {
       article_translations: {

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -30,7 +30,7 @@ const insertAuthorPageMutation = `mutation AddonInsertAuthorPage($page_id: Int!,
   }
 }`;
 
-const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoogleDocNoID($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb,  $first_published_at: timestamptz, $article_sources: [article_source_insert_input!]!) {
+const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoogleDocNoID($locale_code: String!, $created_by_email: String, $headline: String!, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb,  $first_published_at: timestamp, $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
       article_translations: {
@@ -138,7 +138,7 @@ const insertArticleGoogleDocMutationWithoutId = `mutation AddonInsertArticleGoog
   }
 }`;
 
-const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamptz,
+const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWithID($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamp,
   $article_sources: [article_source_insert_input!]!) {
   insert_articles(
     objects: {
@@ -232,7 +232,7 @@ const insertArticleGoogleDocMutation = `mutation AddonInsertArticleGoogleDocWith
   }
 }`;
 
-const insertArticleGoogleDocMutationWithoutSources = `mutation AddonInsertArticleGoogleDocWithoutSources($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamptz) {
+const insertArticleGoogleDocMutationWithoutSources = `mutation AddonInsertArticleGoogleDocWithoutSources($id: Int!, $locale_code: String!, $headline: String!, $created_by_email: String, $published: Boolean, $category_id: Int!, $slug: String!, $document_id: String, $url: String, $custom_byline: String, $content: jsonb, $facebook_description: String, $facebook_title: String, $search_description: String, $search_title: String, $twitter_description: String, $twitter_title: String, $main_image: jsonb, $first_published_at: timestamp) {
   insert_articles(
     objects: {
       article_translations: {

--- a/Page.html
+++ b/Page.html
@@ -19,6 +19,13 @@
         return d.toLocaleString();
       }
 
+      function dateToUTC(localDate) {
+        var dateUTC =  Date.UTC(localDate.getUTCFullYear(), localDate.getUTCMonth(), localDate.getUTCDate(),
+        localDate.getUTCHours(), localDate.getUTCMinutes(), localDate.getUTCSeconds());
+        console.log("localDate:", localDate, "in UTC:", dateUTC);
+        return dateUTC;
+      }
+
       function setValueOrDefault(elementId, value, defaultValue) {
         var element = document.getElementById(elementId);
         if (value !== undefined && value !== null && value !== "") {
@@ -1038,12 +1045,13 @@
         var headline = document.getElementById('article-headline');
         var searchTitle = document.getElementById('article-search-title');
         var searchDescription = document.getElementById('article-search-description');
-
-        const calendar = flatpickr('input[name="article-first-published-date"]', {});
-        console.log("selected dates:", typeof(calendar.selectedDates), calendar.selectedDates)
+       
+        const calendar = flatpickr('input[name="article-first-published-date"]', {enableTime: true,
+            dateFormat: "Y-m-d H:i K"});
         
-        var publishedDate = calendar.selectedDates[0].toISOString();
-        console.log("publishing with date:", publishedDate);
+        var localPublishedDate = calendar.selectedDates[0];
+        var publishedDate = dateToUTC(localPublishedDate);
+        console.log("date:", localPublishedDate, "converted to UTC:", publishedDate);
 
         var sources = {};
 
@@ -1154,6 +1162,11 @@
             if (!window.confirm("You're trying to publish an article without any source tracking info: are you sure?")) { 
               form.style.display = "block";
               loadingDiv.innerHTML = "Please enter source tracking info, then try publishing again.";
+              const redrawCalendar = flatpickr('input[name="article-first-published-date"]', {
+                enableTime: true,
+                dateFormat: "Y-m-d H:i K",
+              });
+
             } else {
               loadingDiv.innerHTML = "<p class='gray'>Publishing without any sources... </p>"
               google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);

--- a/Page.html
+++ b/Page.html
@@ -19,11 +19,24 @@
         return d.toLocaleString();
       }
 
-      function dateToUTC(localDate) {
-        var dateUTC =  Date.UTC(localDate.getUTCFullYear(), localDate.getUTCMonth(), localDate.getUTCDate(),
-        localDate.getUTCHours(), localDate.getUTCMinutes(), localDate.getUTCSeconds());
-        console.log("localDate:", localDate, "in UTC:", dateUTC);
-        return dateUTC;
+      // javascript date handling is awful
+      // function from https://stackoverflow.com/a/17415677
+      function toIsoString(date) {
+        var tzo = -date.getTimezoneOffset(),
+            dif = tzo >= 0 ? '+' : '-',
+            pad = function(num) {
+                var norm = Math.floor(Math.abs(num));
+                return (norm < 10 ? '0' : '') + norm;
+            };
+
+        return date.getFullYear() +
+            '-' + pad(date.getMonth() + 1) +
+            '-' + pad(date.getDate()) +
+            'T' + pad(date.getHours()) +
+            ':' + pad(date.getMinutes()) +
+            ':' + pad(date.getSeconds()) +
+            dif + pad(tzo / 60) +
+            ':' + pad(tzo % 60);
       }
 
       function setValueOrDefault(elementId, value, defaultValue) {
@@ -397,14 +410,14 @@
 
           flatpickr('input[name="article-first-published-date"]', {
             enableTime: true,
-            dateFormat: "Y-m-d H:i K",
+            dateFormat: "Y-m-d h:i K",
             defaultDate: firstPubDate
           });
         } else {
           var today = new Date();
           flatpickr('input[name="article-first-published-date"]', {
             enableTime: true,
-            dateFormat: "Y-m-d H:i K",
+            dateFormat: "Y-m-d h:i K",
             defaultDate: today
           });
         }
@@ -980,14 +993,14 @@
                 console.log("setting published date to ", firstPubDate, mostRecentPubInfo.first_published_at);
                 flatpickr('input[name="article-first-published-date"]', {
                   enableTime: true,
-                  dateFormat: "Y-m-d H:i K",
+                  dateFormat: "Y-m-d h:i K",
                   defaultDate: firstPubDate
                 });
               } else {
                 var today = new Date();
                 flatpickr('input[name="article-first-published-date"]', {
                   enableTime: true,
-                  dateFormat: "Y-m-d H:i K",
+                  dateFormat: "Y-m-d h:i K",
                   defaultDate: today
                 });
               }
@@ -1047,11 +1060,12 @@
         var searchDescription = document.getElementById('article-search-description');
        
         const calendar = flatpickr('input[name="article-first-published-date"]', {enableTime: true,
-            dateFormat: "Y-m-d H:i K"});
+            dateFormat: "Y-m-d h:i K"});
         
-        var localPublishedDate = calendar.selectedDates[0];
-        var publishedDate = dateToUTC(localPublishedDate);
-        console.log("date:", localPublishedDate, "converted to UTC:", publishedDate);
+        var publishedDate = calendar.selectedDates[0];
+        // 2018-08-28T12:30:00+05:30
+        // var formattedPubDate = calendar.formatDate(publishedDate, "y-m-dT")
+        console.log("storing pub date as:", publishedDate);
 
         var sources = {};
 
@@ -1147,8 +1161,9 @@
           for (var i = 0, tag; tag = selectedTags[i++];) {
             submitData["article-tags"].push(tag.text);
           }
-          submitData["first-published-at"] = publishedDate;
-          console.log('submitData["first-published-at"]', publishedDate);
+          var formattedPubDate = toIsoString(publishedDate);
+          submitData["first-published-at"] = formattedPubDate;
+          console.log('formattedPubDate:', formattedPubDate);
           submitData["sources"] = sources;
         }
         
@@ -1164,7 +1179,7 @@
               loadingDiv.innerHTML = "Please enter source tracking info, then try publishing again.";
               const redrawCalendar = flatpickr('input[name="article-first-published-date"]', {
                 enableTime: true,
-                dateFormat: "Y-m-d H:i K",
+                dateFormat: "Y-m-d h:i K",
               });
 
             } else {

--- a/Page.html
+++ b/Page.html
@@ -818,10 +818,8 @@
           buttonsDivTop.style.display = "block";
           setPublishedFlag(false); // new article is not published, ensure correct action buttons display
 
-          // if (data && data.data && data.data.organization_locales) {
-            displayLocales(data.data.organization_locales, localeCode);
-          // }
-
+          displayLocales(data.data.organization_locales, localeCode);
+          
           if (documentType === "article") {
             // console.log("data:", data);
             if (data && data.data && data.data.categories) {
@@ -833,6 +831,13 @@
             if (data && data.data && data.data.authors) {
               displayAuthors(data.data.authors, null);
             }
+
+            var today = new Date();
+            flatpickr('input[name="article-first-published-date"]', {
+              enableTime: true,
+              dateFormat: "Y-m-d h:i K",
+              defaultDate: today
+            });
 
             $('#article-authors').select2({
               width: 'resolve',


### PR DESCRIPTION
Closes #336 - fun with time zone conversions in javascript, hasura and postgres
Closes #337 - now initializes the datetime picker in the sidebar for google docs that haven't been previewed or published yet

Test using latest code in the script editor:

* date is once again stored in postgres as timestamptz
* the sidebar code calls this function to format it (without converting time zone): https://stackoverflow.com/a/17415677
* date is then converted by postgres/hasura to UTC

You can also see that the datepicker is now appearing on newly created docs (not yet previewed/published in hasura) by testing with the latest code using the document "Brand New Article Testing Date Picker", which for me appears as the last test case in the editor's list.