### PR TITLE
Bugfix/prevent overwriting articles same slug

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -346,6 +346,12 @@ async function insertPageGoogleDocs(data) {
   var documentURL = DocumentApp.getActiveDocument().getUrl();
   var content = await getCurrentDocContents();
   
+  var returnValue = {
+    status: "success",
+    message: "Successfully inserted page",
+    data: {}
+  };
+
   let pageData = {
     "slug": data['article-slug'],
     "document_id": documentID,
@@ -363,23 +369,36 @@ async function insertPageGoogleDocs(data) {
     "created_by_email": data['created_by_email'],
   };
 
+  // Check if page already exists with the given slug for this organization
+  var existingPages = await findPageBySlug(pageData["slug"]);
+  if (existingPages && existingPages.data && existingPages.data.pages && existingPages.data.pages.length > 0) {
+    returnValue.status = "error";
+    returnValue.message = "Page already exists with the same slug, please pick a unique slug value."
+    returnValue.data = existingPages.data;
+    return returnValue;  
+  }
+  
   if (data["article-id"] === "") {
+    Logger.log("no id")
     // Logger.log("page data:" + JSON.stringify(pageData));
-    return fetchGraphQL(
+    returnValue.data = await fetchGraphQL(
       insertPageGoogleDocsMutationWithoutId,
       "AddonInsertPageGoogleDocNoID",
       pageData
     );
 
   } else {
+    Logger.log("got id")
     pageData["id"] = data['article-id'];
     // Logger.log("page data:" + JSON.stringify(pageData));
-    return fetchGraphQL(
+    returnValue.data = await fetchGraphQL(
       insertPageGoogleDocsMutation,
       "AddonInsertPageGoogleDocWithID",
       pageData
     );
   }
+
+  return returnValue;
 }
 
 function upsertPublishedArticle(articleId, translationId, localeCode) {
@@ -394,12 +413,28 @@ function upsertPublishedArticle(articleId, translationId, localeCode) {
   );
 }
 
+async function findPageBySlug(slug) {
+  var documentID = DocumentApp.getActiveDocument().getId();
+
+  return fetchGraphQL(
+    findPageBySlugQuery,
+    "AddonFindPageBySlug",
+    {
+      document_id: documentID,
+      slug: slug,
+    }
+  );
+}
+
 async function findArticleByCategoryAndSlug(category_id, slug) {
+  var documentID = DocumentApp.getActiveDocument().getId();
+
   return fetchGraphQL(
     findArticleByCategoryAndSlugQuery,
     "AddonFindArticleByCategorySlug",
     {
       category_id: category_id,
+      document_id: documentID,
       slug: slug,
     }
   );
@@ -504,7 +539,7 @@ async function insertArticleGoogleDocs(data) {
 
   // Logger.log("article data:" + JSON.stringify(articleData));
   if (data["article-id"] === "") {
-    returnValue.data = fetchGraphQL(
+    returnValue.data = await fetchGraphQL(
       insertArticleGoogleDocMutationWithoutId,
       "AddonInsertArticleGoogleDocNoID",
       articleData
@@ -513,7 +548,7 @@ async function insertArticleGoogleDocs(data) {
   } else {
     articleData['id'] = data['article-id'];
     Logger.log("inserting WITH id: " + articleData["first_published_at"] + " " + JSON.stringify(Object.keys(articleData)))
-    returnValue.data =  fetchGraphQL(
+    returnValue.data = await fetchGraphQL(
       insertArticleGoogleDocMutation,
       "AddonInsertArticleGoogleDocWithID",
       articleData
@@ -877,10 +912,15 @@ async function hasuraHandlePublish(formObject) {
   if (isStaticPage) {
     documentType = "page";
     // insert or update page
-    var data = await insertPageGoogleDocs(formObject);
+    var insertPage = await insertPageGoogleDocs(formObject);
+
+    if (insertPage.status === "error") {
+      return insertPage;
+    }
+
     // Logger.log("pageResult: " + JSON.stringify(data))
 
-    var pageID = data.data.insert_pages.returning[0].id;
+    var pageID = insertPage.data.data.insert_pages.returning[0].id;
 
     // store slug + page ID in slug versions table
     var result = await storePageIdAndSlug(pageID, slug);
@@ -888,7 +928,7 @@ async function hasuraHandlePublish(formObject) {
 
     var getOrgLocalesResult = await hasuraGetOrganizationLocales();
     Logger.log("Get Org Locales:" + JSON.stringify(getOrgLocalesResult));
-    data.organization_locales = getOrgLocalesResult.data.organization_locales;
+    insertPage.organization_locales = getOrgLocalesResult.data.organization_locales;
 
     if (pageID && formObject['article-authors']) {
       var authors;
@@ -916,6 +956,8 @@ async function hasuraHandlePublish(formObject) {
 
     Logger.log("publishUrl: " + publishUrl + " fullPublishUrl: " + fullPublishUrl);
 
+    data = insertPage;
+
   } else {
     documentType = "article";
     // insert or update article
@@ -930,11 +972,11 @@ async function hasuraHandlePublish(formObject) {
     }
 
     Logger.log(JSON.stringify(insertArticle));
-    Logger.log("translation created: " + JSON.stringify(insertArticle.data.insert_articles.returning[0].article_translations));
-    var articleID = insertArticle.data.insert_articles.returning[0].id;
-    var categorySlug = insertArticle.data.insert_articles.returning[0].category.slug;
-    var articleSlug = insertArticle.data.insert_articles.returning[0].slug;
-    var translationID = insertArticle.data.insert_articles.returning[0].article_translations[0].id;
+    Logger.log("translation created: " + JSON.stringify(insertArticle.data.data.insert_articles.returning[0].article_translations));
+    var articleID = insertArticle.data.data.insert_articles.returning[0].id;
+    var categorySlug = insertArticle.data.data.insert_articles.returning[0].category.slug;
+    var articleSlug = insertArticle.data.data.insert_articles.returning[0].slug;
+    var translationID = insertArticle.data.data.insert_articles.returning[0].article_translations[0].id;
 
     // first delete any previously set authors
     var deleteAuthorsResult = await hasuraDeleteAuthorArticles(articleID);
@@ -946,7 +988,7 @@ async function hasuraHandlePublish(formObject) {
 
     var getOrgLocalesResult = await hasuraGetOrganizationLocales();
     // Logger.log("Get Org Locales:" + JSON.stringify(getOrgLocalesResult));
-    data.organization_locales = getOrgLocalesResult.data.organization_locales;
+    insertArticle.organization_locales = getOrgLocalesResult.data.organization_locales;
 
     if (articleID) {
       // store slug + article ID in slug versions table
@@ -957,7 +999,7 @@ async function hasuraHandlePublish(formObject) {
       if (publishedArticleData) {
         Logger.log("Published Article Data:" + JSON.stringify(publishedArticleData));
 
-        insertArticle.data.insert_articles.returning[0].published_article_translations = publishedArticleData.data.insert_published_article_translations.returning;
+        insertArticle.data.data.insert_articles.returning[0].published_article_translations = publishedArticleData.data.insert_published_article_translations.returning;
       }
     }
 
@@ -1004,6 +1046,8 @@ async function hasuraHandlePublish(formObject) {
       var path = "articles/" + categorySlug + "/" + articleSlug;
       fullPublishUrl = publishUrl + path;
     }
+
+    data = insertArticle;
   }
 
   // trigger republish of the site to reflect new article
@@ -1059,14 +1103,20 @@ async function hasuraHandlePreview(formObject) {
   if (isStaticPage) {
     documentType = "page";
     // insert or update page
-    var data = await insertPageGoogleDocs(formObject);
+    var insertPage = await insertPageGoogleDocs(formObject);
+
+    if (insertPage.status === "error") {
+      return insertPage;
+    }
+
     // Logger.log("pageResult: " + JSON.stringify(data))
 
-    var pageID = data.data.insert_pages.returning[0].id;
+    Logger.log("insertPage: " + JSON.stringify(insertPage));
+    var pageID = insertPage.data.data.insert_pages.returning[0].id;
 
     var getOrgLocalesResult = await hasuraGetOrganizationLocales();
     Logger.log("Get Org Locales:" + JSON.stringify(getOrgLocalesResult));
-    data.organization_locales = getOrgLocalesResult.data.organization_locales;
+    insertPage.organization_locales = getOrgLocalesResult.data.organization_locales;
 
     // store slug + page ID in slug versions table
     var result = await storePageIdAndSlug(pageID, slug);
@@ -1086,6 +1136,8 @@ async function hasuraHandlePreview(formObject) {
       }
     }
 
+    data = insertPage;
+
   } else {
     documentType = "article";
     // insert or update article
@@ -1103,7 +1155,7 @@ async function hasuraHandlePreview(formObject) {
     }
 
     // Logger.log("articleResult: " + JSON.stringify(data))
-    var articleID = insertArticle.data.insert_articles.returning[0].id;
+    var articleID = insertArticle.data.data.insert_articles.returning[0].id;
 
     // store slug + article ID in slug versions table
     var result = await storeArticleIdAndSlug(articleID, slug);
@@ -1119,7 +1171,7 @@ async function hasuraHandlePreview(formObject) {
     
     var getOrgLocalesResult = await hasuraGetOrganizationLocales();
     // Logger.log("Get Org Locales:" + JSON.stringify(getOrgLocalesResult));
-    data.organization_locales = getOrgLocalesResult.data.organization_locales;
+    insertArticle.organization_locales = getOrgLocalesResult.data.organization_locales;
 
     if (articleID && formObject['article-tags']) {
       var tags;
@@ -1156,6 +1208,8 @@ async function hasuraHandlePreview(formObject) {
         var result = await hasuraCreateAuthorArticle(author, articleID);
       }
     }
+
+    data = insertArticle;
   }
 
   //construct preview url

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -338,6 +338,21 @@ const insertPageGoogleDocsMutationWithoutId = `mutation AddonInsertPageGoogleDoc
     returning {
       id
       slug
+      page_translations {
+        content
+        facebook_description
+        facebook_title
+        first_published_at
+        headline
+        id
+        last_published_at
+        locale_code
+        published
+        search_description
+        search_title
+        twitter_description
+        twitter_title
+      }
       page_google_documents {
         id
         google_document {
@@ -358,6 +373,21 @@ const insertPageGoogleDocsMutation = `mutation AddonInsertPageGoogleDocWithID($i
     returning {
       id
       slug
+      page_translations {
+        content
+        facebook_description
+        facebook_title
+        first_published_at
+        headline
+        id
+        last_published_at
+        locale_code
+        published
+        search_description
+        search_title
+        twitter_description
+        twitter_title
+      }
       page_google_documents {
         id
         google_document {

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -457,8 +457,21 @@ const unpublishArticleMutation = `mutation AddonUnpublishArticle($article_id: In
 
 /* Queries */
 
-const findArticleByCategoryAndSlugQuery = `query AddonFindArticleByCategorySlug($category_id: Int!, $slug: String!) {
-  articles(where: {category_id: {_eq: $category_id}, slug: {_eq: $slug}}) {
+const findPageBySlugQuery = `query AddonFindPageBySlug($slug: String!, $document_id: String!) {
+  pages(where: {slug: {_eq: $slug}, page_google_documents: {google_document: {document_id: {_neq: $document_id}}}}) {
+    id
+    created_at
+    slug
+    page_google_documents {
+      google_document {
+        document_id
+      }
+    }
+  }
+}`;
+
+const findArticleByCategoryAndSlugQuery = `query AddonFindArticleByCategorySlug($category_id: Int!, $slug: String!, $document_id: String!) {
+  articles(where: {category_id: {_eq: $category_id}, slug: {_eq: $slug}, article_google_documents: {google_document: {document_id: {_neq: $document_id}}}}) {
     id
     slug
     category_id

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -427,6 +427,15 @@ const unpublishArticleMutation = `mutation AddonUnpublishArticle($article_id: In
 
 /* Queries */
 
+const findArticleByCategoryAndSlugQuery = `query AddonFindArticleByCategorySlug($category_id: Int!, $slug: String!) {
+  articles(where: {category_id: {_eq: $category_id}, slug: {_eq: $slug}}) {
+    id
+    slug
+    category_id
+    created_at
+  }
+}`;
+
 const getArticleByGoogleDocQuery = `query AddonGetArticleByGoogleDoc($doc_id: String!) {
   articles(where: {article_google_documents: {google_document: {document_id: {_eq: $doc_id}}}}) {
     id

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -29,6 +29,8 @@
         
         if (data && data.data && data.data.articles && data.data.articles[0]) {
           articleId = data.data.articles[0].id;
+          document.getElementById("current-data-id").innerHTML = articleId;
+
           if (
             data.data.articles[0] && 
             data.data.articles[0].article_google_documents && 
@@ -493,6 +495,7 @@
         <div id="republish-info"></div>
         <hr/>
         <button onclick="deleteArticle()">Delete Article</button>
+        <div id="current-data-id"></div>
       </div>
     </div>
 

--- a/Page.html
+++ b/Page.html
@@ -966,8 +966,15 @@
         var div = document.getElementById('loading');
         div.style.display = 'block';
 
-        if (response.data.errors) {
-          div.innerHTML = "<p class='error'>An error occurred: " + JSON.stringify(response.data.errors) + '</p>';
+        if (response.status === "error" || response.data.errors) {
+          let errorMessage;
+          if (response.status === "error") {
+            errorMessage = response.message;
+          } else {
+            errorMessage = JSON.stringify(response.data.errors);
+          }
+          div.innerHTML = "<p class='error'>An error occurred: " + errorMessage + '</p>';
+          
         } else {
           div.innerHTML = '<p style="color: #48C774;">' + response.message + "</p>";
           if (response.data && response.data.data && response.data.data.insert_articles) {

--- a/Page.html
+++ b/Page.html
@@ -377,8 +377,6 @@
           setValueOrDefault('article-facebook-description', translationData.facebook_description, translationData.facebook_description);
           setValueOrDefault('article-twitter-title', translationData.twitter_title, translationData.twitter_title);
           setValueOrDefault('article-twitter-description', translationData.twitter_description, translationData.twitter_description);
-        } else {
-          // selectedLocale.innerHTML = localeCode;
         }
 
         $('#article-authors').select2({
@@ -403,23 +401,24 @@
           }
         });
 
-        console.log("publishedInfo:", publishedInfo);
-        if (publishedInfo) {
-          var firstPubDate = new Date(publishedInfo.first_published_at);
-          console.log("setting published date to ", firstPubDate, publishedInfo.first_published_at);
+        if (documentType === "article") {
+          if (publishedInfo) {
+            var firstPubDate = new Date(publishedInfo.first_published_at);
+            console.log("setting published date to ", firstPubDate, publishedInfo.first_published_at);
 
-          flatpickr('input[name="article-first-published-date"]', {
-            enableTime: true,
-            dateFormat: "Y-m-d h:i K",
-            defaultDate: firstPubDate
-          });
-        } else {
-          var today = new Date();
-          flatpickr('input[name="article-first-published-date"]', {
-            enableTime: true,
-            dateFormat: "Y-m-d h:i K",
-            defaultDate: today
-          });
+            flatpickr('input[name="article-first-published-date"]', {
+              enableTime: true,
+              dateFormat: "Y-m-d h:i K",
+              defaultDate: firstPubDate
+            });
+          } else {
+            var today = new Date();
+            flatpickr('input[name="article-first-published-date"]', {
+              enableTime: true,
+              dateFormat: "Y-m-d h:i K",
+              defaultDate: today
+            });
+          }
         }
 
         if (data && documentType === "article") {
@@ -974,7 +973,7 @@
             errorMessage = JSON.stringify(response.data.errors);
           }
           div.innerHTML = "<p class='error'>An error occurred: " + errorMessage + '</p>';
-          
+
         } else {
           div.innerHTML = '<p style="color: #48C774;">' + response.message + "</p>";
           if (response.data && response.data.data && response.data.data.insert_articles) {
@@ -1027,16 +1026,23 @@
             displayTranslationTools(articleID, documentID, "article", translations[0].headline, googleDocs, organizationLocales);
 
           } else if (response.data && response.data.data && response.data.data.insert_pages) {
-            var pageID = response.data.data.insert_pages.returning[0].id;
+            var pageData = response.data.data.insert_pages.returning[0];
+            console.log("pageData:", pageData);
+
+            var pageID = pageData.id;
             // console.log("page ID:", pageID)
             var idHiddenField = document.getElementById('article-id');
             idHiddenField.value = pageID;
 
-            var googleDocs = response.data.data.insert_pages.returning[0].page_google_documents;
+            var googleDocs = pageData.page_google_documents;
             var organizationLocales = response.data.organization_locales;
             var documentID = response.documentID;
 
-            displayTranslationTools(pageID, documentID, "page", translations[0].headline, googleDocs, organizationLocales);
+            var translations = pageData.page_translations;
+            console.log("page translations:", translations);
+            if (translations[0]) {
+              displayTranslationTools(pageID, documentID, "page", translations[0].headline, googleDocs, organizationLocales);
+            }
 
           } else if (response.data && response.data.data && response.data.data.update_article_translations) {
             // console.log("unpublished article:", response.data);
@@ -1070,18 +1076,11 @@
         var headline = document.getElementById('article-headline');
         var searchTitle = document.getElementById('article-search-title');
         var searchDescription = document.getElementById('article-search-description');
-       
-        const calendar = flatpickr('input[name="article-first-published-date"]', {enableTime: true,
-            dateFormat: "Y-m-d h:i K"});
-        
-        var publishedDate = calendar.selectedDates[0];
-        // 2018-08-28T12:30:00+05:30
-        // var formattedPubDate = calendar.formatDate(publishedDate, "y-m-dT")
-        console.log("storing pub date as:", publishedDate);
 
         var sources = {};
 
         if (documentType !== "page")  {
+
           var elements = formObject.elements;
 
           // build up an object with source data
@@ -1173,6 +1172,15 @@
           for (var i = 0, tag; tag = selectedTags[i++];) {
             submitData["article-tags"].push(tag.text);
           }
+
+          const calendar = flatpickr('input[name="article-first-published-date"]', {enableTime: true,
+            dateFormat: "Y-m-d h:i K"});
+        
+          var publishedDate = calendar.selectedDates[0];
+          // 2018-08-28T12:30:00+05:30
+          // var formattedPubDate = calendar.formatDate(publishedDate, "y-m-dT")
+          console.log("storing pub date as:", publishedDate);
+
           var formattedPubDate = toIsoString(publishedDate);
           submitData["first-published-at"] = formattedPubDate;
           console.log('formattedPubDate:', formattedPubDate);
@@ -1380,7 +1388,7 @@
             <textarea id="article-twitter-description" name="article-twitter-description"></textarea>
           </div>
 
-          <div class="block form-group">
+          <div class="block form-group articles-only">
             <label for="article-first-published-date">
               <b>Published Date</b>
             </label>


### PR DESCRIPTION
Closes #338 
Closes #341 

_NOTE: this is version 98 of the google docs add-on. The latest code includes handling of blockquotes and hrs._

Adds dupe detection on preview & publish of articles scoped to the category & slug and pages scoped to slug in a given organization.

To test, try creating an article in same category with an existing article's slug - but note you'll have to create the google doc first, then add as a test case using latest code. Similarly, you can try creating a page with an existing slug.

<img width="313" alt="Screen Shot 2021-10-04 at 7 47 35 am" src="https://user-images.githubusercontent.com/3397/135771101-7bd9d0f1-8d0a-488c-b874-a660054418f3.png">

This PR also includes a bugfix that removes the custom published date handling from the sidebar for static pages (#341).