### PR TITLE
Retry of duplicate slug detection

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -426,7 +426,7 @@ async function findPageBySlug(slug) {
   );
 }
 
-async function findArticleByCategoryAndSlug(category_id, slug) {
+async function findArticleByCategoryAndSlug(category_id, slug, localeCode) {
   var documentID = DocumentApp.getActiveDocument().getId();
 
   return fetchGraphQL(
@@ -436,6 +436,7 @@ async function findArticleByCategoryAndSlug(category_id, slug) {
       category_id: category_id,
       document_id: documentID,
       slug: slug,
+      locale_code: localeCode,
     }
   );
 }
@@ -529,7 +530,7 @@ async function insertArticleGoogleDocs(data) {
   }
 
   // Check if article already exists with the given category_id and slug for this organization
-  var existingArticles = await findArticleByCategoryAndSlug(articleData["category_id"], articleData["slug"]);
+  var existingArticles = await findArticleByCategoryAndSlug(articleData["category_id"], articleData["slug"], articleData["locale_code"]);
   if (existingArticles && existingArticles.data && existingArticles.data.articles && existingArticles.data.articles.length > 0) {
     returnValue.status = "error";
     returnValue.message = "Article already exists in that category with the same slug, please pick a unique slug value."
@@ -1413,7 +1414,9 @@ async function hasuraGetTranslations(pageOrArticleId, localeCode) {
     data: {}
   };
 
-  var documentID = DocumentApp.getActiveDocument().getId();
+  var document = DocumentApp.getActiveDocument();
+  var documentID = document.getId();
+  var documentTitle = document.getName();
 
   var isStaticPage = isPage(documentID);
 
@@ -1430,6 +1433,7 @@ async function hasuraGetTranslations(pageOrArticleId, localeCode) {
         returnValue.status = "notFound";
         returnValue.message = "Page not found";
       }
+      returnValue.documentTitle = documentTitle;
       returnValue.documentId = documentID;
       returnValue.data = data;
 
@@ -1441,10 +1445,10 @@ async function hasuraGetTranslations(pageOrArticleId, localeCode) {
         returnValue.status = "success";
         returnValue.message = "Retrieved article translation with ID: " + data.article_translations[0].id;
       } else {
-        Logger.log("failed finding a translation: " + JSON.stringify(data));
         returnValue.status = "notFound";
         returnValue.message = "Article translation not found";
       }
+      returnValue.documentTitle = documentTitle;
       returnValue.documentId = documentID;
       returnValue.data = data;
     }

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -470,8 +470,8 @@ const findPageBySlugQuery = `query AddonFindPageBySlug($slug: String!, $document
   }
 }`;
 
-const findArticleByCategoryAndSlugQuery = `query AddonFindArticleByCategorySlug($category_id: Int!, $slug: String!, $document_id: String!) {
-  articles(where: {category_id: {_eq: $category_id}, slug: {_eq: $slug}, article_google_documents: {google_document: {document_id: {_neq: $document_id}}}}) {
+const findArticleByCategoryAndSlugQuery = `query AddonFindArticleByCategorySlug($category_id: Int!, $slug: String!, $document_id: String!, $locale_code: String) {
+  articles(where: {category_id: {_eq: $category_id}, slug: {_eq: $slug}, article_google_documents: {google_document: {document_id: {_neq: $document_id}, locale_code: {_eq: $locale_code}}}}) {
     id
     slug
     category_id

--- a/Page.html
+++ b/Page.html
@@ -305,6 +305,7 @@
         var googleDocs;
         var translationData;
         var publishedInfo;
+        var headline;
         var localeCode = contents.localeCode;
         if (contents.data.articles) {
           if (contents.data.articles[0]) {
@@ -335,8 +336,14 @@
           }
         }
 
-        // displayTranslationTools(id, headline, googleDocs, organization_locales)
-        displayTranslationTools(data.id, contents.documentId, documentType, translationData.headline, googleDocs, contents.data.organization_locales);
+        if (translationData) {
+          headline = translationData.headline;
+        } else if (contents.data.documentTitle) {
+          headline = contents.data.documentTitle;
+        } else {
+          headline = "tk";
+        }
+        displayTranslationTools(data.id, contents.documentId, documentType, headline, googleDocs, contents.data.organization_locales);
         
         if (publishedInfo) {
           displayPublishedInfo(publishedInfo, translationData);


### PR DESCRIPTION
This PR is an updated version of the duplicate slug detection code, testable using "latest code" in the script editor.

**Articles:**

- [x] preview an existing article, succeed
- [x] publish an existing article, succeed
- [x] create new doc, create new test case, set slug & category & locale to existing article values, try to preview, should get error
- [x] create new doc, create new test case, set slug & category & locale to existing article values, try to publish, should get error
- [x] click to create a new translation on existing article (franny lou -> spanish)
- [x] create new test case for new translated doc, open, open sidebar, set title & description values, try to preview & publish, succeed

**Pages:**

- [ ] preview an existing page, succeed
- [ ] publish an existing page, succeed
- [ ] create new doc, create new test case, set slug & locale to existing page values, try to preview, should get error
- [ ] create new doc, create new test case, set slug & locale to existing page values, try to publish, should get error
- [ ] click to create a new translation on existing page
- [ ] create new test case for new translated doc, open, open sidebar, try to preview & publish, succeed