### PR TITLE
Preview pages form re-render bugfix

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -111,7 +111,7 @@ function uploadImageToS3(imageID, contentUri, slug) {
     articleSlug = getArticleSlug();
   }
 
-  Logger.log("uploading image for org " + orgNameSlug + "and article " + articleSlug);
+  // Logger.log("uploading image for org " + orgNameSlug + "and article " + articleSlug);
 
   var objectName = "image" + imageID + ".png";
 

--- a/Code.js
+++ b/Code.js
@@ -1568,7 +1568,7 @@ async function processDocumentContents(activeDoc, document, slug) {
   elements.forEach(element => {
     
     if (element.paragraph && element.paragraph.elements) {
-      Logger.log("element: " + JSON.stringify(element))
+      // Logger.log("element: " + JSON.stringify(element))
 
       var eleData = {
         children: [],
@@ -1689,12 +1689,12 @@ async function processDocumentContents(activeDoc, document, slug) {
             // FORMAT END turns it off
             // all lines in between are given a style of FORMATTED_TEXT without any whitespace stripped
             if (subElement.textRun.content.trim() === "FORMAT START") {
-              Logger.log("START format block")
+              // Logger.log("START format block")
               inSpecialFormatBlock = true;
               storeElement = false;
               
             } else if (subElement.textRun.content.trim() === "FORMAT END") {
-              Logger.log("END format block")
+              // Logger.log("END format block")
               inSpecialFormatBlock = false;
               storeElement = false;
               
@@ -1704,14 +1704,14 @@ async function processDocumentContents(activeDoc, document, slug) {
             eleData.type = "text";
 
             if (inSpecialFormatBlock) {
-              Logger.log("IN SPECIAL BLOCK")
+              // Logger.log("IN SPECIAL BLOCK")
               namedStyle = "FORMATTED_TEXT";
             } else if (element.paragraph.paragraphStyle.namedStyleType) {
               namedStyle = element.paragraph.paragraphStyle.namedStyleType;
             }
 
             eleData.style = namedStyle;
-            Logger.log("eleData.style: " + eleData.style);
+            // Logger.log("eleData.style: " + eleData.style);
 
             // treat any indented text as a blockquote
             if (element.paragraph.paragraphStyle.indentStart || element.paragraph.paragraphStyle.indentFirstLine) {
@@ -1768,11 +1768,11 @@ async function processDocumentContents(activeDoc, document, slug) {
               }
 
               if (s3Url === null || s3Url === undefined || !articleSlugMatches || !assetDomainMatches) {
-                Logger.log(imageID + " " + slug + " has not been uploaded yet, uploading now...")
+                // Logger.log(imageID + " " + slug + " has not been uploaded yet, uploading now...")
                 s3Url = uploadImageToS3(imageID, fullImageData.inlineObjectProperties.embeddedObject.imageProperties.contentUri, slug);
                 imageList[imageID] = s3Url;
               } else {
-                Logger.log(slug + " " + imageID + " has already been uploaded: " + articleSlugMatches + " " + s3Url);
+                // Logger.log(slug + " " + imageID + " has already been uploaded: " + articleSlugMatches + " " + s3Url);
                 imageList[imageID] = s3Url;
               }
 
@@ -1791,7 +1791,7 @@ async function processDocumentContents(activeDoc, document, slug) {
       })
       // skip any blank elements, embeds and lists because they've already been handled above
       if (storeElement && eleData.type !== null && eleData.type !== "list" && eleData.type !== "embed") {
-        Logger.log("Element Data: " + JSON.stringify(eleData));
+        // Logger.log("Element Data: " + JSON.stringify(eleData));
         orderedElements.push(eleData);
       } else if (!storeElement) {
         Logger.log("NOT storing element " + JSON.stringify(eleData));
@@ -1841,7 +1841,7 @@ function formatElements(elements) {
       return -1;
     }
   }).forEach(element => {
-    Logger.log("element.type: " + element.type + " - " + JSON.stringify(element))
+    // Logger.log("element.type: " + element.type + " - " + JSON.stringify(element))
     var formattedElement = {
       type: element.type,
       style: element.style,

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -350,6 +350,15 @@ const insertPageGoogleDocsMutationWithoutId = `mutation AddonInsertPageGoogleDoc
           url
         }
       }
+      page_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+        id
+        page_id
+        headline
+        first_published_at
+        last_published_at
+        locale_code
+        published
+      }
     }
   }
 }`;
@@ -369,6 +378,15 @@ const insertPageGoogleDocsMutation = `mutation AddonInsertPageGoogleDocWithID($i
           }
           url
         }
+      }
+      page_translations(where: {locale_code: {_eq: $locale_code}}, order_by: {id: desc}, limit: 1) {
+        id
+        page_id
+        headline
+        first_published_at
+        last_published_at
+        locale_code
+        published
       }
     }
   }

--- a/Page.html
+++ b/Page.html
@@ -1031,7 +1031,10 @@
             var idHiddenField = document.getElementById('article-id');
             idHiddenField.value = pageID;
 
-            var googleDocs = response.data.data.insert_pages.returning[0].page_google_documents;
+            var pageData = response.data.data.insert_pages.returning[0];
+            
+            var googleDocs = pageData.page_google_documents;
+            var translations = pageData.page_translations;
             var organizationLocales = response.data.organization_locales;
             var documentID = response.documentID;
 

--- a/Page.html
+++ b/Page.html
@@ -1132,7 +1132,7 @@
             }
           })
 
-          var selectedAuthors = $('#article-authors').select2('data')
+          var selectedAuthors = $('#article-authors').select2('data');
           var customByline = document.getElementById("article-custom-byline").value;
           if ( (selectedAuthors === undefined || selectedAuthors.length <= 0) && ( customByline === null || customByline === undefined || customByline === "") ) {
             // console.log("selectedAuthors:", selectedAuthors, "customByline:", customByline)
@@ -1176,6 +1176,10 @@
           submitData["first-published-at"] = formattedPubDate;
           // console.log('formattedPubDate:', formattedPubDate);
           submitData["sources"] = sources;
+          submitData['article-authors'] = [];
+          for (var i = 0, author; author = selectedAuthors[i++];) {
+            submitData["article-authors"].push(author.id);
+          }
         }
         
         if (formIsValid && formObject.submitted === "Preview") {


### PR DESCRIPTION
Closed #352 

The return data was missing page_translations, which caused the error in the sidebar after saving a static page. This PR adds it to the query.

This PR is branched off of #351 so the latest code in the script editor includes both the authors and the save static page fixes.