### PR TITLE
Stores the category slug along with article slug after preview or publish

### DIFF
--- a/GraphQL.js
+++ b/GraphQL.js
@@ -1,7 +1,7 @@
 /* Mutations */
 
-const insertArticleSlugVersion = `mutation AddonInsertArticleSlugVersion($article_id: Int!, $slug: String!) {
-  insert_article_slug_versions(objects: {article_id: $article_id, slug: $slug}, on_conflict: {constraint: slug_versions_pkey, update_columns: article_id}) {
+const insertArticleSlugVersion = `mutation AddonInsertArticleSlugVersion($article_id: Int!, $slug: String!, $category_slug: String!) {
+  insert_article_slug_versions(on_conflict: {constraint: slug_versions_pkey, update_columns: article_id}, objects: {article_id: $article_id, slug: $slug, category_slug: $category_slug}) {
     affected_rows
   }
 }`;


### PR DESCRIPTION
#357 

Satisfies the update required in the publishing tools sidebar to store the slug of the category AND the article for retrieval by the front-end.

Saving this document:
<img width="344" alt="Screen Shot 2021-10-21 at 2 08 02 pm" src="https://user-images.githubusercontent.com/3397/138204706-aed318fa-9446-4031-8f3b-83116365200c.png">

Results in this record in `article_slug_versions`:
<img width="951" alt="Screen Shot 2021-10-21 at 2 05 38 pm" src="https://user-images.githubusercontent.com/3397/138204734-06778dbc-3696-46ff-96da-295e99194556.png">

Meaning if the category slug is changed in the future, like in this example 'business' is changed to 'industry', and an existing link of `/articles/business/simple-article-body` is clicked, there will be a record of the cat slug `business` with the article slug `simple-article-body` that points to the right article ID in the database.