### PR TITLE
Added missing feature to unpublish a page

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -756,12 +756,45 @@ async function hasuraUnpublishArticle(articleId, localeCode) {
   );
 }
 
+async function hasuraUnpublishPage(pageId, localeCode) {
+
+  return fetchGraphQL(
+    unpublishPageMutation,
+    "AddonUnpublishPage",
+    {
+      page_id: pageId,
+      locale_code: localeCode
+    }
+  );
+}
+
 async function hasuraCreateTag(tagData) {
   return fetchGraphQL(
     insertTagMutation,
     "AddonInsertTag",
     tagData
   );
+}
+
+async function hasuraHandleUnpublishPage(formObject) {
+  var pageID = formObject['article-id'];
+  var localeCode = formObject['article-locale'];
+  var response = await hasuraUnpublishPage(pageID, localeCode);
+  
+  var returnValue = {
+    status: "success",
+    message: "Unpublished the page with id " + pageID + " in locale " + localeCode,
+    data: response
+  };
+  if (response.errors) {
+    returnValue.status = "error";
+    returnValue.message = "An unexpected error occurred trying to unpublish the page";
+    returnValue.data = response.errors;
+  } else {
+    // trigger republish of the site to reflect this page no longer being live
+    rebuildSite();
+  }
+  return returnValue;
 }
 
 async function hasuraHandleUnpublish(formObject) {

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -443,6 +443,12 @@ const unpublishArticleMutation = `mutation AddonUnpublishArticle($article_id: In
   }
 }`;
 
+const unpublishPageMutation = `mutation AddonUnpublishPage($page_id: Int!, $locale_code: String!) {
+  update_page_translations(where: {page_id: {_eq: $page_id}, locale_code: {_eq: $locale_code}}, _set: {published: false}) {
+    affected_rows
+  }
+}`;
+
 /* Queries */
 
 const findPageBySlugQuery = `query AddonFindPageBySlug($slug: String!, $document_id: String!, $locale_code: String) {

--- a/Page.html
+++ b/Page.html
@@ -1258,14 +1258,21 @@
             loadingDiv.innerHTML = "<p class='gray'>Publishing... </p>"
             google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
           }
-        } else if ( documentType === "article" && formIsValid && formObject.submitted === "Unpublish") {
+        } else if (formIsValid && formObject.submitted === "Unpublish") {
           // console.log("valid form + unpublish")
-          loadingDiv.innerHTML = "<p class='gray'>Unpublishing article... </p>"
+          loadingDiv.innerHTML = "<p class='gray'>Unpublishing " + documentType + " ...</p>"
           var articleId = document.getElementById('article-id').value;
           var selectedLocale = document.getElementById('article-locale').value;
 
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublish(formObject);
+          console.log("Unpublish", documentType, formIsValid, articleId, selectedLocale);
+          if (documentType === "page") {
+            google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublishPage(formObject);
+
+          } else {
+            google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublish(formObject);
+          }
         } else {
+            
           // console.log("invalid form")
           if (errorMessage !== "") {
             loadingDiv.innerHTML = "<p class='error'>" + errorMessage + "</p>"


### PR DESCRIPTION
Closes #367 

_Test using **version 106** in the script editor._

The problem was that I never 🤦‍♀️ coded the unpublish-page feature - it just worked for articles. So if the doc wasn't for an article, the code for "unpublish" was falling through to the "else" scenario, and showing a generic error.

This PR adds an unpublish page mutation + function and the extra use case to the html for the sidebar.

I tested by opening Oaklyn's "Donate" page, unpublishing it, trying to load it on the site, getting a 404, re-publishing it, and reloading the page successfully.