### PR TITLE
Fixes for Word formatting problems on headings and main images

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -756,12 +756,45 @@ async function hasuraUnpublishArticle(articleId, localeCode) {
   );
 }
 
+async function hasuraUnpublishPage(pageId, localeCode) {
+
+  return fetchGraphQL(
+    unpublishPageMutation,
+    "AddonUnpublishPage",
+    {
+      page_id: pageId,
+      locale_code: localeCode
+    }
+  );
+}
+
 async function hasuraCreateTag(tagData) {
   return fetchGraphQL(
     insertTagMutation,
     "AddonInsertTag",
     tagData
   );
+}
+
+async function hasuraHandleUnpublishPage(formObject) {
+  var pageID = formObject['article-id'];
+  var localeCode = formObject['article-locale'];
+  var response = await hasuraUnpublishPage(pageID, localeCode);
+  
+  var returnValue = {
+    status: "success",
+    message: "Unpublished the page with id " + pageID + " in locale " + localeCode,
+    data: response
+  };
+  if (response.errors) {
+    returnValue.status = "error";
+    returnValue.message = "An unexpected error occurred trying to unpublish the page";
+    returnValue.data = response.errors;
+  } else {
+    // trigger republish of the site to reflect this page no longer being live
+    rebuildSite();
+  }
+  return returnValue;
 }
 
 async function hasuraHandleUnpublish(formObject) {

--- a/GraphQL.js
+++ b/GraphQL.js
@@ -443,6 +443,12 @@ const unpublishArticleMutation = `mutation AddonUnpublishArticle($article_id: In
   }
 }`;
 
+const unpublishPageMutation = `mutation AddonUnpublishPage($page_id: Int!, $locale_code: String!) {
+  update_page_translations(where: {page_id: {_eq: $page_id}, locale_code: {_eq: $locale_code}}, _set: {published: false}) {
+    affected_rows
+  }
+}`;
+
 /* Queries */
 
 const findPageBySlugQuery = `query AddonFindPageBySlug($slug: String!, $document_id: String!, $locale_code: String) {

--- a/Page.html
+++ b/Page.html
@@ -1258,14 +1258,21 @@
             loadingDiv.innerHTML = "<p class='gray'>Publishing... </p>"
             google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
           }
-        } else if ( documentType === "article" && formIsValid && formObject.submitted === "Unpublish") {
+        } else if (formIsValid && formObject.submitted === "Unpublish") {
           // console.log("valid form + unpublish")
-          loadingDiv.innerHTML = "<p class='gray'>Unpublishing article... </p>"
+          loadingDiv.innerHTML = "<p class='gray'>Unpublishing " + documentType + " ...</p>"
           var articleId = document.getElementById('article-id').value;
           var selectedLocale = document.getElementById('article-locale').value;
 
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublish(formObject);
+          console.log("Unpublish", documentType, formIsValid, articleId, selectedLocale);
+          if (documentType === "page") {
+            google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublishPage(formObject);
+
+          } else {
+            google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublish(formObject);
+          }
         } else {
+            
           // console.log("invalid form")
           if (errorMessage !== "") {
             loadingDiv.innerHTML = "<p class='error'>" + errorMessage + "</p>"


### PR DESCRIPTION
_Test in the script editor with version 106 - there's a test case for the example doc at this version already._

Using [this example BBG article](https://docs.google.com/document/d/1g4HDw_Ci36MswvW5rRgVxXzXHsctfbAWPwhSv6EkyF8/edit?addon_dry_run=AAnXSK-Fa6zMk1-qXXlNRHhkfQVF0VrFwY_FBRVarXRpyic3f71-eGYsGFInWJoBZKrm7VEEo9AOnNPXpY2vRZtP2Cr1K58Zc4PYr0jryFYkrA_WEKV45T7CdJfHaYvk0PHsJYvKzWm7#heading=h.d8lba76nu1va) I was able to fix two problems related to microsoft word formatting in the doc:

1. the main image now comes through [in the published article](https://next-tinynewsdemo.vercel.app/en-US/articles/community/bbg-community-events)
2. the strange 2 line "HEADING_2" is now parsed as two separate `<h2>` tags

I'm sure there are going to be more Word-related formatting issues, so what I'd like to do is create some content in my own copy of Word and import it to Google docs, then run through each article and fix whatever comes up. It would also be helpful if there are more example Word docs I could use - having them already imported into Google Docs would be fine.

I've added parsing additional images (any images in the doc) with strange word formatting to my list already.