### PR TITLE
Don't set headline to document title if it's the default untitled value

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -120,7 +120,7 @@
           var selectorString = "#article-tags option[value='" + tag.slug + "']";
           if ( $(selectorString).length <= 0 ) {
             var option = document.createElement("option");
-            console.log(localeCode, "tag.tag_translations:", tag.tag_translations.length, tag.tag_translations);
+            // console.log(localeCode, "tag.tag_translations:", tag.tag_translations.length, tag.tag_translations);
             let translatedTag = tag.tag_translations.find( ({locale_code}) => locale_code === localeCode);
             if (translatedTag) {
               // console.log(localeCode, "found translatedTag:", translatedTag);
@@ -375,7 +375,7 @@
 
         if (translationData) {
           headline = translationData.headline;
-        } else if (contents.documentTitle) {
+        } else if (contents.documentTitle && contents.documentTitle !== "Untitled document") {
           headline = contents.documentTitle;
         } else {
           headline = "tk";
@@ -859,7 +859,7 @@
             localeCode = "en-US";
           }
 
-          if (data && data.data && data.data.headline) {
+          if (data && data.data && data.data.headline && data.data.headline !== "Untitled document") {
             // console.log("setting default article headline to:", data.data.headline)
             var headline = document.getElementById('article-headline');
             headline.value = data.data.headline;
@@ -1277,7 +1277,7 @@
           var articleId = document.getElementById('article-id').value;
           var selectedLocale = document.getElementById('article-locale').value;
 
-          console.log("Unpublish", documentType, formIsValid, articleId, selectedLocale);
+          // console.log("Unpublish", documentType, formIsValid, articleId, selectedLocale);
           if (documentType === "page") {
             google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublishPage(formObject);
 


### PR DESCRIPTION
Closes #374 

Neither the headline nor the search title will be set to the document name if it's "Untitled document" - this is the latest code in the script editor, and there's a test case for an "Untitled document" already setup.