### PR TITLE
Bugfixes for more word doc formatting issues

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1755,7 +1755,9 @@ async function processDocumentContents(activeDoc, document, slug) {
             eleData.style = namedStyle;
 
             // treat any indented text as a blockquote
-            if (element.paragraph.paragraphStyle.indentStart || element.paragraph.paragraphStyle.indentFirstLine) {
+            if ((element.paragraph.paragraphStyle.indentStart && element.paragraph.paragraphStyle.indentStart.magnitude) || 
+                (element.paragraph.paragraphStyle.indentFirstLine && element.paragraph.paragraphStyle.indentFirstLine.magnitude)) {
+              Logger.log("indent para:" + JSON.stringify(element.paragraph));
               eleData.type = "blockquote";
             }
 

--- a/Code.js
+++ b/Code.js
@@ -1609,7 +1609,7 @@ async function processDocumentContents(activeDoc, document, slug) {
   var elementCount = elements.length;
 
   elements.forEach(element => {
-    
+    Logger.log("element: " + JSON.stringify(element));
     if (element.paragraph && element.paragraph.elements) {
       // Logger.log("paragraph element: " + JSON.stringify(element))  
 
@@ -1724,8 +1724,9 @@ async function processDocumentContents(activeDoc, document, slug) {
         if (eleData.type !== "list" && eleData.type !== "embed") {
           var namedStyle;
 
+
           // found a paragraph of text
-          if (subElement.textRun && subElement.textRun.content && subElement.textRun.content.trim().length > 0) {
+          if (subElement.textRun && subElement.textRun.content) {
             // handle specially formatted blocks of text
             // FORMAT START flips the "are we in a specially formatted block?" switch on
             // FORMAT END turns it off
@@ -1809,7 +1810,7 @@ async function processDocumentContents(activeDoc, document, slug) {
 
           // found an image
           if ( subElement.inlineObjectElement && subElement.inlineObjectElement.inlineObjectId) {
-            Logger.log("FOUND IMAGE: " + JSON.stringify(subElement.inlineObjectElement))
+            // Logger.log("FOUND IMAGE: " + JSON.stringify(subElement.inlineObjectElement))
             storeElement = true;
             var imageID = subElement.inlineObjectElement.inlineObjectId;
             eleData.type = "image";


### PR DESCRIPTION
Closes #379 

Test using version `#108` of the code and the "Copy of  BBG Top5Influential Hip Hop Artists" document. I just setup a test case setup for this combination in the script editor for ya.

Fixes include:

* finding all images, which are turned into top-level elements alongside other main element types (blockquote, embed, list, text)
* correct blockquote treatment
* fake "header" text (bold/underlined)
* trailing & leading whitespace in rendered articles (front-end change - https://github.com/news-catalyst/next-tinynewsdemo/pull/983)