### PR TITLE
Report errors to Airbrake with context

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -316,6 +316,8 @@ async function fetchGraphQL(operationsDoc, operationName, variables) {
   var responseText = result.getContentText();
   var responseData = JSON.parse(responseText);
 
+  responseData.orgSlug = ORG_SLUG;
+  Logger.log(Object.keys(responseData), responseData.orgSlug);
   return responseData;
 }
 
@@ -1380,7 +1382,10 @@ async function getTranslationDataForPage(docId, pageId, localeCode) {
 }
 
 async function getTranslationDataForArticle(docId, articleId, localeCode) {
-  const { errors, data } = await fetchTranslationDataForArticle(docId, articleId, localeCode);
+  const {errors, data, orgSlug } = await fetchTranslationDataForArticle(docId, articleId, localeCode);
+
+  data.orgSlug = orgSlug;
+  Logger.log("getTranslationDataForArticle orgSlug: " + orgSlug + " data keys: " + JSON.stringify(Object.keys(data)));
 
   if (errors) {
     console.error("errors:" + JSON.stringify(errors));
@@ -1537,7 +1542,7 @@ async function hasuraGetArticle() {
 
   } else {
     data = await getArticleForGoogleDoc(documentID);
-    Logger.log("hasuraGetArticle data: " + JSON.stringify(data));
+    // Logger.log("hasuraGetArticle data: " + JSON.stringify(data));
     if (data && data.articles && data.articles[0]) {
       storeArticleSlug(data.articles[0].slug);
       returnValue.status = "success";
@@ -1780,15 +1785,15 @@ async function processDocumentContents(activeDoc, document, slug) {
             //  * create a new top-level element
             //  * bump the total elements & elements processed by one
             if (headingRegEx.test(eleData.style) && element.paragraph.elements.length > 1 && eleData.children.length === 1) {
-              Logger.log("Heading element: " + JSON.stringify(eleData));
-              Logger.log("Heading subelement: " + JSON.stringify(subElement));
+              // Logger.log("Heading element: " + JSON.stringify(eleData));
+              // Logger.log("Heading subelement: " + JSON.stringify(subElement));
               var newEleData = {
                 type: "text",
                 style: namedStyle,
                 index: eleData.index,
                 children: [childElement]
               }
-              Logger.log("new eleData: " + JSON.stringify(newEleData));
+              // Logger.log("new eleData: " + JSON.stringify(newEleData));
               orderedElements.push(newEleData);
               elementCount++;
               elementsProcessed++;
@@ -1796,7 +1801,7 @@ async function processDocumentContents(activeDoc, document, slug) {
             } else {
               eleData.children.push(childElement);
               storeElement = true;
-              Logger.log("regular eleData:" + JSON.stringify(eleData));
+              // Logger.log("regular eleData:" + JSON.stringify(eleData));
             }
 
           // blank content but contains a "horizontalRule" element?

--- a/Page.html
+++ b/Page.html
@@ -16,8 +16,17 @@
 
       function alertAirbrake(error) {
         var err = new Error(error);
-        
-        airbrake.notify(err).then(function(notice) {
+        var orgSlugField = document.getElementById('org-slug');
+
+        let orgSlugValue = "";
+        if (orgSlugField) {
+          orgSlugValue = orgSlugField.value;
+        }
+
+        airbrake.notify({
+          context: { orgSlug: orgSlugValue},
+          error: err,
+        }).then(function(notice) {
           if (notice.id) {
             console.log('notice id:', notice.id);
           } else {
@@ -405,8 +414,14 @@
         }
 
         if (data) {
+          // console.log("contents:", contents, "data:", data);
           var slugField = document.getElementById('article-slug');
           slugField.value = data.slug;
+
+          if (contents && contents.data && contents.data.orgSlug) {
+            var orgSlugField = document.getElementById('org-slug');
+            orgSlugField.value = contents.data.orgSlug;
+          }
 
           var idHiddenField = document.getElementById('article-id');
           idHiddenField.value = data.id;
@@ -750,6 +765,7 @@
       }
 
       function handleGetTranslationsForArticle(data) {
+
         if (data && data.status === "error") {
           onFailure(data.message);
           return;
@@ -1423,6 +1439,7 @@
             <input type="hidden" id="article-id" name="article-id" />
             <input id="article-slug" name="article-slug" type="text" />
             <input type="hidden" id="document-type" name="document-type" />
+            <input type="hidden" id="org-slug" name="org-slug" />
             <span class="small">
               If blank, we will create a slug based on the headline.
             </span>


### PR DESCRIPTION
Closes #381 

Test using version `#109` in the script editor. This adds context to all airbrake errors reported, and if possible (should be in most cases) includes the slug for the organization this error occurred in.

_Note I tested this by deliberately triggering an error in airbrake using the `alertAirbrake('some message');` function call in the `Page.html` file. I removed the call from the file once I verified the error was being reported with context._

Context will vary but can include a lot of helpful details - see screenshots.

<img width="974" alt="Screen Shot 2021-12-07 at 11 08 56 am" src="https://user-images.githubusercontent.com/3397/145065714-2d2f7472-e5a8-4b87-a114-a57ec19b252d.png">
<img width="1416" alt="Screen Shot 2021-12-07 at 11 08 39 am" src="https://user-images.githubusercontent.com/3397/145065719-5af0bdf7-3961-4195-8dff-ed65a86bd7c7.png">


