### PR TITLE
Calculate image height & width by converting pt to px

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1887,9 +1887,9 @@ async function processDocumentContents(activeDoc, document, slug) {
               }
 
               let specifiedHeight = fullImageData.inlineObjectProperties.embeddedObject.size.height.magnitude;
-              let calculatedHeight = specifiedHeight * .75; // PT to PX conversion
+              let calculatedHeight = specifiedHeight * 4/3; // PT to PX conversion
               let specifiedWidth = fullImageData.inlineObjectProperties.embeddedObject.size.width.magnitude;
-              let calculatedWidth = specifiedWidth * .75; // PT to PX conversion
+              let calculatedWidth = specifiedWidth * 4/3; // PT to PX conversion
               var childImage = {
                 index: subElement.endIndex,
                 height: calculatedHeight,

--- a/Code.js
+++ b/Code.js
@@ -122,6 +122,7 @@ function uploadImageToS3(imageID, contentUri, slug) {
 
     Logger.log(res.getAllHeaders());
     imageData = res.getBlob(); //.setName("image1");
+
     // try to get content type
     var imageType = imageData.getContentType();
     Logger.log("IMAGE TYPE: " + imageType);
@@ -1759,7 +1760,6 @@ async function processDocumentContents(activeDoc, document, slug) {
         if (eleData.type !== "list" && eleData.type !== "embed") {
           var namedStyle;
 
-
           // found a paragraph of text
           if (subElement.textRun && subElement.textRun.content) {
             // handle specially formatted blocks of text
@@ -1845,7 +1845,6 @@ async function processDocumentContents(activeDoc, document, slug) {
 
           // found an image
           if ( subElement.inlineObjectElement && subElement.inlineObjectElement.inlineObjectId) {
-            
             Logger.log("FOUND IMAGE: " + JSON.stringify(subElement))
             storeElement = true;
             var imageID = subElement.inlineObjectElement.inlineObjectId;
@@ -1884,10 +1883,14 @@ async function processDocumentContents(activeDoc, document, slug) {
                 imageList[imageID] = s3Url;
               }
 
+              let specifiedHeight = fullImageData.inlineObjectProperties.embeddedObject.size.height.magnitude;
+              let calculatedHeight = specifiedHeight * .75; // PT to PX conversion
+              let specifiedWidth = fullImageData.inlineObjectProperties.embeddedObject.size.width.magnitude;
+              let calculatedWidth = specifiedWidth * .75; // PT to PX conversion
               var childImage = {
                 index: subElement.endIndex,
-                height: fullImageData.inlineObjectProperties.embeddedObject.size.height.magnitude,
-                width: fullImageData.inlineObjectProperties.embeddedObject.size.width.magnitude,
+                height: calculatedHeight,
+                width: calculatedWidth,
                 imageId: subElement.inlineObjectElement.inlineObjectId,
                 imageUrl: s3Url,
                 imageAlt: cleanContent(fullImageData.inlineObjectProperties.embeddedObject.title)

--- a/Code.js
+++ b/Code.js
@@ -1859,21 +1859,24 @@ async function processDocumentContents(activeDoc, document, slug) {
 
             var fullImageData = inlineObjects[imageID];
             if (fullImageData) {
-              Logger.log("Found full image data: " + JSON.stringify(fullImageData))
               var s3Url = imageList[imageID];
-
+              // Logger.log(imageID + " ==> " + JSON.stringify(imageList))
+              Logger.log("Found full image data: " + JSON.stringify(fullImageData))
+              // Logger.log(`s3Url: ${typeof(s3Url)} -> ${JSON.stringify(s3Url)} (${slug})`)
               var articleSlugMatches = false;
               var assetDomainMatches = false;
-              if (s3Url && s3Url.match(slug)) {
-                articleSlugMatches = true;
+              if (s3Url && typeof(s3Url) === 'string') {
+                if (s3Url.match(slug)) {
+                  articleSlugMatches = true;
+                } 
+                // image URL should be stored as assets.tinynewsco.org not the s3 bucket domain
+                if (s3Url.match(/assets\.tinynewsco\.org/)) {
+                  assetDomainMatches = true;
+                }
               }
 
-              // image URL should be stored as assets.tinynewsco.org not the s3 bucket domain
-              if (s3Url && s3Url.match(/assets\.tinynewsco\.org/)) {
-                assetDomainMatches = true;
-              }
-
-              if (s3Url === null || s3Url === undefined || !articleSlugMatches || !assetDomainMatches) {
+              
+              if (s3Url === null || s3Url === undefined || s3Url === {} || !articleSlugMatches || !assetDomainMatches) {
                 Logger.log(imageID + " " + slug + " has not been uploaded yet, uploading now...")
               
                 s3Url = uploadImageToS3(imageID, fullImageData.inlineObjectProperties.embeddedObject.imageProperties.contentUri, slug);


### PR DESCRIPTION
Closes #388 

Test using the case setup for the test document at version 112.

I tried to find a way to calculate the actual image dimensions, but shy of creating a standalone service to do this ([example](https://stackoverflow.com/questions/19257264/how-to-get-the-size-in-pixels-of-a-jpeg-image-i-get-with-urlfetchapp-fetchpho)), I couldn't find a way to derive the height and width. This PR converts the dimensions from `pt` to `px` using the calculation in the linked SO answer.