### PR TITLE
Integration with new API

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1020,15 +1020,9 @@ async function hasuraHandlePublish(formObject) {
 
     publishUrl = insertPage.publishUrl;
 
-    var pageID = data.id;
-
     var getOrgLocalesResult = await hasuraGetOrganizationLocales();
     // Logger.log("Get Org Locales:" + JSON.stringify(getOrgLocalesResult));
     data.organization_locales = getOrgLocalesResult.data.organization_locales;
-
-    // // store slug + page ID in slug versions table
-    var result = await storePageIdAndSlug(pageID, slug);
-    Logger.log("stored page id + slug: " + JSON.stringify(result));
 
   } else {
     documentType = "article";
@@ -1115,15 +1109,9 @@ async function hasuraHandlePreview(formObject) {
 
     previewUrl = insertPage.previewUrl;
 
-    var pageID = data.id;
-
     var getOrgLocalesResult = await hasuraGetOrganizationLocales();
     // Logger.log("Get Org Locales:" + JSON.stringify(getOrgLocalesResult));
     data.organization_locales = getOrgLocalesResult.data.organization_locales;
-
-    // store slug + page ID in slug versions table
-    var result = await storePageIdAndSlug(pageID, slug);
-    Logger.log("stored page id + slug: " + JSON.stringify(result));
 
   } else {
     documentType = "article";

--- a/Code.js
+++ b/Code.js
@@ -1110,7 +1110,7 @@ async function hasuraHandlePreview(formObject) {
       return insertPage;
     }
 
-    var data = insertPage.data[0];
+    var data = insertPage.data;
     Logger.log("pageResult: " + JSON.stringify(data))
 
     previewUrl = insertPage.previewUrl;
@@ -1137,14 +1137,8 @@ async function hasuraHandlePreview(formObject) {
 
     previewUrl = insertArticle.previewUrl;
 
-    var data = insertArticle.data[0];
-    var articleID = data.id;
-    var categorySlug = data.category.slug;
-
-    // store slug + article ID in slug versions table
-    var result = await storeArticleIdAndSlug(articleID, slug, categorySlug);
-    Logger.log("stored article id + slug + categorySlug: " + JSON.stringify(result));
-
+    var data = insertArticle.data;
+   
     var getOrgLocalesResult = await hasuraGetOrganizationLocales();
     // Logger.log("Get Org Locales:" + JSON.stringify(getOrgLocalesResult));
     data.organization_locales = getOrgLocalesResult.data.organization_locales;

--- a/Code.js
+++ b/Code.js
@@ -485,7 +485,8 @@ async function insertArticleGoogleDocs(data) {
   var returnValue = {
     status: "success",
     message: "",
-    data: {}
+    data: {},
+    documentType: "article"
   };
 
   var activeDoc = DocumentApp.getActiveDocument();
@@ -585,7 +586,7 @@ async function insertArticleGoogleDocs(data) {
   let response = await previewArticle(articleData, slug, elements, listInfo, imageList, inlineObjects);
   Logger.log("previewArticleResponse: " + Object.keys(response).sort());
   returnValue.data = response.data;
-
+  
   if (response.status && response.status === 'error') {
     returnValue.status = 'error';
     returnValue.message = "An error occurred saving the article"
@@ -1136,8 +1137,6 @@ async function hasuraHandlePublish(formObject) {
 }
 
 async function hasuraHandlePreview(formObject) {
-  var scriptConfig = getScriptConfig();
-
   // set the email for auditing changes
   var currentUserEmail = Session.getActiveUser().getEmail();
   formObject["created_by_email"] = currentUserEmail;
@@ -1243,6 +1242,7 @@ async function hasuraHandlePreview(formObject) {
   return {
     message: message,
     data: data,
+    documentType: documentType,
     documentID: documentID,
     status: "success"
   }
@@ -1574,7 +1574,7 @@ async function previewArticle(articleData, slug, contents, listInfo, imageList, 
   var activeDoc = DocumentApp.getActiveDocument();
   var documentID = activeDoc.getId();
 
-  const requestURL = `${API_URL}/api/sidebar/documents/${documentID}/preview?token=${API_TOKEN}`
+  const requestURL = `${API_URL}/api/sidebar/documents/${documentID}/preview?token=${API_TOKEN}&documentType=article`
   Logger.log("REQUEST URL: " + requestURL);
 
   var options = {

--- a/Code.js
+++ b/Code.js
@@ -1554,6 +1554,10 @@ async function hasuraGetArticle() {
   }
 
   let data = await lookupDataForDocument(documentID);
+  if (!data.documentType) {
+    data.documentType = "article";
+  }
+  
   if (data && data.documentType === 'page' && data.page && data.page.slug) {
     storeArticleSlug(data.page.slug);
     returnValue.data = data;

--- a/Code.js
+++ b/Code.js
@@ -701,32 +701,95 @@ async function linkDocToArticle(data) {
   );
 }
 
-async function hasuraInsertGoogleDoc(articleId, docId, localeCode, url) {
-  return fetchGraphQL(
-    insertGoogleDocMutation,
-    "AddonInsertGoogleDoc",
-    {
+async function hasuraInsertArticleGoogleDoc(articleId, documentID, localeCode, url) {
+  var scriptConfig = getScriptConfig();
+  var API_TOKEN = scriptConfig['DOCUMENT_API_TOKEN'];
+  var API_URL = scriptConfig['DOCUMENT_API_URL'];
+  var ORG_SLUG = scriptConfig['ACCESS_TOKEN'];
+
+  let apiAction = 'insert';
+  const requestURL = `${API_URL}/api/sidebar/documents/${documentID}/${apiAction}?token=${API_TOKEN}&documentType=article`
+  Logger.log("REQUEST URL: " + requestURL);
+
+  var options = {
+    method: 'POST',
+    muteHttpExceptions: true,
+    contentType: 'application/json',
+    headers: {
+      "TNC-Organization": ORG_SLUG
+    },
+    payload: JSON.stringify({
+      locale_code: localeCode,
       article_id: articleId,
-      document_id: docId,
-      locale_code: localeCode,
-      url: url
-    }
+      document_url: url,
+    }),
+  };
+
+  const result = await UrlFetchApp.fetch(
+    requestURL,
+    options
   );
+  
+  var responseText = result.getContentText();
+  var responseData;
+  try {
+    responseData = JSON.parse(responseText);
+  } catch(e) {
+    console.error(e)
+    responseData = {
+      status: 'error',
+      data: responseText
+    }
+  }
+
+  return responseData;
+
 }
 
-async function hasuraInsertPageGoogleDoc(pageId, docId, localeCode, url) {
-  return fetchGraphQL(
-    insertPageGoogleDocMutation,
-    "AddonInsertPageGoogleDoc",
-    {
+async function hasuraInsertPageGoogleDoc(pageId, documentID, localeCode, url) {
+  var scriptConfig = getScriptConfig();
+  var API_TOKEN = scriptConfig['DOCUMENT_API_TOKEN'];
+  var API_URL = scriptConfig['DOCUMENT_API_URL'];
+  var ORG_SLUG = scriptConfig['ACCESS_TOKEN'];
+
+  let apiAction = 'insert';
+  const requestURL = `${API_URL}/api/sidebar/documents/${documentID}/${apiAction}?token=${API_TOKEN}&documentType=article`
+  Logger.log("REQUEST URL: " + requestURL);
+
+  var options = {
+    method: 'POST',
+    muteHttpExceptions: true,
+    contentType: 'application/json',
+    headers: {
+      "TNC-Organization": ORG_SLUG
+    },
+    payload: JSON.stringify({
+      locale_code: localeCode,
       page_id: pageId,
-      document_id: docId,
-      locale_code: localeCode,
-      url: url
-    }
-  );
-}
+      document_url: url,
+    }),
+  };
 
+  const result = await UrlFetchApp.fetch(
+    requestURL,
+    options
+  );
+  
+  var responseText = result.getContentText();
+  var responseData;
+  try {
+    responseData = JSON.parse(responseText);
+  } catch(e) {
+    console.error(e)
+    responseData = {
+      status: 'error',
+      data: responseText
+    }
+  }
+
+  return responseData;
+
+}
 async function hasuraDeleteArticle(articleId) {
   Logger.log("deleting article ID#" + articleId);
   return fetchGraphQL(
@@ -756,8 +819,8 @@ async function hasuraCreateArticleDoc(articleId, newLocale, headline) {
   }
 
   // insert new document ID in google_documents table with newLocale & articleID
-  var response = await hasuraInsertGoogleDoc(articleId, newDocId, newLocale, newDocUrl);
-  Logger.log("hasura insert googleDoc response: " + JSON.stringify(response));
+  var response = await hasuraInsertArticleGoogleDoc(articleId, newDocId, newLocale, newDocUrl);
+  Logger.log("hasura insertArticleGoogleDoc response: " + JSON.stringify(response));
 
   // return new doc ID / url for link?
 
@@ -769,6 +832,7 @@ async function hasuraCreateArticleDoc(articleId, newLocale, headline) {
     data: response
   }
 }
+
 async function hasuraCreatePageDoc(pageId, newLocale, headline) {
   Logger.log("create new doc for page " + pageId + " and locale " + newLocale);
   // create new document in google docs

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -179,6 +179,12 @@
         var contentApi = document.getElementById('content-api');
         contentApi.value = data.contentApi ? data.contentApi : data['CONTENT_API'];
 
+        var apiToken = document.getElementById('document-api-token');
+        apiToken.value = data.apiToken ? data.apiToken : data['DOCUMENT_API_TOKEN'];
+
+        var documentApi = document.getElementById('document-api');
+        documentApi.value = data.documentApi ? data.contentApi : data['DOCUMENT_API_URL'];
+
         var editorUrl = document.getElementById('editor-url');
         editorUrl.value = data.editorUrl ? data.editorUrl : data['EDITOR_URL'];
 
@@ -392,7 +398,18 @@
           </label>
           <input id="content-api" name="CONTENT_API" type="text" />
         </div>
-
+        <div class="block form-group">
+          <label for="document-api-token">
+            <b>Document API Token</b>
+          </label>
+          <input id="document-api-token" name="DOCUMENT_API_TOKEN" type="text" />
+        </div>
+        <div class="block form-group">
+          <label for="document-api-url">
+            <b>Document API URL</b>
+          </label>
+          <input id="document-api-url" name="DOCUMENT_API_URL" type="text" />
+        </div>
         <div class="block form-group">
           <label for="editor-url">
             <b>Homepage Editor URL</b>

--- a/ManualPage.html
+++ b/ManualPage.html
@@ -182,8 +182,8 @@
         var apiToken = document.getElementById('document-api-token');
         apiToken.value = data.apiToken ? data.apiToken : data['DOCUMENT_API_TOKEN'];
 
-        var documentApi = document.getElementById('document-api');
-        documentApi.value = data.documentApi ? data.contentApi : data['DOCUMENT_API_URL'];
+        var documentApi = document.getElementById('document-api-url');
+        documentApi.value = data.documentApi ? data.documentApi : data['DOCUMENT_API_URL'];
 
         var editorUrl = document.getElementById('editor-url');
         editorUrl.value = data.editorUrl ? data.editorUrl : data['EDITOR_URL'];

--- a/Page.html
+++ b/Page.html
@@ -314,14 +314,14 @@
       }
 
       
-      function onSuccessFeatured(result) {
-        if (result && result.featured) {
+      function displayFeaturedMessage(featured, url) {
+        if (featured) {
           
           var div = document.getElementById('featured');
           div.style.display = "block";
           var message = "<b>This article is featured on the homepage</b>";
-          if (result.editorUrl) {
-            message += ": <a target='_new' href='" + result.editorUrl + "'>edit</a>"
+          if (url) {
+            message += ": <a target='_new' href='" + url + "'>edit</a>"
           }
           div.innerHTML = message;
 
@@ -757,7 +757,14 @@ function handleGetTranslationsForArticle(result) {
       var idHiddenField = document.getElementById('article-id');
       idHiddenField.value = id;
     
-      google.script.run.withFailureHandler(onFailureFeatured).withSuccessHandler(onSuccessFeatured).isArticleFeatured(data.id);
+      let articleIsFeatured = false;
+      data.homepage_layout_datas.forEach((homepageSpots) => {
+        articleIsFeatured = Object.values(homepageSpots).includes(id);
+      });
+
+      displayFeaturedMessage(articleIsFeatured, data.editorUrl);
+
+      // google.script.run.withFailureHandler(onFailureFeatured).withSuccessHandler(onSuccessFeatured).isArticleFeatured(data.id);
     
     } else if (data.page) {
       id = data.page.id;
@@ -922,10 +929,10 @@ function handleGetTranslationsForArticle(result) {
 }
 
 function handleGetArticle() {
-    google.script.run.withFailureHandler(onFailure).withSuccessHandler(handleGetTranslationsForArticle).hasuraGetArticle();
+  google.script.run.withFailureHandler(onFailure).withSuccessHandler(handleGetTranslationsForArticle).hasuraGetArticle();
 }
 
-      function displayTranslationTools(id, documentId, documentType, headline, googleDocs, organizationLocales) {
+function displayTranslationTools(id, documentId, documentType, headline, googleDocs, organizationLocales) {
         // console.log("displaying translation tools:", id, documentId, headline, googleDocs, organizationLocales);
 
         var existingDocsOtherLocales = [];

--- a/Page.html
+++ b/Page.html
@@ -313,186 +313,6 @@
         }
       }
 
-      function onSuccessGetArticle(contents) {
-
-        var configDiv = document.getElementById('config');
-        configDiv.style.display = 'none';
-        var div = document.getElementById('loading');
-        div.style.display = 'block';
-        var form = document.getElementById('article-form');
-        form.style.display = "block";
-
-        var buttonsDivBottom = document.getElementById('action-buttons-bottom')
-        buttonsDivBottom.style.display = "block";
-        var buttonsDivTop = document.getElementById('action-buttons-top')
-        buttonsDivTop.style.display = "block";
-
-        if (contents && contents.status && contents.status === "error") {
-          div.innerHTML = "<p class='error'>An error occurred: " + contents.message + '</p>';
-          
-          try {
-            alertAirbrake(JSON.stringify(contents));
-          } catch(e) {
-            console.error("Failed to log error with Airbrake:", e);
-          }
-        } else {
-          div.innerHTML = '<p style="color: #48C774;">' + contents.message + "</p>";
-        }
-
-        // console.log("contents onSuccessGetArticle:", contents);
-        var typeHiddenField = document.getElementById('document-type');
-        var documentType = typeHiddenField.value;
-
-        // hide form fields that are relevant for articles only from documents that are static pages
-        if (documentType !== "article") {
-          [].forEach.call(document.querySelectorAll('.articles-only'), function (el) {
-            el.style.display = 'none';
-          });
-        }
-
-        var data;
-        var googleDocs;
-        var translationData;
-        var publishedInfo;
-        var headline;
-        
-        var localeCode = contents.localeCode;
-        if (!localeCode) {
-          localeCode = "en-US";
-        }
-
-        if (contents.data.articles) {
-          if (contents.data.articles[0]) {
-            data = contents.data.articles[0]
-          }
-          if (contents.data.article_translations) {
-              translationData = contents.data.article_translations[0];
-          }
-          if (contents.data.article_google_documents) {
-            googleDocs = contents.data.article_google_documents;
-          }
-          if (contents.data.published_article_translations && contents.data.published_article_translations[0]) {
-            publishedInfo = contents.data.published_article_translations[0].article_translation;
-            // console.log("found publishedInfo:", publishedInfo);
-          }
-        } else if (contents.data.pages) {
-          documentType = "page"
-          if (contents.data.pages[0]) {
-            data = contents.data.pages[0]
-            
-          }
-          if (contents.data.page_translations) {
-            translationData = contents.data.page_translations[0];
-          }
-
-          if (contents.data.page_google_documents) {
-            googleDocs = contents.data.page_google_documents;
-          }
-        }
-
-        if (translationData) {
-          headline = translationData.headline;
-        } else if (contents.documentTitle && contents.documentTitle !== "Untitled document") {
-          headline = contents.documentTitle;
-        } else {
-          headline = "tk";
-        }
-        displayTranslationTools(data.id, contents.documentId, documentType, headline, googleDocs, contents.data.organization_locales);
-        
-        if (publishedInfo) {
-          displayPublishedInfo(publishedInfo, translationData);
-        }
-
-        // if (contents.data.organization_locales) {
-          displayLocales(contents.data.organization_locales, localeCode);
-        // }
-        
-        if (documentType === "article") {
-          displayCategories(contents.data.categories, data.category);
-          displayTags(localeCode, contents.data.tags, data.tag_articles);
-          displayAuthors(contents.data.authors, data.author_articles);
-        }
-
-        if (data) {
-          // console.log("contents:", contents, "data:", data);
-          var slugField = document.getElementById('article-slug');
-          slugField.value = data.slug;
-
-          if (contents && contents.data && contents.data.orgSlug) {
-            var orgSlugField = document.getElementById('org-slug');
-            orgSlugField.value = contents.data.orgSlug;
-          }
-
-          var idHiddenField = document.getElementById('article-id');
-          idHiddenField.value = data.id;
-          
-        }
-
-        // var selectedLocale = document.getElementById('selected-locale');
-        if (translationData) {
-          setPublishedFlag(translationData.published);
-
-          var articleHeadline = document.getElementById('article-headline');
-          articleHeadline.value = translationData.headline;
-
-          // selectedLocale.innerHTML = translationData.locale_code;
-
-          setValueOrDefault('article-custom-byline', translationData.custom_byline, "");
-          setValueOrDefault('article-search-title', translationData.search_title, translationData.search_title);
-          setValueOrDefault('article-search-description', translationData.search_description, translationData.search_description);
-          setValueOrDefault('article-facebook-title', translationData.facebook_title, translationData.facebook_title);
-          setValueOrDefault('article-facebook-description', translationData.facebook_description, translationData.facebook_description);
-          setValueOrDefault('article-twitter-title', translationData.twitter_title, translationData.twitter_title);
-          setValueOrDefault('article-twitter-description', translationData.twitter_description, translationData.twitter_description);
-        } else {
-          // selectedLocale.innerHTML = localeCode;
-        }
-
-        $('#article-authors').select2({
-          width: 'resolve',
-        });
-
-        $('#article-tags').select2({
-          width: 'resolve',
-          tags: true,
-          createTag: function (params) {
-            var term = $.trim(params.term);
-
-            if (term === '') {
-              return null;
-            }
-
-            return {
-              id: term,
-              text: term,
-              newTag: true // add additional parameters
-            }
-          }
-        });
-
-        // console.log("publishedInfo:", publishedInfo);
-        if (publishedInfo) {
-          var firstPubDate = new Date(publishedInfo.first_published_at);
-          // console.log("setting published date to ", firstPubDate, publishedInfo.first_published_at);
-
-          flatpickr('input[name="article-first-published-date"]', {
-            enableTime: true,
-            dateFormat: "Y-m-d h:i K",
-            defaultDate: firstPubDate
-          });
-        } else {
-          var today = new Date();
-          flatpickr('input[name="article-first-published-date"]', {
-            enableTime: true,
-            dateFormat: "Y-m-d h:i K",
-            defaultDate: today
-          });
-        }
-
-        if (data && documentType === "article") {
-          google.script.run.withFailureHandler(onFailureFeatured).withSuccessHandler(onSuccessFeatured).isArticleFeatured(data.id);
-        }
-      }
       
       function onSuccessFeatured(result) {
         if (result && result.featured) {
@@ -763,202 +583,347 @@
         sourceContainer.appendChild(formDiv);
 
       }
+      function onSuccessGetArticle(data) {
+// console.log("contents onSuccessGetArticle:", contents);
+// var typeHiddenField = document.getElementById('document-type');
+// var documentType = typeHiddenField.value;
 
-      function handleGetTranslationsForArticle(data) {
 
-        if (data && data.status === "error") {
-          onFailure(data.message);
-          return;
+}
+
+function handleGetTranslationsForArticle(result) {
+  var configDiv = document.getElementById('config');
+  configDiv.style.display = 'none';
+  var div = document.getElementById('loading');
+  div.style.display = 'block';
+  var form = document.getElementById('article-form');
+  form.style.display = "block";
+
+  var buttonsDivBottom = document.getElementById('action-buttons-bottom')
+  buttonsDivBottom.style.display = "block";
+  var buttonsDivTop = document.getElementById('action-buttons-top')
+  buttonsDivTop.style.display = "block";
+
+  if (result && result.status && result.status === "error") {
+    div.innerHTML = "<p class='error'>An error occurred: " + data.message + '</p>';
+    
+    try {
+      alertAirbrake(JSON.stringify(data));
+    } catch(e) {
+      console.error("Failed to log error with Airbrake:", e);
+    }
+
+    return;
+  } else {
+    div.innerHTML = '<p style="color: #48C774;">' + result.message + "</p>";
+  }
+  
+  var articleId;
+  var pageId;
+  var localeCode;
+  var typeHiddenField = document.getElementById('document-type');
+  var documentType = "article";
+  
+  var data = result.data;
+
+  if (data && data.documentType) {
+    documentType = data.documentType;
+  }
+  typeHiddenField.value = documentType;
+
+  console.log("data:", data);
+
+  if (documentType === "article" && data.article && data.article.id) {
+
+    articleId = data.article.id;
+
+    if (data.article.canonical_url) {
+      var canonicalUrlField = document.getElementById('article-custom-canonical-url');
+      canonicalUrlField.value = data.article.canonical_url;
+    }
+
+    if (
+      data.article.article_google_documents && 
+      data.article.article_google_documents[0] && 
+      data.article.article_google_documents[0].google_document) {
+        localeCode = data.article.article_google_documents[0].google_document.locale_code;
+    }
+
+    var blankSource = {
+      name: "",
+      race: "",
+      zip: "",
+      affiliation: "",
+      phone: "",
+      email: "",
+      gender: "",
+      sexual_orientation: "",
+      ethnicity: "",
+      role: "",
+      age: ""
+    }
+
+    var sourceContainer = document.getElementById('sources-container');
+    var sourcesCounter = 0;
+    sourcesCounter += 1;
+
+    // first add an empty set of form fields to the top of the sources-container
+    addAnotherSource("new_1", blankSource);
+    sourcesCounter += 1;
+
+    var sourceListContainer = document.getElementById('sources-list-container');
+    var sourceUnorderedList = document.createElement("ul");
+
+    // then loop over existing sources and render the filled-in set of form fields
+    if (data.article.article_sources) {
+      var sources = data.article.article_sources;
+      // console.log("found " + sources.length + " sources");
+      sources.forEach(sourceData => {
+        sourcesCounter += 1;
+        var source = sourceData.source;
+        // console.log("found source id# " + source.id);
+
+        addAnotherSource(source.id, source);
+
+        var sourceListItem = document.createElement("li");
+        sourceListItem.style.cursor = "pointer";
+        sourceListItem.innerHTML = "<a onClick='expandSource(" + source.id + ")'>" + source.name + "</a>";
+        sourceUnorderedList.appendChild(sourceListItem)
+      });
+    }
+
+    sourceListContainer.appendChild(sourceUnorderedList);
+
+    var counterField = document.getElementById("source-tracking-counter");
+    counterField.value = sourcesCounter;
+  }
+
+  if (documentType === "page" && data.page) {
+    // hide the source tracking form
+    var sourceListContainer = document.getElementById('sources-list-container');
+    sourceListContainer.style.display = "none";
+    var addSourceButton = document.getElementById('add-another-source');
+    addSourceButton.style.display = "none";
+
+    // hide fields that are for articles only
+    [].forEach.call(document.querySelectorAll('.articles-only'), function (el) {
+      el.style.display = 'none';
+    });
+
+    pageId = data.page.id;
+    // console.log("hasuraGetPage id:", pageId);
+    if (data.page.page_google_documents && data.page.page_google_documents[0] && data.page.page_google_documents[0].google_document) {
+      localeCode = data.page.page_google_documents[0].google_document.locale_code;
+    }
+  }
+
+  if (!localeCode) {
+    localeCode = "en-US";
+  }
+  
+  if ( (articleId || pageId) && localeCode) {
+    // console.log("FOUND articleId: " + articleId + ", pageId: " + pageId + ", localeCode: " + localeCode);
+    var googleDocs;
+    var translationData;
+    var publishedInfo;
+    var headline;
+    var id;
+
+    if (data.article) {
+      id = data.article.id;
+      if (data.article.article_translations) {
+        translationData = data.article.article_translations[0];
+      }
+      if (data.article_google_documents) {
+        googleDocs = data.article_google_documents;
+      }
+      if (data.published_article_translations && data.published_article_translations[0]) {
+        publishedInfo = data.published_article_translations[0].article_translation;
+        // console.log("found publishedInfo:", publishedInfo);
+      }
+
+      displayCategories(data.categories, data.article.category);
+      displayTags(localeCode, data.tags, data.article.tag_articles);
+      displayAuthors(data.authors, data.article.author_articles);
+
+      var slugField = document.getElementById('article-slug');
+      slugField.value = data.article.slug;
+
+      if (data.orgSlug) {
+        var orgSlugField = document.getElementById('org-slug');
+        orgSlugField.value = data.orgSlug;
+      }
+
+      var idHiddenField = document.getElementById('article-id');
+      idHiddenField.value = id;
+    
+      google.script.run.withFailureHandler(onFailureFeatured).withSuccessHandler(onSuccessFeatured).isArticleFeatured(data.id);
+    
+    } else if (data.page) {
+      id = data.page.id;
+      if (data.page.page_translations) {
+        translationData = data.page.page_translations[0];
+      }
+
+      if (data.page_google_documents) {
+        googleDocs = data.page_google_documents;
+      }
+
+      var slugField = document.getElementById('article-slug');
+      slugField.value = data.page.slug;
+
+      if (data.orgSlug) {
+        var orgSlugField = document.getElementById('org-slug');
+        orgSlugField.value = data.orgSlug;
+      }
+
+      var idHiddenField = document.getElementById('article-id');
+      idHiddenField.value = id;
+    
+    }
+
+    if (translationData) {
+      headline = translationData.headline;
+    } else if (data.documentTitle && data.documentTitle !== "Untitled document") {
+      headline = data.documentTitle;
+    } else {
+      headline = "tk";
+    }
+    displayTranslationTools(id, data.documentId, documentType, headline, googleDocs, data.organization_locales);
+
+    if (publishedInfo) {
+      displayPublishedInfo(publishedInfo, translationData);
+
+      var firstPubDate = new Date(publishedInfo.first_published_at);
+      // console.log("setting published date to ", firstPubDate, publishedInfo.first_published_at);
+
+      flatpickr('input[name="article-first-published-date"]', {
+        enableTime: true,
+        dateFormat: "Y-m-d h:i K",
+        defaultDate: firstPubDate
+      });
+
+    } else {
+      var today = new Date();
+      flatpickr('input[name="article-first-published-date"]', {
+        enableTime: true,
+        dateFormat: "Y-m-d h:i K",
+        defaultDate: today
+      });
+    
+    }
+
+    displayLocales(data.organization_locales, localeCode);
+
+    if (translationData) {
+      setPublishedFlag(translationData.published);
+
+      var articleHeadline = document.getElementById('article-headline');
+      articleHeadline.value = headline;
+
+      setValueOrDefault('article-custom-byline', translationData.custom_byline, "");
+      setValueOrDefault('article-search-title', translationData.search_title, translationData.search_title);
+      setValueOrDefault('article-search-description', translationData.search_description, translationData.search_description);
+      setValueOrDefault('article-facebook-title', translationData.facebook_title, translationData.facebook_title);
+      setValueOrDefault('article-facebook-description', translationData.facebook_description, translationData.facebook_description);
+      setValueOrDefault('article-twitter-title', translationData.twitter_title, translationData.twitter_title);
+      setValueOrDefault('article-twitter-description', translationData.twitter_description, translationData.twitter_description);
+    }
+
+    $('#article-authors').select2({
+      width: 'resolve',
+    });
+
+    $('#article-tags').select2({
+      width: 'resolve',
+      tags: true,
+      createTag: function (params) {
+        var term = $.trim(params.term);
+
+        if (term === '') {
+          return null;
         }
-        var articleId;
-        var pageId;
-        var localeCode;
-        var typeHiddenField = document.getElementById('document-type');
-        var documentType = "article";
-        
-        if (data && data.data && data.data.articles) {
-          documentType = "article";
+
+        return {
+          id: term,
+          text: term,
+          newTag: true // add additional parameters
         }
-        if (data && data.data && data.data.pages) {
-          documentType = "page";
-        }
+      }
+    });
 
-        typeHiddenField.value = documentType;
+  } else {
+    if (!localeCode) {
+      localeCode = "en-US";
+    }
+    console.log("Failed to find stored data, new document? Using localeCode: " + localeCode);
 
-        if (documentType === "article" && data && data.data && data.data.articles && data.data.articles[0]) {
+    // TBD: where to get the active doc headline from - pretty sure this html doc can't access it?
+    if (data && data.headline && data.headline !== "Untitled document") {
+      // console.log("setting default article headline to:", data.data.headline)
+      var headline = document.getElementById('article-headline');
+      headline.value = data.headline;
+      var searchTitle = document.getElementById('article-search-title');
+      searchTitle.value = data.headline;
+    } else {
+      console.log("data.headline is undefined:", data);
+    }
 
-          articleId = data.data.articles[0].id;
+    setPublishedFlag(false); // new article is not published, ensure correct action buttons display
 
-          if (data.data.articles[0].canonical_url) {
-            var canonicalUrlField = document.getElementById('article-custom-canonical-url');
-            canonicalUrlField.value = data.data.articles[0].canonical_url;
-          }
-
-          if (
-            data.data.articles[0] && 
-            data.data.articles[0].article_google_documents && 
-            data.data.articles[0].article_google_documents[0] && 
-            data.data.articles[0].article_google_documents[0].google_document) {
-              localeCode = data.data.articles[0].article_google_documents[0].google_document.locale_code;
-            }
-
-            var blankSource = {
-              name: "",
-              race: "",
-              zip: "",
-              affiliation: "",
-              phone: "",
-              email: "",
-              gender: "",
-              sexual_orientation: "",
-              ethnicity: "",
-              role: "",
-              age: ""
-            }
-
-            var sourceContainer = document.getElementById('sources-container');
-            var sourcesCounter = 0;
-            sourcesCounter += 1;
-
-            // first add an empty set of form fields to the top of the sources-container
-            addAnotherSource("new_1", blankSource);
-            sourcesCounter += 1;
-
-            var sourceListContainer = document.getElementById('sources-list-container');
-            var sourceUnorderedList = document.createElement("ul");
-
-            // then loop over existing sources and render the filled-in set of form fields
-            if (
-              data.data.articles[0] &&
-              data.data.articles[0].article_sources
-              ) {
-                var sources = data.data.articles[0].article_sources;
-                // console.log("found " + sources.length + " sources");
-                sources.forEach(sourceData => {
-                  sourcesCounter += 1;
-                  var source = sourceData.source;
-                  // console.log("found source id# " + source.id);
-
-                  addAnotherSource(source.id, source);
-
-                  var sourceListItem = document.createElement("li");
-                  sourceListItem.style.cursor = "pointer";
-                  sourceListItem.innerHTML = "<a onClick='expandSource(" + source.id + ")'>" + source.name + "</a>";
-                  sourceUnorderedList.appendChild(sourceListItem)
-                });
-            }
-
-            sourceListContainer.appendChild(sourceUnorderedList);
-
-            var counterField = document.getElementById("source-tracking-counter");
-            counterField.value = sourcesCounter;
-        }
-
-        if (documentType === "page" && data.data.pages[0]) {
-          // hide the source tracking form
-          var sourceListContainer = document.getElementById('sources-list-container');
-          sourceListContainer.style.display = "none";
-          var addSourceButton = document.getElementById('add-another-source');
-          addSourceButton.style.display = "none";
-
-          typeHiddenField.value = documentType;
-          pageId = data.data.pages[0].id;
-          // console.log("hasuraGetPage id:", pageId);
-          if (
-            data.data.pages[0] && 
-            data.data.pages[0].page_google_documents && 
-            data.data.pages[0].page_google_documents[0] && 
-            data.data.pages[0].page_google_documents[0].google_document) {
-              localeCode = data.data.pages[0].page_google_documents[0].google_document.locale_code;
-            }
-        }
-
-        if (articleId && localeCode) {
-          google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessGetArticle).hasuraGetTranslations(articleId, localeCode);
-        } else if (pageId && localeCode) {
-          google.script.run.withFailureHandler(onFailure).withSuccessHandler(onSuccessGetArticle).hasuraGetTranslations(pageId, localeCode);
-        } else {
-
-          if (!localeCode) {
-            localeCode = "en-US";
-          }
-
-          if (data && data.data && data.data.headline && data.data.headline !== "Untitled document") {
-            // console.log("setting default article headline to:", data.data.headline)
-            var headline = document.getElementById('article-headline');
-            headline.value = data.data.headline;
-            var searchTitle = document.getElementById('article-search-title');
-            searchTitle.value = data.data.headline;
-          } else {
-            // console.log("data.headline is undefined:", data);
-          }
-          var configDiv = document.getElementById('config');
-          configDiv.style.display = 'none';
-
-          var div = document.getElementById('loading');
-          div.style.display = 'block';
-          div.innerHTML = data.message;
-          var form = document.getElementById('article-form');
-          form.style.display = "block";
-          var buttonsDivBottom = document.getElementById('action-buttons-bottom')
-          buttonsDivBottom.style.display = "block";
-          var buttonsDivTop = document.getElementById('action-buttons-top')
-          buttonsDivTop.style.display = "block";
-          setPublishedFlag(false); // new article is not published, ensure correct action buttons display
-
-          displayLocales(data.data.organization_locales, localeCode);
+    displayLocales(data.organization_locales, localeCode);
           
-          if (documentType === "article") {
-            // console.log("data:", data);
-            if (data && data.data && data.data.categories) {
-              displayCategories(data.data.categories, null);
-            }
-            if (data && data.data && data.data.tags) {
-              displayTags(localeCode, data.data.tags, null);
-            }
-            if (data && data.data && data.data.authors) {
-              displayAuthors(data.data.authors, null);
-            }
+    if (documentType === "article") {
+      // console.log("data:", data);
+      if (data && data.categories) {
+        displayCategories(data.categories, null);
+      }
+      if (data && data.tags) {
+        displayTags(localeCode, data.tags, null);
+      }
+      if (data && data.authors) {
+        displayAuthors(data.authors, null);
+      }
 
-            var today = new Date();
-            flatpickr('input[name="article-first-published-date"]', {
-              enableTime: true,
-              dateFormat: "Y-m-d h:i K",
-              defaultDate: today
-            });
+      var today = new Date();
+      flatpickr('input[name="article-first-published-date"]', {
+        enableTime: true,
+        dateFormat: "Y-m-d h:i K",
+        defaultDate: today
+      });
 
-            $('#article-authors').select2({
-              width: 'resolve',
-            });
+      $('#article-authors').select2({
+        width: 'resolve',
+      });
 
-            $('#article-tags').select2({
-              width: 'resolve',
-              tags: true,
-              createTag: function (params) {
-                var term = $.trim(params.term);
+      $('#article-tags').select2({
+        width: 'resolve',
+        tags: true,
+        createTag: function (params) {
+          var term = $.trim(params.term);
 
-                if (term === '') {
-                  return null;
-                }
+          if (term === '') {
+            return null;
+          }
 
-                return {
-                  id: term,
-                  text: term,
-                  newTag: true // add additional parameters
-                }
-              }
-            });
-          } else {
-            [].forEach.call(document.querySelectorAll('.articles-only'), function (el) {
-              el.style.display = 'none';
-            });
+          return {
+            id: term,
+            text: term,
+            newTag: true // add additional parameters
           }
         }
-      }
+      });
+    } else {
+      [].forEach.call(document.querySelectorAll('.articles-only'), function (el) {
+        el.style.display = 'none';
+      });
+    }
+  }
+}
 
-      function handleGetArticle() {
-         google.script.run.withFailureHandler(onFailure).withSuccessHandler(handleGetTranslationsForArticle).hasuraGetArticle();
-      }
+function handleGetArticle() {
+    google.script.run.withFailureHandler(onFailure).withSuccessHandler(handleGetTranslationsForArticle).hasuraGetArticle();
+}
 
       function displayTranslationTools(id, documentId, documentType, headline, googleDocs, organizationLocales) {
         // console.log("displaying translation tools:", id, documentId, headline, googleDocs, organizationLocales);

--- a/Page.html
+++ b/Page.html
@@ -592,6 +592,9 @@
 }
 
 function handleGetTranslationsForArticle(result) {
+  console.log("result:", result);
+
+  
   var configDiv = document.getElementById('config');
   configDiv.style.display = 'none';
   var div = document.getElementById('loading');
@@ -605,10 +608,10 @@ function handleGetTranslationsForArticle(result) {
   buttonsDivTop.style.display = "block";
 
   if (result && result.status && result.status === "error") {
-    div.innerHTML = "<p class='error'>An error occurred: " + data.message + '</p>';
+    div.innerHTML = "<p class='error'>An error occurred: " + result.message + '</p>';
     
     try {
-      alertAirbrake(JSON.stringify(data));
+      alertAirbrake(JSON.stringify(result));
     } catch(e) {
       console.error("Failed to log error with Airbrake:", e);
     }
@@ -624,6 +627,7 @@ function handleGetTranslationsForArticle(result) {
   var typeHiddenField = document.getElementById('document-type');
   var documentType = "article";
   
+
   var data = result.data;
 
   if (data && data.documentType) {
@@ -631,7 +635,6 @@ function handleGetTranslationsForArticle(result) {
   }
   typeHiddenField.value = documentType;
 
-  console.log("data:", data);
 
   if (documentType === "article" && data.article && data.article.id) {
 

--- a/Page.html
+++ b/Page.html
@@ -1030,287 +1030,295 @@ function displayTranslationTools(id, documentId, documentType, headline, googleD
     }
   }
 
-      function onSuccessPreviewPublish(response) {
-        var configDiv = document.getElementById('config');
-        configDiv.style.display = 'none';
-        var div = document.getElementById('loading');
-        div.style.display = 'block';
+  function onSuccessPreviewPublish(response) {
+    var configDiv = document.getElementById('config');
+    configDiv.style.display = 'none';
+    var div = document.getElementById('loading');
+    div.style.display = 'block';
 
-        if (response.data.errors) {
-          div.innerHTML = "<p class='error'>An error occurred: " + JSON.stringify(response.data.errors) + '</p>';
-          try {
-            alertAirbrake(JSON.stringify(response.data.errors));
-          } catch(e) {
-            console.error("Failed to log error with Airbrake:", e);
-          }
-        } else {
-          div.innerHTML = '<p style="color: #48C774;">' + response.message + "</p>";
-          if (response.data && response.data.data && response.data.data.insert_articles) {
-            var articleID = response.data.data.insert_articles.returning[0].id;
-            var idHiddenField = document.getElementById('article-id');
-            idHiddenField.value = articleID;
+    console.log("onSuccessPreviewPublish:", response);
 
-            var articleSlug = response.data.data.insert_articles.returning[0].slug;
-            var slugField = document.getElementById('article-slug');
-            slugField.value = articleSlug;
+    if (response.data.errors || response.status === 'error') {
+      console.log("error:", response);
+      if (response.data.errors) {
+        console.log("response.data.errors:", response.data.errors);
+        div.innerHTML = "<p class='error'>An error occurred: " + JSON.stringify(response.data.errors) + '</p>';
+        try {
+          alertAirbrake(JSON.stringify(response.data.errors));
+        } catch(e) {
+          console.error("Failed to log error with Airbrake:", e);
+        }
+      } else {
+        console.log("response.message:", response.message);
+        div.innerHTML = "<p class='error'>" + response.message + '</p>';
+      }
+    } else {
+      div.innerHTML = '<p style="color: #48C774;">' + response.message + "</p>";
+      if (response.data && response.documentType && response.documentType === 'article') {
+        var articleID = response.data.id;
+        var idHiddenField = document.getElementById('article-id');
+        idHiddenField.value = articleID;
+        console.log("set", idHiddenField, "to id#", articleID);
 
-            var articleID = response.data.data.insert_articles.returning[0].id;
-            var idHiddenField = document.getElementById('article-id');
-            idHiddenField.value = articleID;
+        var articleSlug = response.data.slug;
+        var slugField = document.getElementById('article-slug');
+        slugField.value = articleSlug;
 
-            var translations = response.data.data.insert_articles.returning[0].article_translations;
-            if (translations[0]) {
-              setPublishedFlag(translations[0].published);
-            }
-            var publishedInfo = response.data.data.insert_articles.returning[0].published_article_translations;
-            if (publishedInfo && publishedInfo[0]) {
-              var mostRecentPubInfo = publishedInfo[0].article_translation;
-              displayPublishedInfo(mostRecentPubInfo, translations[0]);
-              
-              // console.log("publishedInfo:", mostRecentPubInfo);
-              if (mostRecentPubInfo) {
-                var firstPubDate = new Date(mostRecentPubInfo.first_published_at);
-                // console.log("setting published date to ", firstPubDate, mostRecentPubInfo.first_published_at);
-                flatpickr('input[name="article-first-published-date"]', {
-                  enableTime: true,
-                  dateFormat: "Y-m-d h:i K",
-                  defaultDate: firstPubDate
-                });
-              } else {
-                var today = new Date();
-                flatpickr('input[name="article-first-published-date"]', {
-                  enableTime: true,
-                  dateFormat: "Y-m-d h:i K",
-                  defaultDate: today
-                });
-              }
-            }
-
-            // console.log("response:", response);
-            var googleDocs = response.data.data.insert_articles.returning[0].article_google_documents;
-            var organizationLocales = response.data.organization_locales;
-            var documentID = response.documentID;
-            // console.log("googleDocs:", googleDocs, "organizationLocales:", organizationLocales, "documentID:", documentID);
-        
-            displayTranslationTools(articleID, documentID, "article", translations[0].headline, googleDocs, organizationLocales);
-
-          } else if (response.data && response.data.data && response.data.data.insert_pages) {
-            var pageID = response.data.data.insert_pages.returning[0].id;
-            // console.log("page ID:", pageID)
-            var idHiddenField = document.getElementById('article-id');
-            idHiddenField.value = pageID;
-
-            var pageData = response.data.data.insert_pages.returning[0];
-            
-            var googleDocs = pageData.page_google_documents;
-            var translations = pageData.page_translations;
-            var organizationLocales = response.data.organization_locales;
-            var documentID = response.documentID;
-
-            displayTranslationTools(pageID, documentID, "page", translations[0].headline, googleDocs, organizationLocales);
-
-          } else if (response.data && response.data.data && response.data.data.update_article_translations) {
-            // console.log("unpublished article:", response.data);
-            setPublishedFlag(false);
+        var translations = response.data.article_translations;
+        if (translations[0]) {
+          setPublishedFlag(translations[0].published);
+          console.log("translations[0]:", translations[0]);
+        }
+        var publishedInfo = response.data.published_article_translations;
+        if (publishedInfo && publishedInfo[0]) {
+          console.log("publishedInfo:", publishedInfo[0])
+          var mostRecentPubInfo = publishedInfo[0].article_translation;
+          displayPublishedInfo(mostRecentPubInfo, translations[0]);
+          
+          // console.log("publishedInfo:", mostRecentPubInfo);
+          if (mostRecentPubInfo) {
+            var firstPubDate = new Date(mostRecentPubInfo.first_published_at);
+            // console.log("setting published date to ", firstPubDate, mostRecentPubInfo.first_published_at);
+            flatpickr('input[name="article-first-published-date"]', {
+              enableTime: true,
+              dateFormat: "Y-m-d h:i K",
+              defaultDate: firstPubDate
+            });
           } else {
-            console.log("unknown: ", response);
+            var today = new Date();
+            flatpickr('input[name="article-first-published-date"]', {
+              enableTime: true,
+              dateFormat: "Y-m-d h:i K",
+              defaultDate: today
+            });
           }
         }
 
-        var form = document.getElementById('article-form');
-        form.style.display = "block";
-      }
+        // console.log("response:", response);
+        var googleDocs = response.data.article_google_documents;
+        var organizationLocales = response.data.organization_locales;
+        var documentID = response.documentID;
+        console.log("googleDocs:", googleDocs, "organizationLocales:", organizationLocales, "documentID:", documentID);
+    
+        displayTranslationTools(articleID, documentID, "article", translations[0].headline, googleDocs, organizationLocales);
 
-      function handleClick(formObject) {
-        var form = document.getElementById('article-form');
-        form.style.display = "none";
+      } else if (response.data && response.documentType === 'page') { 
+        var pageID = response.data.id;
+        // console.log("page ID:", pageID)
+        var idHiddenField = document.getElementById('article-id');
+        idHiddenField.value = pageID;
 
-        var formIsValid = true;
-
-        var configDiv = document.getElementById('config');
-        configDiv.style.display = "none";
-
-        var loadingDiv = document.getElementById('loading');
-        loadingDiv.style.display = "block";
-
-        var errorMessage = "";
-
-        var typeHiddenField = document.getElementById('document-type');
-        var documentType = typeHiddenField.value;
-
-        var headline = document.getElementById('article-headline');
-        var searchTitle = document.getElementById('article-search-title');
-        var searchDescription = document.getElementById('article-search-description');
-        var category = document.getElementById('article-category');
-
-        const calendar = flatpickr('input[name="article-first-published-date"]', {enableTime: true,
-            dateFormat: "Y-m-d h:i K"});
+        var pageData = response.data;
         
-        var publishedDate = calendar.selectedDates[0];
-        // 2018-08-28T12:30:00+05:30
-        // var formattedPubDate = calendar.formatDate(publishedDate, "y-m-dT")
-        // console.log("storing pub date as:", publishedDate);
+        var googleDocs = pageData.page_google_documents;
+        var translations = pageData.page_translations;
+        var organizationLocales = response.data.organization_locales;
+        var documentID = response.documentID;
 
-        var sources = {};
+        displayTranslationTools(pageID, documentID, "page", translations[0].headline, googleDocs, organizationLocales);
 
-        if (documentType !== "page")  {
-          var elements = formObject.elements;
+      } else if (response.data && response.data.data && response.data.data.update_article_translations) { // TODO get rid of this?? not sure what it's for
+        // console.log("unpublished article:", response.data);
+        setPublishedFlag(false);
+      } else {
+        console.log("unknown response: ", response);
+      }
+    }
 
-          // build up an object with source data
-          // keys are source ids
-          for (var i = 0, element; element = elements[i++];) {
-            var elementMatch = element.name.match(/source\[(.*?)\]\.(.*?)$/);
-            if (elementMatch) {
-              var id = elementMatch[1];
-              if (sources[id] === undefined) {
-                sources[id] = {};
-              }
-              var fieldName = elementMatch[2];
-              var value = element.value;
-              sources[id][fieldName] = value
-            }
+    var form = document.getElementById('article-form');
+    form.style.display = "block";
+  }
+
+  function handleClick(formObject) {
+    var form = document.getElementById('article-form');
+    form.style.display = "none";
+
+    var formIsValid = true;
+
+    var configDiv = document.getElementById('config');
+    configDiv.style.display = "none";
+
+    var loadingDiv = document.getElementById('loading');
+    loadingDiv.style.display = "block";
+
+    var errorMessage = "";
+
+    var typeHiddenField = document.getElementById('document-type');
+    var documentType = typeHiddenField.value;
+
+    var headline = document.getElementById('article-headline');
+    var searchTitle = document.getElementById('article-search-title');
+    var searchDescription = document.getElementById('article-search-description');
+    var category = document.getElementById('article-category');
+
+    const calendar = flatpickr('input[name="article-first-published-date"]', {enableTime: true,
+        dateFormat: "Y-m-d h:i K"});
+    
+    var publishedDate = calendar.selectedDates[0];
+    // 2018-08-28T12:30:00+05:30
+    // var formattedPubDate = calendar.formatDate(publishedDate, "y-m-dT")
+    // console.log("storing pub date as:", publishedDate);
+
+    var sources = {};
+
+    if (documentType !== "page")  {
+      var elements = formObject.elements;
+
+      // build up an object with source data
+      // keys are source ids
+      for (var i = 0, element; element = elements[i++];) {
+        var elementMatch = element.name.match(/source\[(.*?)\]\.(.*?)$/);
+        if (elementMatch) {
+          var id = elementMatch[1];
+          if (sources[id] === undefined) {
+            sources[id] = {};
           }
-          // loop over sources and check that each has either an email or phone specified
-          Object.keys(sources).forEach(id => {
-            var email = sources[id]['email'];
-            var phone = sources[id]['phone'];
-            var name = sources[id]['name'];
-            
-            // name is required
-            if (!/new_/.test(id) && !name) {
-              errorMessage += "<br>'Name' is required on all sources.";
-              delete sources[id];
-              formIsValid = false;
+          var fieldName = elementMatch[2];
+          var value = element.value;
+          sources[id][fieldName] = value
+        }
+      }
+      // loop over sources and check that each has either an email or phone specified
+      Object.keys(sources).forEach(id => {
+        var email = sources[id]['email'];
+        var phone = sources[id]['phone'];
+        var name = sources[id]['name'];
+        
+        // name is required
+        if (!/new_/.test(id) && !name) {
+          errorMessage += "<br>'Name' is required on all sources.";
+          delete sources[id];
+          formIsValid = false;
 
-            // new source form that lacks a name, email and phone should be omitted
-            } else if (/new_/.test(id) && (!name && !email && !phone) ) {
-              // remove blank source from the list
-              delete sources[id];
-              // console.log(sources);
+        // new source form that lacks a name, email and phone should be omitted
+        } else if (/new_/.test(id) && (!name && !email && !phone) ) {
+          // remove blank source from the list
+          delete sources[id];
+          // console.log(sources);
 
-            } else {
-              if (name && (phone || email)) {
-                // console.log(name, "has a name + a phone or email:", phone, email);
-              } else if (!name) {
-                // console.log("source is missing a name")
-                errorMessage += "<br>'Name' is required on all sources.";
-                delete sources[id];
-                formIsValid = false;
-              } else {
-                // console.log(id, name, "is missing a phone/email")
-                delete sources[id];
-                errorMessage += "<br>All sources must have either a phone or email.";
-                formIsValid = false;
-              }
-            }
-          })
-
-          var selectedAuthors = $('#article-authors').select2('data');
-          var customByline = document.getElementById("article-custom-byline").value;
-          if ( (selectedAuthors === undefined || selectedAuthors.length <= 0) && ( customByline === null || customByline === undefined || customByline === "") ) {
-            // console.log("selectedAuthors:", selectedAuthors, "customByline:", customByline)
-            errorMessage += "<br>Author or custom byline is required.";
+        } else {
+          if (name && (phone || email)) {
+            // console.log(name, "has a name + a phone or email:", phone, email);
+          } else if (!name) {
+            // console.log("source is missing a name")
+            errorMessage += "<br>'Name' is required on all sources.";
+            delete sources[id];
+            formIsValid = false;
+          } else {
+            // console.log(id, name, "is missing a phone/email")
+            delete sources[id];
+            errorMessage += "<br>All sources must have either a phone or email.";
             formIsValid = false;
           }
         }
-        if (!headline.value) {
-          // console.log("headline is missing:", headline.value, typeof(headline.value));
-          errorMessage += "<br>Headline is required.";
-          formIsValid = false;
-        }
-        if (!searchTitle.value) {
-          // console.log("search title is missing:", searchTitle.value, typeof(searchTitle.value));
-          errorMessage += "<br>Search title is required.";
-          formIsValid = false;
-        }
-        if (!searchDescription.value) {
-          // console.log("searchDescription is missing:", searchDescription.value, typeof(searchDescription.value));
-          errorMessage += "<br>Search description is required.";
-          formIsValid = false;
-        }
-        if (!category.value) {
-          errorMessage += "<br>Category/section is required.";
-          formIsValid = false;
-        }
+      })
 
-        // assemble the data to submit - unfortunately we can't pass the form object with any additional data here
-        var submitData = {};
-        var elements = formObject.elements;
-        for (var i = 0, element; element = elements[i++];) {
-          var key = element.name;
-          var value = element.value;
-          if ( !(/source/).test(key) ) {
-            submitData[key] = value;
-          }
-        }
-        if (documentType === "article") {
-          var selectedTags = $('#article-tags').select2('data');
-          submitData["article-tags"] = [];
-          for (var i = 0, tag; tag = selectedTags[i++];) {
-            submitData["article-tags"].push(tag.text);
-          }
-          var formattedPubDate = toIsoString(publishedDate);
-          submitData["first-published-at"] = formattedPubDate;
-          // console.log('formattedPubDate:', formattedPubDate);
-          submitData["sources"] = sources;
-          submitData['article-authors'] = [];
-          for (var i = 0, author; author = selectedAuthors[i++];) {
-            submitData["article-authors"].push(author.id);
-          }
-        }
-        
-        if (formIsValid && formObject.submitted === "Preview") {
-          // console.log("valid form + preview")
-          loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
-          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePreview(submitData);
-        } else if ( formIsValid && (formObject.submitted === "Publish" || formObject.submitted === "Re-publish") ) {
-          // console.log("valid form + ", formIsValid, formObject.submitted)
-          if (documentType === "article" && $.isEmptyObject(sources)) {
-            if (!window.confirm("You're trying to publish an article without any source tracking info: are you sure?")) { 
-              form.style.display = "block";
-              loadingDiv.innerHTML = "Please enter source tracking info, then try publishing again.";
-              const redrawCalendar = flatpickr('input[name="article-first-published-date"]', {
-                enableTime: true,
-                dateFormat: "Y-m-d h:i K",
-              });
-
-            } else {
-              loadingDiv.innerHTML = "<p class='gray'>Publishing without any sources... </p>"
-              google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
-            }
-          } else {
-            loadingDiv.innerHTML = "<p class='gray'>Publishing... </p>"
-            google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
-          }
-        } else if (formIsValid && formObject.submitted === "Unpublish") {
-          // console.log("valid form + unpublish")
-          loadingDiv.innerHTML = "<p class='gray'>Unpublishing " + documentType + " ...</p>"
-          var articleId = document.getElementById('article-id').value;
-          var selectedLocale = document.getElementById('article-locale').value;
-
-          // console.log("Unpublish", documentType, formIsValid, articleId, selectedLocale);
-          if (documentType === "page") {
-            google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublishPage(formObject);
-
-          } else {
-            google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublish(formObject);
-          }
-        } else {
-            
-          // console.log("invalid form")
-          if (errorMessage !== "") {
-            loadingDiv.innerHTML = "<p class='error'>" + errorMessage + "</p>"
-            try {
-              alertAirbrake(errorMessage);
-            } catch(e) {
-              console.error("Failed to log error with Airbrake:", e);
-            }
-          } else {
-            loadingDiv.innerHTML = "<p class='error'>Please make sure all required fields are filled in.</p>"
-          }
-          form.style.display = "block";
-        }
+      var selectedAuthors = $('#article-authors').select2('data');
+      var customByline = document.getElementById("article-custom-byline").value;
+      if ( (selectedAuthors === undefined || selectedAuthors.length <= 0) && ( customByline === null || customByline === undefined || customByline === "") ) {
+        // console.log("selectedAuthors:", selectedAuthors, "customByline:", customByline)
+        errorMessage += "<br>Author or custom byline is required.";
+        formIsValid = false;
       }
+    }
+    if (!headline.value) {
+      // console.log("headline is missing:", headline.value, typeof(headline.value));
+      errorMessage += "<br>Headline is required.";
+      formIsValid = false;
+    }
+    if (!searchTitle.value) {
+      // console.log("search title is missing:", searchTitle.value, typeof(searchTitle.value));
+      errorMessage += "<br>Search title is required.";
+      formIsValid = false;
+    }
+    if (!searchDescription.value) {
+      // console.log("searchDescription is missing:", searchDescription.value, typeof(searchDescription.value));
+      errorMessage += "<br>Search description is required.";
+      formIsValid = false;
+    }
+    if (!category.value) {
+      errorMessage += "<br>Category/section is required.";
+      formIsValid = false;
+    }
+
+    // assemble the data to submit - unfortunately we can't pass the form object with any additional data here
+    var submitData = {};
+    var elements = formObject.elements;
+    for (var i = 0, element; element = elements[i++];) {
+      var key = element.name;
+      var value = element.value;
+      if ( !(/source/).test(key) ) {
+        submitData[key] = value;
+      }
+    }
+    if (documentType === "article") {
+      var selectedTags = $('#article-tags').select2('data');
+      submitData["article-tags"] = [];
+      for (var i = 0, tag; tag = selectedTags[i++];) {
+        submitData["article-tags"].push(tag.text);
+      }
+      var formattedPubDate = toIsoString(publishedDate);
+      submitData["first-published-at"] = formattedPubDate;
+      // console.log('formattedPubDate:', formattedPubDate);
+      submitData["sources"] = sources;
+      submitData['article-authors'] = [];
+      for (var i = 0, author; author = selectedAuthors[i++];) {
+        submitData["article-authors"].push(author.id);
+      }
+    }
+    
+    if (formIsValid && formObject.submitted === "Preview") {
+      // console.log("valid form + preview")
+      loadingDiv.innerHTML = "<p class='gray'>Loading preview...</p>"
+      google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePreview(submitData);
+    } else if ( formIsValid && (formObject.submitted === "Publish" || formObject.submitted === "Re-publish") ) {
+      // console.log("valid form + ", formIsValid, formObject.submitted)
+      if (documentType === "article" && $.isEmptyObject(sources)) {
+        if (!window.confirm("You're trying to publish an article without any source tracking info: are you sure?")) { 
+          form.style.display = "block";
+          loadingDiv.innerHTML = "Please enter source tracking info, then try publishing again.";
+          const redrawCalendar = flatpickr('input[name="article-first-published-date"]', {
+            enableTime: true,
+            dateFormat: "Y-m-d h:i K",
+          });
+
+        } else {
+          loadingDiv.innerHTML = "<p class='gray'>Publishing without any sources... </p>"
+          google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
+        }
+      } else {
+        loadingDiv.innerHTML = "<p class='gray'>Publishing... </p>"
+        google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandlePublish(submitData);
+      }
+    } else if (formIsValid && formObject.submitted === "Unpublish") {
+      // console.log("valid form + unpublish")
+      loadingDiv.innerHTML = "<p class='gray'>Unpublishing " + documentType + " ...</p>"
+      var articleId = document.getElementById('article-id').value;
+      var selectedLocale = document.getElementById('article-locale').value;
+
+      // console.log("Unpublish", documentType, formIsValid, articleId, selectedLocale);
+      if (documentType === "page") {
+        google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublishPage(formObject);
+
+      } else {
+        google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublish(formObject);
+      }
+    } else {
+        
+      // console.log("invalid form")
+      if (errorMessage !== "") {
+        loadingDiv.innerHTML = "<p class='error'>" + errorMessage + "</p>"
+        try {
+          alertAirbrake(errorMessage);
+        } catch(e) {
+          console.error("Failed to log error with Airbrake:", e);
+        }
+      } else {
+        loadingDiv.innerHTML = "<p class='error'>Please make sure all required fields are filled in.</p>"
+      }
+      form.style.display = "block";
+    }
+  }
       window.onload = (function(){
         var form = document.getElementById('article-form');
         form.style.display = "none";

--- a/Page.html
+++ b/Page.html
@@ -1222,7 +1222,7 @@ function displayTranslationTools(id, documentId, documentType, headline, googleD
         errorMessage += "<br>Author or custom byline is required.";
         formIsValid = false;
       }
-      if (!category.value) {
+      if (!category.value && documentType === 'article') {
         errorMessage += "<br>Category/section is required.";
         formIsValid = false;
       } 

--- a/Page.html
+++ b/Page.html
@@ -1112,6 +1112,7 @@ function displayTranslationTools(id, documentId, documentType, headline, googleD
         
         var googleDocs = pageData.page_google_documents;
         var translations = pageData.page_translations;
+        console.log("translations:", translations);
         var organizationLocales = response.data.organization_locales;
         var documentID = response.documentID;
 
@@ -1145,6 +1146,7 @@ function displayTranslationTools(id, documentId, documentType, headline, googleD
 
     var typeHiddenField = document.getElementById('document-type');
     var documentType = typeHiddenField.value;
+    console.log("handleClick for docType:", documentType);
 
     var headline = document.getElementById('article-headline');
     var searchTitle = document.getElementById('article-search-title');
@@ -1220,6 +1222,10 @@ function displayTranslationTools(id, documentId, documentType, headline, googleD
         errorMessage += "<br>Author or custom byline is required.";
         formIsValid = false;
       }
+      if (!category.value) {
+        errorMessage += "<br>Category/section is required.";
+        formIsValid = false;
+      } 
     }
     if (!headline.value) {
       // console.log("headline is missing:", headline.value, typeof(headline.value));
@@ -1236,11 +1242,7 @@ function displayTranslationTools(id, documentId, documentType, headline, googleD
       errorMessage += "<br>Search description is required.";
       formIsValid = false;
     }
-    if (!category.value) {
-      errorMessage += "<br>Category/section is required.";
-      formIsValid = false;
-    }
-
+    
     // assemble the data to submit - unfortunately we can't pass the form object with any additional data here
     var submitData = {};
     var elements = formObject.elements;

--- a/Page.html
+++ b/Page.html
@@ -600,7 +600,6 @@
 function handleGetTranslationsForArticle(result) {
   console.log("result:", result);
 
-  
   var configDiv = document.getElementById('config');
   configDiv.style.display = 'none';
   var div = document.getElementById('loading');
@@ -632,7 +631,6 @@ function handleGetTranslationsForArticle(result) {
   var localeCode;
   var typeHiddenField = document.getElementById('document-type');
   var documentType = "article";
-  
 
   var data = result.data;
 
@@ -641,9 +639,7 @@ function handleGetTranslationsForArticle(result) {
   }
   typeHiddenField.value = documentType;
 
-
   if (documentType === "article" && data.article && data.article.id) {
-
     articleId = data.article.id;
 
     if (data.article.canonical_url) {
@@ -738,6 +734,7 @@ function handleGetTranslationsForArticle(result) {
     var headline;
     var id;
 
+    console.log("data:", data);
     displayLocales(data.organization_locales, localeCode);
 
     if (data.article) {
@@ -888,6 +885,7 @@ function handleGetTranslationsForArticle(result) {
 
     setPublishedFlag(false); // new article is not published, ensure correct action buttons display
 
+    console.log("data:", data);
     displayLocales(data.organization_locales, localeCode);
           
     if (documentType === "article") {

--- a/Page.html
+++ b/Page.html
@@ -241,6 +241,7 @@
           lastSpan.innerHTML = formatDate(publishedInfo.last_published_at);
 
           var translationIdSpan = document.getElementById("translation-id");
+          console.log("displayPublishedInfo pubInfo/translationData", publishedInfo, translationData);
           if (translationData && publishedInfo.id === translationData.id) {
             translationIdSpan.innerHTML = "This translation was published at:";
           } else {
@@ -748,7 +749,6 @@ function handleGetTranslationsForArticle(result) {
       }
       if (data.published_article_translations && data.published_article_translations[0]) {
         publishedInfo = data.published_article_translations[0].article_translation;
-        // console.log("found publishedInfo:", publishedInfo);
       }
 
       displayCategories(data.categories, data.article.category);
@@ -830,8 +830,12 @@ function handleGetTranslationsForArticle(result) {
     }
 
     if (translationData) {
-      setPublishedFlag(translationData.published);
-
+      if (publishedInfo) {
+        console.log("found publishedInfo:", publishedInfo);
+        setPublishedFlag(true);
+      } else {
+        setPublishedFlag(translationData.published);
+      }
       var articleHeadline = document.getElementById('article-headline');
       articleHeadline.value = headline;
 
@@ -1063,13 +1067,11 @@ function displayTranslationTools(id, documentId, documentType, headline, googleD
         slugField.value = articleSlug;
 
         var translations = response.data.article_translations;
-        if (translations[0]) {
-          setPublishedFlag(translations[0].published);
-          console.log("translations[0]:", translations[0]);
-        }
+        
         var publishedInfo = response.data.published_article_translations;
         if (publishedInfo && publishedInfo[0]) {
           console.log("publishedInfo:", publishedInfo[0])
+          setPublishedFlag(true);
           var mostRecentPubInfo = publishedInfo[0].article_translation;
           displayPublishedInfo(mostRecentPubInfo, translations[0]);
           

--- a/Page.html
+++ b/Page.html
@@ -161,6 +161,12 @@
 
       function displayLocales(locales, currentLocale) {
         var articleLocaleSelect = document.getElementById('article-locale');
+
+        var selectOption = document.createElement("option");
+        selectOption.text = "Please select:";
+        selectOption.value = "";
+        articleLocaleSelect.add(selectOption);
+
         if (locales) {
           locales.forEach(localeData => {
             // first check if this option already exists; don't add dupes!
@@ -355,7 +361,7 @@
         loadingDiv.style.display = "block";
         loadingDiv.innerHTML = "<p class='error'>An error occurred: " + error + "</p>";
         var form = document.getElementById('article-form');
-        form.style.display = "none";
+        form.style.display = "block";
       }
 
       function createTextInputDiv(id, label, name, value) {
@@ -732,8 +738,11 @@ function handleGetTranslationsForArticle(result) {
     var headline;
     var id;
 
+    displayLocales(data.organization_locales, localeCode);
+
     if (data.article) {
       id = data.article.id;
+
       if (data.article.article_translations) {
         translationData = data.article.article_translations[0];
       }
@@ -822,8 +831,6 @@ function handleGetTranslationsForArticle(result) {
       });
     
     }
-
-    displayLocales(data.organization_locales, localeCode);
 
     if (translationData) {
       setPublishedFlag(translationData.published);
@@ -936,92 +943,92 @@ function handleGetArticle() {
 }
 
 function displayTranslationTools(id, documentId, documentType, headline, googleDocs, organizationLocales) {
-        // console.log("displaying translation tools:", id, documentId, headline, googleDocs, organizationLocales);
+    // console.log("displaying translation tools:", id, documentId, headline, googleDocs, organizationLocales);
 
-        var existingDocsOtherLocales = [];
-        var availableLocales = [];
+    var existingDocsOtherLocales = [];
+    var availableLocales = [];
 
-        var selectedLocale = document.getElementById('article-locale').value;
+    var selectedLocale = document.getElementById('article-locale').value;
 
-        // console.log("organizationLocales:", organizationLocales)
-        if (googleDocs) {
-          organizationLocales.forEach( (orgLocale) => {
-            var foundLocaleDoc = false;
-            // loop over each google doc associated with this article
-            googleDocs.forEach( (doc) => {
-              // if google doc is not the current one we have open...
-              if (doc.google_document.document_id !== documentId) {
-                // ... and this org locale is equal to the google doc's locale
-                if (orgLocale.locale.code === doc.google_document.locale_code) {
-                  // add it to the list of documents available that are translations of this article
-                  existingDocsOtherLocales.push(doc.google_document);
-                  foundLocaleDoc = true;
-                }
-              // current document
-              } else {
-                if (orgLocale.locale.code === doc.google_document.locale_code) {
-                  foundLocaleDoc = true;
-                }
-              }
-            });
-            // if we didn't find a google document for this org locale, mark it as available
-            if (!foundLocaleDoc) {
-              availableLocales.push(orgLocale.locale);
+    // console.log("organizationLocales:", organizationLocales)
+    if (googleDocs) {
+      organizationLocales.forEach( (orgLocale) => {
+        var foundLocaleDoc = false;
+        // loop over each google doc associated with this article
+        googleDocs.forEach( (doc) => {
+          // if google doc is not the current one we have open...
+          if (doc.google_document.document_id !== documentId) {
+            // ... and this org locale is equal to the google doc's locale
+            if (orgLocale.locale.code === doc.google_document.locale_code) {
+              // add it to the list of documents available that are translations of this article
+              existingDocsOtherLocales.push(doc.google_document);
+              foundLocaleDoc = true;
             }
-          })
-
-          // console.log("availableLocales:", availableLocales, "existingDocsOtherLocales:", existingDocsOtherLocales);
-
-          if (availableLocales && availableLocales.length > 0) {
-            availableLocales.forEach(availableLocale => {
-              if (availableLocale.code !== selectedLocale) {
-                // TODO: make another version of this button for the bottom of the sidebar?
-                var buttonId = "translate-button-top-" + availableLocale.code;
-                if (!document.getElementById(buttonId)) { // avoid adding multiple instances of the same button
-                  var button = document.createElement("button");
-                  button.setAttribute("class", "blue");
-                  button.setAttribute("type", "button");
-                  button.setAttribute("id", buttonId);
-                  button.setAttribute("data-headline", headline);
-                  button.setAttribute("data-doc-type", documentType);
-                  if (documentType === "page") {
-                    button.setAttribute("data-page-id", id);
-                  } else {
-                    button.setAttribute("data-article-id", id);
-                  }
-                  button.setAttribute("data-locale", availableLocale.code);
-                  button.setAttribute("onClick", "handleCreateDoc(this)");
-                  button.innerHTML = 'Translate to ' + availableLocale.name;
-                  // console.log(availableLocale, "button:", button);
-                  var buttonsTopContainer = document.getElementById('action-buttons-top');
-                  buttonsTopContainer.appendChild(button);
-                }
-              }
-            })
+          // current document
+          } else {
+            if (orgLocale.locale.code === doc.google_document.locale_code) {
+              foundLocaleDoc = true;
+            }
           }
-
-          if (existingDocsOtherLocales.length > 0) {
-            existingDocsOtherLocales.forEach(doc => {
-              // console.log("existing doc:", doc)
-              if (doc.locale.code !== selectedLocale) {
-                
-                var buttonId = "translate-button-top-" + doc.locale.code;
-                if (!document.getElementById(buttonId)) { // avoid adding multiple instances of the same button
-                  var button = document.createElement("button");
-                  button.setAttribute("id", buttonId);
-                  button.setAttribute("class", "blue");
-                  button.setAttribute("type", "button");
-                  var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
-                  button.setAttribute("onClick", buttonOpenLink);
-                  button.innerHTML = "Open in " + doc.locale.name;
-                  var buttonsTopContainer = document.getElementById('action-buttons-top');
-                  buttonsTopContainer.appendChild(button);
-                }
-              }
-            });
-          }
+        });
+        // if we didn't find a google document for this org locale, mark it as available
+        if (!foundLocaleDoc) {
+          availableLocales.push(orgLocale.locale);
         }
+      })
+
+      // console.log("availableLocales:", availableLocales, "existingDocsOtherLocales:", existingDocsOtherLocales);
+
+      if (availableLocales && availableLocales.length > 0) {
+        availableLocales.forEach(availableLocale => {
+          if (availableLocale.code !== selectedLocale) {
+            // TODO: make another version of this button for the bottom of the sidebar?
+            var buttonId = "translate-button-top-" + availableLocale.code;
+            if (!document.getElementById(buttonId)) { // avoid adding multiple instances of the same button
+              var button = document.createElement("button");
+              button.setAttribute("class", "blue");
+              button.setAttribute("type", "button");
+              button.setAttribute("id", buttonId);
+              button.setAttribute("data-headline", headline);
+              button.setAttribute("data-doc-type", documentType);
+              if (documentType === "page") {
+                button.setAttribute("data-page-id", id);
+              } else {
+                button.setAttribute("data-article-id", id);
+              }
+              button.setAttribute("data-locale", availableLocale.code);
+              button.setAttribute("onClick", "handleCreateDoc(this)");
+              button.innerHTML = 'Translate to ' + availableLocale.name;
+              // console.log(availableLocale, "button:", button);
+              var buttonsTopContainer = document.getElementById('action-buttons-top');
+              buttonsTopContainer.appendChild(button);
+            }
+          }
+        })
       }
+
+      if (existingDocsOtherLocales.length > 0) {
+        existingDocsOtherLocales.forEach(doc => {
+          // console.log("existing doc:", doc)
+          if (doc.locale.code !== selectedLocale) {
+            console.log(doc.locale.code, selectedLocale);
+            var buttonId = "translate-button-top-" + doc.locale.code;
+            if (!document.getElementById(buttonId)) { // avoid adding multiple instances of the same button
+              var button = document.createElement("button");
+              button.setAttribute("id", buttonId);
+              button.setAttribute("class", "blue");
+              button.setAttribute("type", "button");
+              var buttonOpenLink = "window.open('" + doc.url + "', '_blank')";
+              button.setAttribute("onClick", buttonOpenLink);
+              button.innerHTML = "Open in " + doc.locale.name;
+              var buttonsTopContainer = document.getElementById('action-buttons-top');
+              buttonsTopContainer.appendChild(button);
+            }
+          }
+        });
+      }
+    }
+  }
 
       function onSuccessPreviewPublish(response) {
         var configDiv = document.getElementById('config');

--- a/Page.html
+++ b/Page.html
@@ -1293,16 +1293,11 @@ function displayTranslationTools(id, documentId, documentType, headline, googleD
     } else if (formIsValid && formObject.submitted === "Unpublish") {
       // console.log("valid form + unpublish")
       loadingDiv.innerHTML = "<p class='gray'>Unpublishing " + documentType + " ...</p>"
-      var articleId = document.getElementById('article-id').value;
-      var selectedLocale = document.getElementById('article-locale').value;
+      // var articleId = document.getElementById('article-id').value;
+      // var selectedLocale = document.getElementById('article-locale').value;
 
-      // console.log("Unpublish", documentType, formIsValid, articleId, selectedLocale);
-      if (documentType === "page") {
-        google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublishPage(formObject);
-
-      } else {
-        google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublish(formObject);
-      }
+      google.script.run.withSuccessHandler(onSuccessPreviewPublish).withFailureHandler(onFailure).hasuraHandleUnpublish(formObject);
+    
     } else {
         
       // console.log("invalid form")


### PR DESCRIPTION
**Update:** I've resolved & merged conflicts with the main branch in this one, deployed this branch as the latest code in the script editor and tested against the now live document API this work integrates with, at least for the `oaklyn` organization. Lookup, preview, publish, and unpublish all worked as expected. I also started [a spreadsheet](https://docs.google.com/spreadsheets/d/1eW7tZPZhBV5h70txOGjuf0gCy7nNGhCFXV57HNKKKj4/edit#gid=0) where examples of each org's API calls are linked.

This PR goes with [the API endpoints PR](https://github.com/news-catalyst/next-tinynewsdemo/pull/1011) in the front-end repo. It is currently the "latest code" in the script editor.

Closes #392 

- [x] on sidebar load, lookup article data by documentID replacing hasuraGetArticle, hasuraGetArticleTranslations, isArticleFeatured
- [x] on sidebar load, lookup page data by documentID replacing hasuraGetArticle, hasuraGetArticleTranslations
- [x] on sidebar load, lookup unknown documentID and return sitewide data (replacing hasuraGetArticle etc)
- [x] on preview, save article data (published: false) and return preview article link
- [x] on publish, save article data (published: true) and return published article link
- [x] on unpublish, update published: false and return message
- [x] on sidebar load, find existing translations, displaying `open in $locale` buttons
- [x] on sidebar load, display `translate to $locale` button for languages not yet translated to
- [x] fixes display of action buttons for preview/published/unpublished states https://github.com/news-catalyst/google-app-scripts/issues/392 