### PR TITLE
bugfix: don't require a category unless the doc is for an article

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -1246,7 +1246,7 @@
           errorMessage += "<br>Search description is required.";
           formIsValid = false;
         }
-        if (!category.value) {
+        if (!category.value && documentType === 'article') {
           errorMessage += "<br>Category/section is required.";
           formIsValid = false;
         }


### PR DESCRIPTION
Fixes the reported issue trying to save a new `about` page for Austin Vida but getting an error that a "category/section" is required. It should only be required on articles not static pages.

Test using 'latest code' in the script editor. Happy to publish this ASAP. This branch does not contain the new API code.