### PR TITLE
Don't alert airbrake if required form field is missing a value

### DIFF
--- a/Page.html
+++ b/Page.html
@@ -1089,11 +1089,6 @@ function handleGetArticle() {
       // console.log("invalid form")
       if (errorMessage !== "") {
         loadingDiv.innerHTML = "<p class='error'>" + errorMessage + "</p>"
-        try {
-          alertAirbrake(errorMessage);
-        } catch(e) {
-          console.error("Failed to log error with Airbrake:", e);
-        }
       } else {
         loadingDiv.innerHTML = "<p class='error'>Please make sure all required fields are filled in.</p>"
       }


### PR DESCRIPTION
Closes #412 

It's misleading and noisy to alert Airbrake when someone's using the form and forgets to fill in a required field (form validation fails). This PR removes the error reporting on missing required fields.

To test, run > test as add-on > choose any article > latest code > try to preview or publish with any required field missing (example: headline). You should not see an error reported [in the Airbrake Dashboard](https://jacqui-newscatalyst-org.airbrake.io/projects/370377/groups/3264926762952072381?tab=overview).